### PR TITLE
Feat: Add new dorq login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 
 👩‍🔬 *Experimental*
-
+* New CLI command: `python -m orquestra.sdk._base.cli._dorq._entry login`.
 
 🐛 *Bug Fixes*
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -107,7 +107,6 @@ def stop(wf_run_id: t.Optional[str], config: t.Optional[str]):
     action.on_cmd_call(wf_run_id, config)
 
 
-<<<<<<< Updated upstream
 @cloup.command()
 @cloup.option_group(
     "Services",
@@ -170,7 +169,8 @@ dorq.section(
     down,
     status,
 )
-=======
+
+
 @dorq.command()
 @cloup.option(
     "-s", "--server",
@@ -188,7 +188,6 @@ def login(server: str, token: t.Optional[str]):
 
     action = Action()
     action.on_cmd_call(server, token)
->>>>>>> Stashed changes
 
 
 def main():

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -173,11 +173,13 @@ dorq.section(
 
 @dorq.command()
 @cloup.option(
-    "-s", "--server",
+    "-s",
+    "--server",
     required=True,
 )
 @cloup.option(
-    "-t", "--token",
+    "-t",
+    "--token",
     required=False,
 )
 def login(server: str, token: t.Optional[str]):

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -173,14 +173,14 @@ dorq.section(
 
 @dorq.command()
 @cloup.option(
-    "-s",
-    "--server",
-    required=True,
+    "-s", "--server", required=True, help="server URI that you want to log into"
 )
 @cloup.option(
     "-t",
     "--token",
     required=False,
+    help="User Token to given server. To generate token, use this command without -t"
+    "option first",
 )
 def login(server: str, token: t.Optional[str]):
     """

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -107,6 +107,7 @@ def stop(wf_run_id: t.Optional[str], config: t.Optional[str]):
     action.on_cmd_call(wf_run_id, config)
 
 
+<<<<<<< Updated upstream
 @cloup.command()
 @cloup.option_group(
     "Services",
@@ -169,6 +170,25 @@ dorq.section(
     down,
     status,
 )
+=======
+@dorq.command()
+@cloup.option(
+    "-s", "--server",
+    required=True,
+)
+@cloup.option(
+    "-t", "--token",
+    required=False,
+)
+def login(server: str, token: t.Optional[str]):
+    """
+    Login in to remote cluster
+    """
+    from ._login._login import Action
+
+    action = Action()
+    action.on_cmd_call(server, token)
+>>>>>>> Stashed changes
 
 
 def main():

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -14,10 +14,7 @@ from .._ui import _presenters
 
 class Action:
     """
-    Encapsulates app-related logic for handling ``orq workflow submit``.
-
-    The module is considered part of the name, so this class should be read as
-    ``_dorq._workflow._submit.Action``.
+    Encapsulates app-related logic for handling `orq login`.
     """
 
     def __init__(

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -1,0 +1,66 @@
+################################################################################
+# © Copyright 2022 Zapata Computing Inc.
+################################################################################
+"""
+Code for 'orq login'.
+"""
+import typing as t
+
+from orquestra.sdk import exceptions
+
+from .. import _repos
+from .._ui import _presenters
+
+
+class Action:
+    """
+    Encapsulates app-related logic for handling ``orq workflow submit``.
+
+    The module is considered part of the name, so this class should be read as
+    ``_dorq._workflow._submit.Action``.
+    """
+
+    def __init__(
+        self,
+        presenter=_presenters.WrappedCorqOutputPresenter(),
+        config_repo=_repos.ConfigRepo(),
+        qe_repo=_repos.QeClientRepo(),
+    ):
+        self._presenter = presenter
+
+        # data sources
+        self._config_repo = config_repo
+        self._qe_repo = qe_repo
+
+    def on_cmd_call(
+        self, url: str, token: t.Optional[str]
+    ):
+        try:
+            self._on_cmd_call_with_exceptions(url, token)
+        except Exception as e:
+            self._presenter.show_error(e)
+
+    def _on_cmd_call_with_exceptions(
+        self,
+        url: str,
+        token: t.Optional[str],
+    ):
+        """
+        Implementation of the command action. Doesn't catch exceptions.
+        """
+        if token is None:
+            self._prompt_for_login(url)
+        else:
+            self._save_token(url, token)
+
+    def _prompt_for_login(self, url: str):
+        login_url = self._qe_repo.get_login_url(url)
+        print("Please follow this URL to proceed with login:")
+        print(login_url)
+        print("Then save the token using command: \n"
+              f"orq login -s {url} -t <paste your token here>")
+
+    def _save_token(self, url, token):
+        config_name = self._config_repo.store_token_in_config(url, token)
+        print(f"Token saved in config file. "
+              f"Configuration name for {url} is {config_name}")

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -32,9 +32,7 @@ class Action:
         self._config_repo = config_repo
         self._qe_repo = qe_repo
 
-    def on_cmd_call(
-        self, url: str, token: t.Optional[str]
-    ):
+    def on_cmd_call(self, url: str, token: t.Optional[str]):
         try:
             self._on_cmd_call_with_exceptions(url, token)
         except Exception as e:
@@ -57,10 +55,14 @@ class Action:
         login_url = self._qe_repo.get_login_url(url)
         print("Please follow this URL to proceed with login:")
         print(login_url)
-        print("Then save the token using command: \n"
-              f"orq login -s {url} -t <paste your token here>")
+        print(
+            "Then save the token using command: \n"
+            f"orq login -s {url} -t <paste your token here>"
+        )
 
     def _save_token(self, url, token):
         config_name = self._config_repo.store_token_in_config(url, token)
-        print(f"Token saved in config file. "
-              f"Configuration name for {url} is {config_name}")
+        print(
+            f"Token saved in config file. "
+            f"Configuration name for {url} is {config_name}"
+        )

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -19,12 +19,13 @@ class Action:
 
     def __init__(
         self,
-        presenter=_presenters.WrappedCorqOutputPresenter(),
+        exception_presenter=_presenters.WrappedCorqOutputPresenter(),
+        login_presenter=_presenters.LoginPresenter(),
         config_repo=_repos.ConfigRepo(),
-        qe_repo=_repos.QeClientRepo(),
+        qe_repo=_repos.QEClientRepo(),
     ):
-        self._presenter = presenter
-
+        self._exception_presenter = exception_presenter
+        self._login_presenter = login_presenter
         # data sources
         self._config_repo = config_repo
         self._qe_repo = qe_repo
@@ -33,7 +34,7 @@ class Action:
         try:
             self._on_cmd_call_with_exceptions(url, token)
         except Exception as e:
-            self._presenter.show_error(e)
+            self._exception_presenter.show_error(e)
 
     def _on_cmd_call_with_exceptions(
         self,
@@ -50,16 +51,8 @@ class Action:
 
     def _prompt_for_login(self, url: str):
         login_url = self._qe_repo.get_login_url(url)
-        print("Please follow this URL to proceed with login:")
-        print(login_url)
-        print(
-            "Then save the token using command: \n"
-            f"orq login -s {url} -t <paste your token here>"
-        )
+        self._login_presenter.prompt_for_login(login_url, url)
 
     def _save_token(self, url, token):
         config_name = self._config_repo.store_token_in_config(url, token)
-        print(
-            f"Token saved in config file. "
-            f"Configuration name for {url} is {config_name}"
-        )
+        self._login_presenter.prompt_config_saved(url, config_name)

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -10,14 +10,15 @@ import sys
 import typing as t
 import warnings
 from pathlib import Path
+
 import requests
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _config, _db, _factory, loader
+from orquestra.sdk._base._qe import _client
 from orquestra.sdk.schema.configs import ConfigName, RuntimeName
 from orquestra.sdk.schema.workflow_run import WorkflowRun, WorkflowRunId
-from orquestra.sdk._base._qe import _client
 
 
 class WorkflowRunRepo:
@@ -108,6 +109,7 @@ class ConfigRepo:
     """
     Wraps accessing ~/.orquestra/config.json
     """
+
     @staticmethod
     def list_config_names() -> t.Sequence[ConfigName]:
         return sdk.RuntimeConfig.list_configs()
@@ -133,6 +135,7 @@ class QeClientRepo:
     """
     Wraps access to QE client
     """
+
     @staticmethod
     def get_login_url(uri: str):
         client = _client.QEClient(session=requests.Session(), base_uri=uri)
@@ -141,7 +144,7 @@ class QeClientRepo:
             target_url = client.get_login_url()
         except (requests.ConnectionError, requests.exceptions.MissingSchema):
             print(f"Unable to communicate with server: {uri}", file=sys.stderr)
-            raise exceptions.UnauthorizedError(f"Cannot connect to server \"{uri}\"")
+            raise exceptions.UnauthorizedError(f'Cannot connect to server "{uri}"')
         return target_url
 
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -140,7 +140,6 @@ class QEClientRepo:
         try:
             target_url = client.get_login_url()
         except (requests.ConnectionError, requests.exceptions.MissingSchema):
-            print(f"Unable to communicate with server: {uri}", file=sys.stderr)
             raise exceptions.UnauthorizedError(f'Cannot connect to server "{uri}"')
         return target_url
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -110,12 +110,10 @@ class ConfigRepo:
     Wraps accessing ~/.orquestra/config.json
     """
 
-    @staticmethod
-    def list_config_names() -> t.Sequence[ConfigName]:
+    def list_config_names(self) -> t.Sequence[ConfigName]:
         return sdk.RuntimeConfig.list_configs()
 
-    @staticmethod
-    def store_token_in_config(uri, token):
+    def store_token_in_config(self, uri, token):
         runtime_name = RuntimeName.QE_REMOTE
         config_name = _config.generate_config_name(runtime_name, uri)
 
@@ -131,13 +129,12 @@ class ConfigRepo:
         return config_name
 
 
-class QeClientRepo:
+class QEClientRepo:
     """
     Wraps access to QE client
     """
 
-    @staticmethod
-    def get_login_url(uri: str):
+    def get_login_url(self, uri: str):
         client = _client.QEClient(session=requests.Session(), base_uri=uri)
         # Ask QE for the login url to log in to the platform
         try:

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -97,3 +97,17 @@ class ServicePresenter:
                 tablefmt="plain",
             ),
         )
+
+
+class LoginPresenter:
+    def prompt_for_login(self, login_url, url):
+        click.echo("Please follow this URL to proceed with login:")
+        click.echo(login_url)
+        click.echo(
+            "Then save the token using command: \n"
+            f"orq login -s {url} -t <paste your token here>"
+        )
+
+    def prompt_config_saved(self, url, config_name):
+        click.echo("Token saved in config file.")
+        click.echo(f"Configuration name for {url} is {config_name}")

--- a/tests/cli/dorq/test_entrypoint.py
+++ b/tests/cli/dorq/test_entrypoint.py
@@ -35,6 +35,7 @@ class TestCommandTreeAssembly:
             ["up"],
             ["down"],
             ["status"],
+            ["login"],
         ],
     )
     @pytest.mark.parametrize(

--- a/tests/cli/dorq/test_login.py
+++ b/tests/cli/dorq/test_login.py
@@ -1,0 +1,75 @@
+from unittest.mock import MagicMock, Mock, PropertyMock, call
+
+import pytest
+
+from orquestra.sdk._base.cli._dorq._login import _login
+from orquestra.sdk.schema.responses import ResponseStatusCode
+
+
+class TestAction:
+    """
+    Test boundaries::
+        [_up.Action]->[arg resolvers]
+                    ->[presenter]
+    """
+
+    @staticmethod
+    def test_passed_server_no_token(capsys):
+        """
+        Verifies how we pass variables between subcomponents.
+        """
+        # Given
+        # CLI inputs
+        url = "my_url"
+        token = None
+
+        # Mocks
+        presenter = MagicMock()
+        qe_repo = MagicMock()
+        config_repo = MagicMock()
+
+        action = _login.Action(
+            presenter=presenter,
+            qe_repo=qe_repo,
+            config_repo=config_repo
+        )
+
+        # When
+        action.on_cmd_call(url=url, token=token)
+
+        # Then
+        # We should get the login url from QE
+        assert qe_repo.mock_calls.count(call.get_login_url(url))
+        captured = capsys.readouterr()
+        assert "Please follow this URL to proceed with login" in captured.out
+        assert "Then save the token using command:" in captured.out
+        assert f"orq login -s {url} -t <paste your token here>" in captured.out
+
+    @staticmethod
+    def test_passed_server_and_token(capsys):
+        """
+        Verifies how we pass variables between subcomponents.
+        """
+        # Given
+        # CLI inputs
+        url = "my_url"
+        token = "my_token"
+
+        presenter = MagicMock()
+        qe_repo = MagicMock()
+        config_repo = MagicMock()
+
+        action = _login.Action(
+            presenter=presenter,
+            qe_repo=qe_repo,
+            config_repo=config_repo
+        )
+
+        # When
+        action.on_cmd_call(url=url, token=token)
+
+        # Then
+        # We should get the login url from QE
+        assert config_repo.mock_calls.count(call.store_token_in_config(url, token))
+        captured = capsys.readouterr()
+        assert f"Configuration name for {url} is " in captured.out

--- a/tests/cli/dorq/test_login.py
+++ b/tests/cli/dorq/test_login.py
@@ -29,9 +29,7 @@ class TestAction:
         config_repo = MagicMock()
 
         action = _login.Action(
-            presenter=presenter,
-            qe_repo=qe_repo,
-            config_repo=config_repo
+            presenter=presenter, qe_repo=qe_repo, config_repo=config_repo
         )
 
         # When
@@ -60,9 +58,7 @@ class TestAction:
         config_repo = MagicMock()
 
         action = _login.Action(
-            presenter=presenter,
-            qe_repo=qe_repo,
-            config_repo=config_repo
+            presenter=presenter, qe_repo=qe_repo, config_repo=config_repo
         )
 
         # When

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -315,7 +315,7 @@ class TestConfigRepo:
             "uri, token, config_name",
             [
                 ("http://name.domain", "funny_token", "name"),
-                ("http://actual_name.domain", "new_token", "actual_name"),
+                ("https://actual_name.domain", "new_token", "actual_name"),
             ],
             ids=[
                 "Creating new config entry",

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -318,9 +318,11 @@ class TestConfigRepo:
             ids=[
                 "Creating new config entry",
                 "Updating existing config entry",
-            ]
+            ],
         )
