### PR TITLE
Chore: Silence dependabot warnings

### DIFF
--- a/tests/sdk/v2/data/bad_requirements.txt
+++ b/tests/sdk/v2/data/bad_requirements.txt
@@ -1,3 +1,3 @@
-joblib==1.1.0
+joblib==1.2.0
 joblib==2.1.0
-numpy==1.21.5
+numpy==1.22.0

--- a/tests/sdk/v2/data/requirements.txt
+++ b/tests/sdk/v2/data/requirements.txt
@@ -1,2 +1,2 @@
-joblib==1.1.0
-numpy==1.21.5
+joblib==1.2.0
+numpy==1.22.0

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -576,7 +576,7 @@ def test_default_for_non_interactive_mode(monkeypatch):
         ),
         (
             sdk.PythonImports(file="tests/sdk/v2/data/requirements.txt"),
-            ["joblib==1.1.0", "numpy==1.21.5"],
+            ["joblib==1.2.0", "numpy==1.22.0"],
             do_not_raise(),
         ),
         (
@@ -602,7 +602,7 @@ def test_default_for_non_interactive_mode(monkeypatch):
             sdk.PythonImports(
                 "scipy==1.7.3", file="tests/sdk/v2/data/requirements.txt"
             ),
-            ["joblib==1.1.0", "numpy==1.21.5", "scipy==1.7.3"],
+            ["joblib==1.2.0", "numpy==1.22.0", "scipy==1.7.3"],
             do_not_raise(),
         ),
         (


### PR DESCRIPTION
# The problem

Dependabot shows security issues - it detects them in our requirements.txt files that we use for testing to parse requirements files. Unfortunately it is impossible to "exclude" those from scanning:
https://github.com/dependabot/dependabot-core/issues/4364

# This PR's solution

As we cannot exclude test directories from scanning - the solution is just to bump the revisions.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
