### PR TITLE
Fix: Fix logging scenarios when no config was passed

### DIFF
--- a/src/orquestra/sdk/_base/cli/_corq/action/_login.py
+++ b/src/orquestra/sdk/_base/cli/_corq/action/_login.py
@@ -211,13 +211,13 @@ def orq_login(args: argparse.Namespace):
             new_runtime_options=resolved_runtime_options,
         )
     else:
+        config_name = _config.generate_config_name(runtime_name, server_uri)
         # Generate a suitable name for the config
         stored_config, _ = _config.write_config(
-            _config_name,
+            config_name,
             runtime_name,
             resolved_runtime_options,
         )
-        config_name = stored_config.config_name
 
     _config.update_default_config_name(config_name)
 


### PR DESCRIPTION
# The problem

After config reorganisation, user could no longer do orq login -s <uri> without specifying config.

# This PR's solution

Solution to the problem: When user uses orq login -s <uri> -c <config>, existing config is updated
When user uses orq login -s <uri> new config is created with auto-generated name

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