-        def test_update_config(tmp_path: Path, monkeypatch, config_content, uri, token, config_name):
+        def test_update_config(
+            tmp_path: Path, monkeypatch, config_content, uri, token, config_name
+        ):
             """
             Verifies that the output is a list that makes sense for the user to select
             the config value from.
@@ -334,7 +336,10 @@ class TestConfigRepo:
             repo = _repos.ConfigRepo()
             # this assert stands to protect the json content. For this test to work
             # it assumes that such config exist, and it matches parametrized values.
-            assert config_content["configs"]["actual_name"]["runtime_options"]["uri"] == "http://actual_name.domain"
+            assert (
+                config_content["configs"]["actual_name"]["runtime_options"]["uri"]
+                == "http://actual_name.domain"
+            )
 
             # When
             repo.store_token_in_config(uri, token)
@@ -343,7 +348,10 @@ class TestConfigRepo:
             with open(config_path) as f:
                 content = json.load(f)
                 assert content["configs"][config_name]["runtime_options"]["uri"] == uri
-                assert content["configs"][config_name]["runtime_options"]["token"] == token
+                assert (
+                    content["configs"][config_name]["runtime_options"]["token"] == token
+                )
+
 
 class TestResolveDottedName:
     """

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -355,13 +355,13 @@ class TestConfigRepo:
                 )
 
 
