### PR TITLE
feat: Public API for listing workflow runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 🔥 *Features*
+* `list_workflow_runs` added to the Public API. This lets you list the workflows for a given config, for example `sdk.list_workflow_runs("ray")` or `sdk.list_workflow_runs("prod-d")`.
 
 
 👩‍🔬 *Experimental*

--- a/src/orquestra/sdk/__init__.py
+++ b/src/orquestra/sdk/__init__.py
@@ -4,7 +4,13 @@
 """Orquestra SDK allows to define computational workflows using Python DSL."""
 
 from . import secrets
-from ._base._api import RuntimeConfig, TaskRun, WorkflowRun, migrate_config_file
+from ._base._api import (
+    RuntimeConfig,
+    TaskRun,
+    WorkflowRun,
+    list_workflow_runs,
+    migrate_config_file,
+)
 from ._base._dsl import (
     ArtifactFuture,
     DataAggregation,
@@ -38,6 +44,7 @@ __all__ = [
     "WorkflowDef",
     "WorkflowRun",
     "WorkflowTemplate",
+    "list_workflow_runs",
     "migrate_config_file",
     "secrets",
     "task",

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -49,15 +49,17 @@ from .serde import deserialize_constant
 
 COMPLETED_STATES = [State.FAILED, State.TERMINATED, State.SUCCEEDED]
 
-def _resolve_config(config: t.Union[ConfigName, "RuntimeConfig"], config_save_file: t.Optional[t.Union[Path, str]]) -> "RuntimeConfig":
+
+def _resolve_config(
+    config: t.Union[ConfigName, "RuntimeConfig"],
+    config_save_file: t.Optional[t.Union[Path, str]],
+) -> "RuntimeConfig":
     if isinstance(config, RuntimeConfig):
         # EZ. Passed-in explicitly.
         resolved_config = config
     elif isinstance(config, str):
         # Shorthand: just the config name.
-        resolved_config = RuntimeConfig.load(
-            config, config_save_file=config_save_file
-        )
+        resolved_config = RuntimeConfig.load(config, config_save_file=config_save_file)
     else:
         raise TypeError(f"'config' is of unsupported type {type(config)}.")
 

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -754,7 +754,6 @@ def list_workflow_runs(
             saved. If omitted, the default config file path is used.
 
     Raises:
-        ModuleNotFoundError: when the orquestra-runtime package is not installed.
         ConfigNameNotFoundError: when the named config is not found in the file.
 
     Returns:

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -735,7 +735,7 @@ def list_workflow_runs(
     *,
     limit: t.Optional[int] = None,
     max_age: t.Optional[str] = None,
-    state: t.Optional[State] = None,
+    state: t.Optional[t.Union[State, t.List[State]]] = None,
     project_dir: t.Optional[t.Union[Path, str]] = None,
     config_save_file: t.Optional[t.Union[Path, str]] = None,
 ) -> t.List[WorkflowRun]:

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -734,7 +734,6 @@ def list_workflow_runs(
     config: t.Union[ConfigName, "RuntimeConfig"],
     *,
     limit: t.Optional[int] = None,
-    prefix: t.Optional[str] = None,
     max_age: t.Optional[str] = None,
     state: t.Optional[State] = None,
     project_dir: t.Optional[t.Union[Path, str]] = None,
@@ -772,7 +771,7 @@ def list_workflow_runs(
     # Note: WorkflowRun means something else in runtime land. To avoid overloading, this
     #       import is aliased to WorkflowRunStatus in here.
     run_statuses: t.List[WorkflowRunModel] = runtime.list_workflow_runs(
-        limit=limit, prefix=prefix, max_age=_parse_max_age(max_age), state=state
+        limit=limit, max_age=_parse_max_age(max_age), state=state
     )
 
     # We need to convert to the public API notion of a WorkflowRun

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -250,7 +250,7 @@ class CERuntime(RuntimeInterface):
         """Stops a workflow run.
 
         Raises:
-        WorkflowRunCanNotBeTerminated if workflow run is cannot be terminated.
+            WorkflowRunCanNotBeTerminated if workflow run is cannot be terminated.
         """
         try:
             self._client.terminate_workflow_run(workflow_run_id)

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -279,6 +279,7 @@ class CERuntime(RuntimeInterface):
                 A list of the workflow runs
         """
         try:
+            # TODO(ORQSDK-684): driver client cannot do filtering via API yet
             runs = self._client.list_workflow_runs()
         except _exceptions.InvalidTokenError as e:
             raise exceptions.UnauthorizedError(f"{e}") from e

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -263,7 +263,7 @@ class CERuntime(RuntimeInterface):
         limit: Optional[int] = None,
         prefix: Optional[str] = None,
         max_age: Optional[timedelta] = None,
-        state: Optional[State] = None,
+        state: Optional[Union[State, List[State]]] = None,
     ) -> List[WorkflowRun]:
         """
         List the workflow runs, with some filters

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -261,7 +261,6 @@ class CERuntime(RuntimeInterface):
         self,
         *,
         limit: Optional[int] = None,
-        prefix: Optional[str] = None,
         max_age: Optional[timedelta] = None,
         state: Optional[Union[State, List[State]]] = None,
     ) -> List[WorkflowRun]:
@@ -270,7 +269,6 @@ class CERuntime(RuntimeInterface):
 
         Args:
             limit: Restrict the number of runs to return, prioritising the most recent.
-            prefix: Only return runs that start with the specified string.
             max_age: Only return runs younger than the specified maximum age.
             status: Only return runs of runs with the specified status.
         Returns:

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -1,6 +1,7 @@
 ################################################################################
 # © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Union
 
@@ -11,7 +12,12 @@ from orquestra.sdk._base.abc import RuntimeInterface
 from orquestra.sdk.schema.configs import RuntimeConfiguration
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
-from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRun, WorkflowRunId
+from orquestra.sdk.schema.workflow_run import (
+    State,
+    TaskRunId,
+    WorkflowRun,
+    WorkflowRunId,
+)
 
 from . import _client, _exceptions, _models
 
@@ -250,6 +256,27 @@ class CERuntime(RuntimeInterface):
             self._client.terminate_workflow_run(workflow_run_id)
         except _exceptions.InvalidTokenError as e:
             raise exceptions.UnauthorizedError(f"{e}")
+
+    def list_workflow_runs(
+        self,
+        *,
+        limit: Optional[int] = None,
+        prefix: Optional[str] = None,
+        max_age: Optional[timedelta] = None,
+        state: Optional[State] = None,
+    ) -> List[WorkflowRun]:
+        """
+        List the workflow runs, with some filters
+
+        Args:
+            limit: Restrict the number of runs to return, prioritising the most recent.
+            prefix: Only return runs that start with the specified string.
+            max_age: Only return runs younger than the specified maximum age.
+            status: Only return runs of runs with the specified status.
+        Returns:
+                A list of the workflow runs
+        """
+        raise NotImplementedError()
 
     def get_full_logs(
         self, run_id: Optional[Union[WorkflowRunId, TaskRunId]] = None

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -271,6 +271,10 @@ class CERuntime(RuntimeInterface):
             limit: Restrict the number of runs to return, prioritising the most recent.
             max_age: Only return runs younger than the specified maximum age.
             status: Only return runs of runs with the specified status.
+
+        Raises:
+            UnauthorizedError: if the remote cluster rejects the token
+
         Returns:
                 A list of the workflow runs
         """

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -192,6 +192,15 @@ class InProcessRuntime:
         """
         now = datetime.now(timezone.utc)
 
+        if state is not None:
+            if not isinstance(state, list):
+                state_list = [state]
+            else:
+                state_list = state
+        else:
+            state_list = None
+
+
         wf_runs = []
         # Each workflow run executed with the in-process runtime is stored within the
         # runtime object.
@@ -203,7 +212,7 @@ class InProcessRuntime:
 
             # Let's filter the workflows at this point, instead of iterating over a list
             # multiple times
-            if state is not None and wf_run.status.state != state:
+            if state_list is not None and wf_run.status.state not in state_list:
                 continue
             if prefix is not None and wf_run_id.startswith(prefix):
                 continue

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -175,7 +175,6 @@ class InProcessRuntime:
         self,
         *,
         limit: t.Optional[int] = None,
-        prefix: t.Optional[str] = None,
         max_age: t.Optional[timedelta] = None,
         state: t.Optional[State] = None,
     ) -> t.List[WorkflowRun]:
@@ -184,9 +183,9 @@ class InProcessRuntime:
 
         Args:
             limit: Restrict the number of runs to return, prioritising the most recent.
-            prefix: Only return runs that start with the specified string.
             max_age: Only return runs younger than the specified maximum age.
             status: Only return runs of runs with the specified status.
+
         Returns:
                 A list of the workflow runs
         """

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -200,7 +200,6 @@ class InProcessRuntime:
         else:
             state_list = None
 
-
         wf_runs = []
         # Each workflow run executed with the in-process runtime is stored within the
         # runtime object.

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -212,8 +212,6 @@ class InProcessRuntime:
             # multiple times
             if state_list is not None and wf_run.status.state not in state_list:
                 continue
-            if prefix is not None and wf_run_id.startswith(prefix):
-                continue
             if max_age is not None and (
                 now - (wf_run.status.start_time or now) < max_age
             ):

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -821,7 +821,6 @@ class QERuntime(RuntimeInterface):
         self,
         *,
         limit: Optional[int] = None,
-        prefix: Optional[str] = None,
         max_age: Optional[timedelta] = None,
         state: Optional[Union[State, List[State]]] = None,
     ) -> List[WorkflowRun]:
@@ -830,7 +829,7 @@ class QERuntime(RuntimeInterface):
         # Grab the workflows we know about from the DB
         with WorkflowDB.open_project_db(self._project_dir) as db:
             stored_runs = db.get_workflow_runs_list(
-                prefix=prefix, config_name=self._config.config_name
+                config_name=self._config.config_name
             )
 
         # Short circuit if we don't have any workflow runs

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -824,6 +824,20 @@ class QERuntime(RuntimeInterface):
         max_age: Optional[timedelta] = None,
         state: Optional[Union[State, List[State]]] = None,
     ) -> List[WorkflowRun]:
+        """
+        List the workflow runs, with some filters
+
+        Args:
+            limit: Restrict the number of runs to return, prioritising the most recent.
+            max_age: Only return runs younger than the specified maximum age.
+            status: Only return runs of runs with the specified status.
+
+        Raises:
+            orquestra.sdk.exceptions.UnauthorizedError: if QE returns 401
+
+        Returns:
+            A list of the workflow runs
+        """
         now = datetime.now(timezone.utc)
 
         # Grab the workflows we know about from the DB

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -192,7 +192,7 @@ class RuntimeInterface(ABC):
         limit: t.Optional[int] = None,
         prefix: t.Optional[str] = None,
         max_age: t.Optional[timedelta] = None,
-        state: t.Optional[State] = None,
+        state: t.Optional[t.Union[State, t.List[State]]] = None,
     ) -> t.List[WorkflowRun]:
         """
         List the workflow runs, with some filters

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -190,7 +190,6 @@ class RuntimeInterface(ABC):
         self,
         *,
         limit: t.Optional[int] = None,
-        prefix: t.Optional[str] = None,
         max_age: t.Optional[timedelta] = None,
         state: t.Optional[t.Union[State, t.List[State]]] = None,
     ) -> t.List[WorkflowRun]:
@@ -199,7 +198,6 @@ class RuntimeInterface(ABC):
 
         Args:
             limit: Restrict the number of runs to return, prioritising the most recent.
-            prefix: Only return runs that start with the specified string.
             max_age: Only return runs younger than the specified maximum age.
             status: Only return runs of runs with the specified status.
         Returns:

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -12,13 +12,19 @@ This module shouldn't contain any implementation, only interface definitions.
 
 import typing as t
 from abc import ABC, abstractmethod
+from datetime import timedelta
 from pathlib import Path
 from typing import List, Optional
 
 from orquestra.sdk.schema.configs import RuntimeConfiguration
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
-from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRun, WorkflowRunId
+from orquestra.sdk.schema.workflow_run import (
+    State,
+    TaskRunId,
+    WorkflowRun,
+    WorkflowRunId,
+)
 
 
 class LogReader(t.Protocol):
@@ -176,6 +182,28 @@ class RuntimeInterface(ABC):
     ) -> t.Iterator[t.Sequence[str]]:
         """
         See LogReader.iter_logs.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def list_workflow_runs(
+        self,
+        *,
+        limit: t.Optional[int] = None,
+        prefix: t.Optional[str] = None,
+        max_age: t.Optional[timedelta] = None,
+        state: t.Optional[State] = None,
+    ) -> t.List[WorkflowRun]:
+        """
+        List the workflow runs, with some filters
+
+        Args:
+            limit: Restrict the number of runs to return, prioritising the most recent.
+            prefix: Only return runs that start with the specified string.
+            max_age: Only return runs younger than the specified maximum age.
+            status: Only return runs of runs with the specified status.
+        Returns:
+                A list of the workflow runs
         """
         raise NotImplementedError()
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -851,7 +851,6 @@ class RayRuntime(RuntimeInterface):
         self,
         *,
         limit: t.Optional[int] = None,
-        prefix: t.Optional[str] = None,
         max_age: t.Optional[timedelta] = None,
         state: t.Optional[t.Union[State, t.List[State]]] = None,
     ) -> t.List[WorkflowRun]:
@@ -877,8 +876,6 @@ class RayRuntime(RuntimeInterface):
 
             # Let's filter the workflows at this point, instead of iterating over a list
             # multiple times
-            if prefix is not None and not wf_run_id.startswith(prefix):
-                continue
             if state_list is not None and wf_run.status.state not in state_list:
                 continue
             if max_age is not None and (

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -854,6 +854,17 @@ class RayRuntime(RuntimeInterface):
         max_age: t.Optional[timedelta] = None,
         state: t.Optional[t.Union[State, t.List[State]]] = None,
     ) -> t.List[WorkflowRun]:
+        """
+        List the workflow runs, with some filters
+
+        Args:
+            limit: Restrict the number of runs to return, prioritising the most recent.
+            max_age: Only return runs younger than the specified maximum age.
+            status: Only return runs of runs with the specified status.
+
+        Returns:
+                A list of the workflow runs
+        """
         now = datetime.now(timezone.utc)
 
         if state is not None:

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -13,7 +13,7 @@ import json
 import re
 import traceback
 import typing as t
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from orquestra.sdk import exceptions
@@ -847,3 +847,55 @@ class RayRuntime(RuntimeInterface):
             yield from self._fluentbit_reader.iter_logs(run_id)
         else:
             yield from self._ray_reader.iter_logs(run_id)
+
+    def list_workflow_runs(
+        self,
+        *,
+        limit: t.Optional[int] = None,
+        prefix: t.Optional[str] = None,
+        max_age: t.Optional[timedelta] = None,
+        state: t.Optional[State] = None,
+    ) -> t.List[WorkflowRun]:
+        now = datetime.now(timezone.utc)
+
+        # Grab the workflows we know about from the DB
+        if self._project_dir is not None:
+            config_name: str
+            if self._config is None:
+                config_name = "no config"
+            else:
+                config_name = self._config.config_name
+            with WorkflowDB.open_project_db(Path(self._project_dir)) as db:
+                stored_runs = db.get_workflow_runs_list(
+                    prefix=prefix, config_name=config_name
+                )
+        else:
+            stored_runs = []
+
+        # Short circuit if we don't have any workflow runs
+        if len(stored_runs) == 0:
+            return []
+
+        wf_runs = []
+        for wf_run_id in (r.workflow_run_id for r in stored_runs):
+            try:
+                wf_run = self.get_workflow_run_status(wf_run_id)
+            except exceptions.NotFoundError:
+                continue
+
+            # Let's filter the workflows at this point, instead of iterating over a list
+            # multiple times
+            if state is not None and wf_run.status.state != state:
+                continue
+            if max_age is not None and (
+                now - (wf_run.status.start_time or now) < max_age
+            ):
+                continue
+            wf_runs.append(wf_run)
+
+        # We have to wait until we have all the workflow runs before sorting
+        if limit is not None:
+            wf_runs = sorted(wf_runs, key=lambda run: run.status.start_time or now)[
+                -limit:
+            ]
+        return wf_runs

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -881,7 +881,9 @@ class RayRuntime(RuntimeInterface):
                 continue
             if state_list is not None and wf_run.status.state not in state_list:
                 continue
-            if max_age is not None and (now - (wf_run.status.start_time or now) > max_age):
+            if max_age is not None and (
+                now - (wf_run.status.start_time or now) > max_age
+            ):
                 continue
             wf_runs.append(wf_run)
 

--- a/tests/runtime/corq/test_cli_with_ray.py
+++ b/tests/runtime/corq/test_cli_with_ray.py
@@ -581,7 +581,7 @@ class TestCLIWithRay:
                 prefix=None,
                 max_age=None,
                 status=None,
-                config=None,
+                config=TEST_CONFIG_NAME,
                 additional_project_dirs=[],
                 all=True,
             )
@@ -614,7 +614,7 @@ class TestCLIWithRay:
                 prefix=None,
                 max_age=None,
                 status=None,
-                config=None,
+                config=TEST_CONFIG_NAME,
                 additional_project_dirs=[],
                 all=True,
             )
@@ -654,7 +654,7 @@ class TestCLIWithRay:
                 prefix=None,
                 max_age=None,
                 status=None,
-                config=None,
+                config=TEST_CONFIG_NAME,
                 additional_project_dirs=[],
                 all=False,
             )
@@ -693,7 +693,7 @@ class TestCLIWithRay:
                 prefix="hello",
                 max_age=None,
                 status=None,
-                config=None,
+                config=TEST_CONFIG_NAME,
                 additional_project_dirs=[],
                 all=False,
             )
@@ -840,7 +840,7 @@ class TestCLIWithRay:
                 prefix=None,
                 max_age=max_age,
                 status=None,
-                config=None,
+                config=TEST_CONFIG_NAME,
                 additional_project_dirs=[],
                 all=False,
             )
@@ -894,7 +894,7 @@ class TestCLIWithRay:
                 prefix=None,
                 max_age=None,
                 status=State.RUNNING,
-                config=None,
+                config=TEST_CONFIG_NAME,
                 additional_project_dirs=[],
                 all=False,
             )

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -1336,22 +1336,6 @@ class TestListWorkflowRuns:
         # Then
         assert len(runs) == 0
 
-    def test_with_prefix(
-        self,
-        runtime,
-        mock_workflow_db_location,
-        mock_local_db,
-        monkeypatch,
-    ):
-        # This method doesn't handle prefixes, this test just checks the prefix is
-        # passed to what does the prefix handling -> WorkflowDB.get_workflow_runs_list
-        # Given
-        monkeypatch.setattr(runtime, "get_workflow_run_status", MagicMock(WorkflowRun))
-        # When
-        _ = runtime.list_workflow_runs(prefix="hello")
-        # Then
-        mock_local_db.assert_called_once_with(prefix="hello", config_name="hello")
-
     def test_with_state(
         self, runtime, mock_workflow_db_location, mock_local_db, monkeypatch
     ):

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -9,7 +9,7 @@ import json
 import tarfile
 import typing as t
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
 import responses
@@ -1264,6 +1264,162 @@ class TestStopWorkflowRun:
         response = runtime.stop_workflow_run("hello-there-abc123-r000")
 
         assert response is None
+
+
+class TestListWorkflowRuns:
+    @pytest.fixture
+    def mock_local_db(self, monkeypatch):
+        get_workflow_runs_list = Mock(
+            return_value=[
+                StoredWorkflowRun(
+                    workflow_run_id="hello-there-abc123-r000",
+                    config_name="hello",
+                    workflow_def=TEST_WORKFLOW,
+                ),
+                StoredWorkflowRun(
+                    workflow_run_id="hello-there-abc123-r000",
+                    config_name="hello",
+                    workflow_def=TEST_WORKFLOW,
+                ),
+                StoredWorkflowRun(
+                    workflow_run_id="hello-there-abc123-r000",
+                    config_name="hello",
+                    workflow_def=TEST_WORKFLOW,
+                ),
+                StoredWorkflowRun(
+                    workflow_run_id="hello-there-abc123-r000",
+                    config_name="hello",
+                    workflow_def=TEST_WORKFLOW,
+                ),
+            ]
+        )
+        monkeypatch.setattr(
+            _db.WorkflowDB, "get_workflow_runs_list", get_workflow_runs_list
+        )
+        return get_workflow_runs_list
+
+    def test_happy_path(
+        self, runtime, mock_workflow_db_location, mock_local_db, monkeypatch
+    ):
+        # Given
+        mock_status = MagicMock()
+        monkeypatch.setattr(
+            runtime, "get_workflow_run_status", MagicMock(return_value=mock_status)
+        )
+        # When
+        runs = runtime.list_workflow_runs()
+        # Then
+        assert len(runs) == 4
+
+    def test_missing_wf_in_db(self, runtime, mock_workflow_db_location, monkeypatch):
+        # Given
+        get_workflow_runs_list = Mock(return_value=[])
+        monkeypatch.setattr(
+            _db.WorkflowDB, "get_workflow_runs_list", get_workflow_runs_list
+        )
+        # When
+        runs = runtime.list_workflow_runs()
+        # Then
+        assert len(runs) == 0
+
+    def test_missing_wf_in_runtime(
+        self, runtime, mock_workflow_db_location, mock_local_db, monkeypatch
+    ):
+        # Given
+        monkeypatch.setattr(
+            runtime,
+            "get_workflow_run_status",
+            MagicMock(side_effect=exceptions.WorkflowRunNotFoundError),
+        )
+        # When
+        runs = runtime.list_workflow_runs()
+        # Then
+        assert len(runs) == 0
+
+    def test_with_prefix(
+        self,
+        runtime,
+        mock_workflow_db_location,
+        mock_local_db,
+        monkeypatch,
+    ):
+        # This method doesn't handle prefixes, this test just checks the prefix is
+        # passed to what does the prefix handling -> WorkflowDB.get_workflow_runs_list
+        # Given
+        monkeypatch.setattr(runtime, "get_workflow_run_status", MagicMock(WorkflowRun))
+        # When
+        _ = runtime.list_workflow_runs(prefix="hello")
+        # Then
+        mock_local_db.assert_called_once_with(prefix="hello", config_name="hello")
+
+    def test_with_state(
+        self, runtime, mock_workflow_db_location, mock_local_db, monkeypatch
+    ):
+        # Given
+        mock_status = MagicMock()
+        type(mock_status.status).state = PropertyMock(
+            side_effect=[
+                State.RUNNING,
+                State.SUCCEEDED,
+                State.SUCCEEDED,
+                State.RUNNING,
+            ]
+        )
+        monkeypatch.setattr(
+            runtime, "get_workflow_run_status", MagicMock(return_value=mock_status)
+        )
+        # When
+        runs = runtime.list_workflow_runs(state=State.RUNNING)
+        # Then
+        assert len(runs) == 2
+
+    def test_with_max_age(
+        self, runtime, mock_workflow_db_location, mock_local_db, monkeypatch
+    ):
+        # Given
+        mock_status = MagicMock()
+        type(mock_status.status).start_time = PropertyMock(
+            side_effect=[
+                None,
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(seconds=5),
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(seconds=5),
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(days=4),
+            ]
+        )
+        monkeypatch.setattr(
+            runtime, "get_workflow_run_status", MagicMock(return_value=mock_status)
+        )
+        # When
+        runs = runtime.list_workflow_runs(max_age=datetime.timedelta(minutes=2))
+        # Then
+        assert len(runs) == 3
+
+    def test_with_limit(
+        self, runtime, mock_workflow_db_location, mock_local_db, monkeypatch
+    ):
+        # Given
+        mock_status = MagicMock()
+        type(mock_status.status).start_time = PropertyMock(
+            side_effect=[
+                None,
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(seconds=5),
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(seconds=5),
+                datetime.datetime.now(datetime.timezone.utc)
+                - datetime.timedelta(days=4),
+            ]
+        )
+        monkeypatch.setattr(
+            runtime, "get_workflow_run_status", MagicMock(return_value=mock_status)
+        )
+        # When
+        runs = runtime.list_workflow_runs(limit=2)
+        # Then
+        assert len(runs) == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -319,23 +319,6 @@ class TestRayRuntime:
             # Then
             assert len(runs) == 0
 
-        def test_with_prefix(self, client, runtime_config, monkeypatch, tmp_path):
-            # Given
-            client.list_all.return_value = [("mocked", Mock()), ("dont-want!", Mock())]
-            runtime = _dag.RayRuntime(
-                client=client,
-                config=runtime_config,
-                project_dir=tmp_path,
-            )
-            # Given
-            mock_status = Mock()
-            monkeypatch.setattr(
-                runtime, "get_workflow_run_status", Mock(return_value=mock_status)
-            )
-            runs = runtime.list_workflow_runs(prefix="mocked")
-            # Then
-            assert len(runs) == 1
-
         def test_with_state(self, client, runtime_config, monkeypatch, tmp_path):
             # Given
             client.list_all.return_value = [("mocked", Mock())] * 4

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -5,15 +5,16 @@
 Unit tests for orquestra.sdk._ray._dag. If you need a test against a live
 Ray connection, see tests/ray/test_integration.py instead.
 """
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, PropertyMock
 
 import pytest
 
+from orquestra.sdk import exceptions
 from orquestra.sdk._base._config import RuntimeConfiguration, RuntimeName
 from orquestra.sdk._ray import _client, _dag
-from orquestra.sdk.schema.workflow_run import State
+from orquestra.sdk.schema.workflow_run import State, WorkflowRun
 
 TEST_TIME = datetime.now(timezone.utc)
 
@@ -181,6 +182,12 @@ class TestRayRuntime:
             runtime_name=RuntimeName.RAY_LOCAL,
         )
 
+    @staticmethod
+    @pytest.fixture
+    def client():
+        client = Mock()
+        return client
+
     class TestReadingLogs:
         """
         Verifies that RayRuntime gets whatever DirectRayReader or FluentbitReader
@@ -272,3 +279,161 @@ class TestRayRuntime:
             # Then
             assert result_batch == logs_batch
             reader_mock.iter_logs.assert_called_with(run_id)
+
+    class TestListWorkflowRuns:
+        def test_happy_path(self, client, runtime_config, monkeypatch, tmp_path):
+            # Given
+            client.list_all.return_value = [("mocked", Mock())]
+            runtime = _dag.RayRuntime(
+                client=client,
+                config=runtime_config,
+                project_dir=tmp_path,
+            )
+            mock_status = Mock()
+            monkeypatch.setattr(
+                runtime, "get_workflow_run_status", Mock(return_value=mock_status)
+            )
+            # When
+            runs = runtime.list_workflow_runs()
+            # Then
+            client.list_all.assert_called()
+            assert len(runs) == 1
+
+        def test_missing_wf_in_runtime(
+            self, client, runtime_config, monkeypatch, tmp_path
+        ):
+            # Given
+            client.list_all.return_value = [("mocked", Mock())]
+            runtime = _dag.RayRuntime(
+                client=client,
+                config=runtime_config,
+                project_dir=tmp_path,
+            )
+            monkeypatch.setattr(
+                runtime,
+                "get_workflow_run_status",
+                Mock(side_effect=exceptions.WorkflowRunNotFoundError),
+            )
+            # When
+            runs = runtime.list_workflow_runs()
+            # Then
+            assert len(runs) == 0
+
+        def test_with_prefix(self, client, runtime_config, monkeypatch, tmp_path):
+            # Given
+            client.list_all.return_value = [("mocked", Mock()), ("dont-want!", Mock())]
+            runtime = _dag.RayRuntime(
+                client=client,
+                config=runtime_config,
+                project_dir=tmp_path,
+            )
+            # Given
+            mock_status = Mock()
+            monkeypatch.setattr(
+                runtime, "get_workflow_run_status", Mock(return_value=mock_status)
+            )
+            runs = runtime.list_workflow_runs(prefix="mocked")
+            # Then
+            assert len(runs) == 1
+
+        def test_with_state(self, client, runtime_config, monkeypatch, tmp_path):
+            # Given
+            client.list_all.return_value = [("mocked", Mock())] * 4
+            runtime = _dag.RayRuntime(
+                client=client,
+                config=runtime_config,
+                project_dir=tmp_path,
+            )
+            # Given
+            mock_status = Mock()
+            type(mock_status.status).state = PropertyMock(
+                side_effect=[
+                    State.RUNNING,
+                    State.SUCCEEDED,
+                    State.FAILED,
+                    State.RUNNING,
+                ]
+            )
+            monkeypatch.setattr(
+                runtime, "get_workflow_run_status", Mock(return_value=mock_status)
+            )
+            # When
+            runs = runtime.list_workflow_runs(state=State.RUNNING)
+            # Then
+            assert len(runs) == 2
+
+        def test_with_state_list(self, client, runtime_config, monkeypatch, tmp_path):
+            # Given
+            client.list_all.return_value = [("mocked", Mock())] * 4
+            runtime = _dag.RayRuntime(
+                client=client,
+                config=runtime_config,
+                project_dir=tmp_path,
+            )
+            # Given
+            mock_status = Mock()
+            type(mock_status.status).state = PropertyMock(
+                side_effect=[
+                    State.RUNNING,
+                    State.SUCCEEDED,
+                    State.FAILED,
+                    State.RUNNING,
+                ]
+            )
+            monkeypatch.setattr(
+                runtime, "get_workflow_run_status", Mock(return_value=mock_status)
+            )
+            # When
+            runs = runtime.list_workflow_runs(state=[State.SUCCEEDED, State.FAILED])
+            # Then
+            assert len(runs) == 2
+
+        def test_with_max_age(self, client, runtime_config, monkeypatch, tmp_path):
+            # Given
+            client.list_all.return_value = [("mocked", Mock())] * 4
+            runtime = _dag.RayRuntime(
+                client=client,
+                config=runtime_config,
+                project_dir=tmp_path,
+            )
+            mock_status = Mock()
+            type(mock_status.status).start_time = PropertyMock(
+                side_effect=[
+                    None,
+                    datetime.now(timezone.utc) - timedelta(seconds=5),
+                    datetime.now(timezone.utc) - timedelta(seconds=5),
+                    datetime.now(timezone.utc) - timedelta(days=4),
+                ]
+            )
+            monkeypatch.setattr(
+                runtime, "get_workflow_run_status", Mock(return_value=mock_status)
+            )
+            # When
+            runs = runtime.list_workflow_runs(max_age=timedelta(minutes=2))
+            # Then
+            assert len(runs) == 3
+
+        def test_with_limit(self, client, runtime_config, monkeypatch, tmp_path):
+            # Given
+            client.list_all.return_value = [("mocked", Mock())] * 4
+            runtime = _dag.RayRuntime(
+                client=client,
+                config=runtime_config,
+                project_dir=tmp_path,
+            )
+            mock_status = Mock()
+            type(mock_status.status).start_time = PropertyMock(
+                side_effect=[
+                    None,
+                    datetime.now(timezone.utc) - timedelta(seconds=5),
+                    datetime.now(timezone.utc) - timedelta(seconds=5),
+                    datetime.now(timezone.utc) - timedelta(days=4),
+                ]
+            )
+            monkeypatch.setattr(
+                runtime, "get_workflow_run_status", Mock(return_value=mock_status)
+            )
+            # When
+            runs = runtime.list_workflow_runs(limit=2)
+            # Then
+            assert len(runs) == 2

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -1,7 +1,8 @@
 # © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
+from datetime import timedelta
 from pathlib import Path
-from unittest.mock import DEFAULT, MagicMock, call
+from unittest.mock import DEFAULT, MagicMock, Mock, call
 
 import pytest
 
@@ -10,7 +11,7 @@ from orquestra.sdk._base._driver import _ce_runtime, _client, _exceptions, _mode
 from orquestra.sdk._base._testing._example_wfs import my_workflow
 from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
 from orquestra.sdk.schema.responses import JSONResult
-from orquestra.sdk.schema.workflow_run import WorkflowRunId
+from orquestra.sdk.schema.workflow_run import State, WorkflowRunId
 
 
 @pytest.fixture
@@ -719,3 +720,69 @@ class TestStopWorkflowRun:
         # When
         with pytest.raises(exceptions.UnauthorizedError):
             runtime.stop_workflow_run(workflow_run_id)
+
+
+class TestListWorkflowRuns:
+    def test_happy_path(
+        self,
+        mocked_client: MagicMock,
+        runtime: _ce_runtime.CERuntime,
+    ):
+        # Given
+        wf_runs = [Mock(), Mock()]
+        mocked_client.list_workflow_runs.return_value = _client.Paginated(
+            contents=wf_runs
+        )
+
+        # When
+        runs = runtime.list_workflow_runs()
+
+        # Then
+        mocked_client.list_workflow_runs.assert_called_once_with()
+        assert runs == wf_runs
+
+    @pytest.mark.xfail(reason="Filtering not available in CE runtime yet")
+    def test_filter_args_passed_to_client(
+        self,
+        mocked_client: MagicMock,
+        runtime: _ce_runtime.CERuntime,
+    ):
+        # Given
+        kwargs = {
+            "prefix": "mocked",
+            "max_age": timedelta(hours=1),
+            "limit": None,
+            "state": State.SUCCEEDED,
+        }
+        # When
+        _ = runtime.list_workflow_runs(**kwargs)
+
+        # Then
+        mocked_client.list_workflow_runs.assert_called_once_with(**kwargs)
+
+    def test_unknown_http(
+        self,
+        mocked_client: MagicMock,
+        runtime: _ce_runtime.CERuntime,
+        workflow_run_id: str,
+    ):
+        # Given
+        mocked_client.list_workflow_runs.side_effect = _exceptions.UnknownHTTPError(
+            MagicMock()
+        )
+
+        # When
+        with pytest.raises(_exceptions.UnknownHTTPError):
+            runtime.list_workflow_runs()
+
+    def test_token_failure(
+        self,
+        mocked_client: MagicMock,
+        runtime: _ce_runtime.CERuntime,
+        workflow_run_id: str,
+    ):
+        mocked_client.list_workflow_runs.side_effect = _exceptions.InvalidTokenError
+
+        # When
+        with pytest.raises(exceptions.UnauthorizedError):
+            runtime.list_workflow_runs()

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -752,9 +752,7 @@ class TestListWorkflowRuns:
         limit = None
         state = State.SUCCEEDED
         # When
-        _ = runtime.list_workflow_runs(
-            max_age=max_age, limit=limit, state=state
-        )
+        _ = runtime.list_workflow_runs(max_age=max_age, limit=limit, state=state)
 
         # Then
         mocked_client.list_workflow_runs.assert_called_once_with(

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -748,17 +748,19 @@ class TestListWorkflowRuns:
         runtime: _ce_runtime.CERuntime,
     ):
         # Given
-        kwargs = {
-            "prefix": "mocked",
-            "max_age": timedelta(hours=1),
-            "limit": None,
-            "state": State.SUCCEEDED,
-        }
+        prefix = "mocked"
+        max_age = timedelta(hours=1)
+        limit = None
+        state = State.SUCCEEDED
         # When
-        _ = runtime.list_workflow_runs(**kwargs)
+        _ = runtime.list_workflow_runs(
+            prefix=prefix, max_age=max_age, limit=limit, state=state
+        )
 
         # Then
-        mocked_client.list_workflow_runs.assert_called_once_with(**kwargs)
+        mocked_client.list_workflow_runs.assert_called_once_with(
+            prefix=prefix, max_age=max_age, limit=limit, state=state
+        )
 
     def test_unknown_http(
         self,

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -748,18 +748,17 @@ class TestListWorkflowRuns:
         runtime: _ce_runtime.CERuntime,
     ):
         # Given
-        prefix = "mocked"
         max_age = timedelta(hours=1)
         limit = None
         state = State.SUCCEEDED
         # When
         _ = runtime.list_workflow_runs(
-            prefix=prefix, max_age=max_age, limit=limit, state=state
+            max_age=max_age, limit=limit, state=state
         )
 
         # Then
         mocked_client.list_workflow_runs.assert_called_once_with(
-            prefix=prefix, max_age=max_age, limit=limit, state=state
+            max_age=max_age, limit=limit, state=state
         )
 
     def test_unknown_http(

--- a/tests/sdk/v2/test_api.py
+++ b/tests/sdk/v2/test_api.py
@@ -1533,16 +1533,7 @@ class TestListWorkflows:
         _ = _api.list_workflow_runs("mocked_config", max_age=max_age)
         # Then
         mock_config_runtime.list_workflow_runs.assert_called_with(
-            limit=None, prefix=None, max_age=delta, state=None
-        )
-
-    def test_with_prefix(self, mock_config_runtime):
-        # Given
-        # When
-        _ = _api.list_workflow_runs("mocked_config", prefix="hello")
-        # Then
-        mock_config_runtime.list_workflow_runs.assert_called_with(
-            limit=None, prefix="hello", max_age=None, state=None
+            limit=None, max_age=delta, state=None
         )
 
     def test_with_limit(self, mock_config_runtime):
@@ -1551,7 +1542,7 @@ class TestListWorkflows:
         _ = _api.list_workflow_runs("mocked_config", limit=10)
         # Then
         mock_config_runtime.list_workflow_runs.assert_called_with(
-            limit=10, prefix=None, max_age=None, state=None
+            limit=10, max_age=None, state=None
         )
 
     def test_with_state(self, mock_config_runtime):
@@ -1560,7 +1551,7 @@ class TestListWorkflows:
         _ = _api.list_workflow_runs("mocked_config", state=State.SUCCEEDED)
         # Then
         mock_config_runtime.list_workflow_runs.assert_called_with(
-            limit=None, prefix=None, max_age=None, state=State.SUCCEEDED
+            limit=None, max_age=None, state=State.SUCCEEDED
         )
 
 

--- a/tests/sdk/v2/test_api.py
+++ b/tests/sdk/v2/test_api.py
@@ -13,7 +13,9 @@ import time
 import typing as t
 import unittest
 import warnings
-from unittest.mock import DEFAULT, MagicMock, Mock, patch
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import DEFAULT, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 
@@ -1479,6 +1481,87 @@ class TestRuntimeConfiguration:
             assert dict["runtime_options"]["uri"] == config.uri
             assert dict["runtime_options"]["address"] == config.address
             assert dict["runtime_options"]["token"] == config.token
+
+
+class TestListWorkflows:
+    @staticmethod
+    @pytest.fixture
+    def mock_config_runtime(monkeypatch):
+        run = MagicMock()
+        type(run).id = PropertyMock(side_effect=["wf0", "wf1", "wf2"])
+        runtime = Mock(RuntimeInterface)
+        # For getting workflow ID
+        runtime.list_workflow_runs.return_value = [run, run, run]
+        mock_config = MagicMock(_api.RuntimeConfig)
+        mock_config._get_runtime.return_value = runtime
+        monkeypatch.setattr(
+            _api.RuntimeConfig, "load", MagicMock(return_value=mock_config)
+        )
+
+        return runtime
+
+    def test_get_all_wfs(self, mock_config_runtime):
+        # Given
+        # When
+        runs = _api.list_workflow_runs("mocked_config")
+        # Then
+        assert len(runs) == 3
+        assert runs[0].run_id == "wf0"
+        assert runs[1].run_id == "wf1"
+        assert runs[2].run_id == "wf2"
+
+    def test_invalid_max_age(self, mock_config_runtime):
+        # Given
+        # When
+        with pytest.raises(ValueError) as exc_info:
+            _ = _api.list_workflow_runs("mocked_config", max_age="hello")
+        assert exc_info.match("Time strings must")
+
+    @pytest.mark.parametrize(
+        "max_age, delta",
+        [
+            ("1d", timedelta(days=1)),
+            ("2h", timedelta(hours=2)),
+            ("3m", timedelta(minutes=3)),
+            ("4s", timedelta(seconds=4)),
+            ("1d2h3m4s", timedelta(days=1, seconds=7384)),
+        ],
+    )
+    def test_with_max_age(self, mock_config_runtime, max_age, delta):
+        # Given
+        # When
+        _ = _api.list_workflow_runs("mocked_config", max_age=max_age)
+        # Then
+        mock_config_runtime.list_workflow_runs.assert_called_with(
+            limit=None, prefix=None, max_age=delta, state=None
+        )
+
+    def test_with_prefix(self, mock_config_runtime):
+        # Given
+        # When
+        _ = _api.list_workflow_runs("mocked_config", prefix="hello")
+        # Then
+        mock_config_runtime.list_workflow_runs.assert_called_with(
+            limit=None, prefix="hello", max_age=None, state=None
+        )
+
+    def test_with_limit(self, mock_config_runtime):
+        # Given
+        # When
+        _ = _api.list_workflow_runs("mocked_config", limit=10)
+        # Then
+        mock_config_runtime.list_workflow_runs.assert_called_with(
+            limit=10, prefix=None, max_age=None, state=None
+        )
+
+    def test_with_state(self, mock_config_runtime):
+        # Given
+        # When
+        _ = _api.list_workflow_runs("mocked_config", state=State.SUCCEEDED)
+        # Then
+        mock_config_runtime.list_workflow_runs.assert_called_with(
+            limit=None, prefix=None, max_age=None, state=State.SUCCEEDED
+        )
 
 
 def test_python_310_importlib_abc_bug():


### PR DESCRIPTION
# The problem

There is no way to get the list of workflow runs via the public API

# This PR's solution

- Adds a new function to the public API to list workflow runs by config
- Adds a new method to the internal runtime interface

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