-class TestQeClientRepo:
+class TestQEClientRepo:
     def test_return_valid_token(self, monkeypatch):
         # Given
         fake_login_url = "http://my_login.url"
         monkeypatch.setattr(QEClient, "get_login_url", lambda x: fake_login_url)
 
-        repo = _repos.QeClientRepo
+        repo = _repos.QEClientRepo()
 
         # When
         login_url = repo.get_login_url("uri")
@@ -379,7 +379,7 @@ class TestQeClientRepo:
 
         monkeypatch.setattr(QEClient, "get_login_url", _exception)
 
-        repo = _repos.QeClientRepo
+        repo = _repos.QEClientRepo()
 
         # Then
         with pytest.raises(exceptions.UnauthorizedError):

--- a/tests/cli/dorq/ui/test_presenters.py
+++ b/tests/cli/dorq/ui/test_presenters.py
@@ -146,3 +146,34 @@ class TestServicesPresneter:
             # Then
             captured = capsys.readouterr()
             assert "mocked  Not Running  something" in captured.out
+
+
+class TestLoginPresenter:
+    def test_prompt_for_login(self, capsys):
+        # Given
+        url = "cool_url"
+        login_url = "cool_login_url"
+        presenter = _presenters.LoginPresenter()
+
+        # When
+        presenter.prompt_for_login(login_url, url)
+
+        # Then
+        captured = capsys.readouterr()
+        assert "Please follow this URL to proceed with login" in captured.out
+        assert login_url in captured.out
+        assert "Then save the token using command:" in captured.out
+        assert f"orq login -s {url} -t <paste your token here>" in captured.out
+
+    def test_prompt_config_saved(self, capsys):
+        # Given
+        url = "cool_url"
+        config_name = "cool_config_name"
+        presenter = _presenters.LoginPresenter()
+
+        # When
+        presenter.prompt_config_saved(url, config_name)
+
+        # Then
+        captured = capsys.readouterr()
+        assert f"Configuration name for {url} is {config_name}" in captured.out

--- a/tests/sdk/v2/data/configs.py
+++ b/tests/sdk/v2/data/configs.py
@@ -27,6 +27,14 @@ TEST_CONFIG_JSON = {
                 "token": "test_token",
             },
         },
+        "actual_name": {
+            "config_name": "actual_name",
+            "runtime_name": "QE_REMOTE",
+            "runtime_options": {
+                "uri": "http://actual_name.domain",
+                "token": "this_token_best_token",
+            },
+        },
     },
     "default_config_name": "test_config_default",
 }


### PR DESCRIPTION
# The problem

New CLI has to give users ability to log in

# This PR's solution

Does create orq login command with possibility to store tokens

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
