### PR TITLE
Feat: Extend dorq login with --ce flag for CE login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 👩‍🔬 *Experimental*
 * New CLI command: `python -m orquestra.sdk._base.cli._dorq._entry login`.
+* New CLI Login commands allows to login to CE with --ce flag
 
 🐛 *Bug Fixes*
 

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -121,10 +121,17 @@ class DriverClient:
 
     # --- helpers ---
 
-    def _get(self, endpoint: str, query_params: Optional[Mapping]) -> requests.Response:
+    def _get(
+        self,
+        endpoint: str,
+        query_params: Optional[Mapping],
+        allow_redirects: bool = True,
+    ) -> requests.Response:
         """Helper method for GET requests"""
         response = self._session.get(
-            urljoin(self._base_uri, endpoint), params=query_params
+            urljoin(self._base_uri, endpoint),
+            params=query_params,
+            allow_redirects=allow_redirects,
         )
 
         return response
@@ -218,6 +225,7 @@ class DriverClient:
         resp = self._get(
             API_ACTIONS["get_login_url"],
             query_params={"state": "0"},
+            allow_redirects=False,
         )
         return resp.headers["Location"]
 

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -41,6 +41,8 @@ API_ACTIONS = {
     # Logs
     "get_workflow_run_logs": "/api/workflow-run-logs",
     "get_task_run_logs": "/api/task-run-logs",
+    # Login
+    "get_login_url": "v1/login",
 }
 
 
@@ -205,6 +207,19 @@ class DriverClient:
             prev_page_token=prev_token,
             next_page_token=next_token,
         )
+
+    def get_login_url(self) -> str:
+        """First step in the auth flow. Fetches the URL that the user has to visit.
+
+        Raises:
+            requests.ConnectionError: if the request fails.
+            KeyError: if the URL couldn't be found in the response.
+        """
+        resp = self._get(
+            API_ACTIONS["get_login_url"],
+            query_params={"state": "0"},
+        )
+        return resp.headers["Location"]
 
     def get_workflow_def(self, workflow_def_id: _models.WorkflowDefID) -> WorkflowDef:
         """

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -182,14 +182,15 @@ dorq.section(
     help="User Token to given server. To generate token, use this command without -t"
     "option first",
 )
-def login(server: str, token: t.Optional[str]):
+@cloup.option("--ce", is_flag=True, default=False, help="Start a Ray cluster")
+def login(server: str, token: t.Optional[str], ce: bool):
     """
     Login in to remote cluster
     """
     from ._login._login import Action
 
     action = Action()
-    action.on_cmd_call(server, token)
+    action.on_cmd_call(server, token, ce)
 
 
 def main():

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -52,7 +52,7 @@ class Action:
 
     def _prompt_for_login(self, url: str, ce: bool):
         login_url = self._runtime_repo.get_login_url(url, ce)
-        self._login_presenter.prompt_for_login(login_url, url)
+        self._login_presenter.prompt_for_login(login_url, url, ce)
 
     def _save_token(self, url, token, ce: bool):
         config_name = self._config_repo.store_token_in_config(url, token, ce)

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -22,17 +22,17 @@ class Action:
         exception_presenter=_presenters.WrappedCorqOutputPresenter(),
         login_presenter=_presenters.LoginPresenter(),
         config_repo=_repos.ConfigRepo(),
-        qe_repo=_repos.QEClientRepo(),
+        runtime_repo=_repos.RuntimeRepo(),
     ):
         self._exception_presenter = exception_presenter
         self._login_presenter = login_presenter
         # data sources
         self._config_repo = config_repo
-        self._qe_repo = qe_repo
+        self._runtime_repo = runtime_repo
 
-    def on_cmd_call(self, url: str, token: t.Optional[str]):
+    def on_cmd_call(self, url: str, token: t.Optional[str], ce: bool):
         try:
-            self._on_cmd_call_with_exceptions(url, token)
+            self._on_cmd_call_with_exceptions(url, token, ce)
         except Exception as e:
             self._exception_presenter.show_error(e)
 
@@ -40,19 +40,20 @@ class Action:
         self,
         url: str,
         token: t.Optional[str],
+        ce: bool,
     ):
         """
         Implementation of the command action. Doesn't catch exceptions.
         """
         if token is None:
-            self._prompt_for_login(url)
+            self._prompt_for_login(url, ce)
         else:
-            self._save_token(url, token)
+            self._save_token(url, token, ce)
 
-    def _prompt_for_login(self, url: str):
-        login_url = self._qe_repo.get_login_url(url)
+    def _prompt_for_login(self, url: str, ce: bool):
+        login_url = self._runtime_repo.get_login_url(url, ce)
         self._login_presenter.prompt_for_login(login_url, url)
 
-    def _save_token(self, url, token):
-        config_name = self._config_repo.store_token_in_config(url, token)
+    def _save_token(self, url, token, ce: bool):
+        config_name = self._config_repo.store_token_in_config(url, token, ce)
         self._login_presenter.prompt_config_saved(url, config_name)

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -24,11 +24,15 @@ class Action:
         config_repo=_repos.ConfigRepo(),
         runtime_repo=_repos.RuntimeRepo(),
     ):
-        self._exception_presenter = exception_presenter
-        self._login_presenter = login_presenter
+        # presenters
+        self._exception_presenter: _presenters.WrappedCorqOutputPresenter = (
+            exception_presenter
+        )
+        self._login_presenter: _presenters.LoginPresenter = login_presenter
+
         # data sources
-        self._config_repo = config_repo
-        self._runtime_repo = runtime_repo
+        self._config_repo: _repos.ConfigRepo = config_repo
+        self._runtime_repo: _repos.RuntimeRepo = runtime_repo
 
     def on_cmd_call(self, url: str, token: t.Optional[str], ce: bool):
         try:

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -16,6 +16,7 @@ import requests
 from orquestra import sdk
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _config, _db, _factory, loader
+from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._qe import _client
 from orquestra.sdk.schema.configs import ConfigName, RuntimeName
 from orquestra.sdk.schema.workflow_run import WorkflowRun, WorkflowRunId
@@ -113,8 +114,8 @@ class ConfigRepo:
     def list_config_names(self) -> t.Sequence[ConfigName]:
         return sdk.RuntimeConfig.list_configs()
 
-    def store_token_in_config(self, uri, token):
-        runtime_name = RuntimeName.QE_REMOTE
+    def store_token_in_config(self, uri, token, ce):
+        runtime_name = RuntimeName.CE_REMOTE if ce else RuntimeName.QE_REMOTE
         config_name = _config.generate_config_name(runtime_name, uri)
 
         config = sdk.RuntimeConfig(
@@ -129,14 +130,17 @@ class ConfigRepo:
         return config_name
 
 
-class QEClientRepo:
+class RuntimeRepo:
     """
-    Wraps access to QE client
+    Wraps access to QE/CE clients
     """
 
-    def get_login_url(self, uri: str):
-        client = _client.QEClient(session=requests.Session(), base_uri=uri)
-        # Ask QE for the login url to log in to the platform
+    def get_login_url(self, uri: str, ce: bool):
+        if ce:
+            client = DriverClient(base_uri=uri, session=requests.Session())
+        else:
+            client = _client.QEClient(session=requests.Session(), base_uri=uri)
+            # Ask QE for the login url to log in to the platform
         try:
             target_url = client.get_login_url()
         except (requests.ConnectionError, requests.exceptions.MissingSchema):

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -7,6 +7,7 @@ Repositories that encapsulate data access used by dorq commands.
 import importlib
 import os
 import sys
+import typing
 import typing as t
 import warnings
 from pathlib import Path
@@ -136,6 +137,7 @@ class RuntimeRepo:
     """
 
     def get_login_url(self, uri: str, ce: bool):
+        client: typing.Union[DriverClient, _client.QEClient]
         if ce:
             client = DriverClient(base_uri=uri, session=requests.Session())
         else:

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -100,12 +100,15 @@ class ServicePresenter:
 
 
 class LoginPresenter:
-    def prompt_for_login(self, login_url, url):
+    def prompt_for_login(self, login_url, url, ce):
         click.echo("Please follow this URL to proceed with login:")
         click.echo(login_url)
         click.echo(
-            "Then save the token using command: \n"
-            f"orq login -s {url} -t <paste your token here>"
+            (
+                "Then save the token using command: \n"
+                f"orq login -s {url} -t <paste your token here>"
+            )
+            + (" --ce" if ce else "")
         )
 
     def prompt_config_saved(self, url, config_name):

--- a/tests/cli/dorq/test_login.py
+++ b/tests/cli/dorq/test_login.py
@@ -14,7 +14,8 @@ class TestAction:
     """
 
     @staticmethod
-    def test_passed_server_no_token():
+    @pytest.mark.parametrize("ce", [True, False])
+    def test_passed_server_no_token(ce):
         """
         Verifies how we pass variables between subcomponents.
         """
@@ -27,30 +28,31 @@ class TestAction:
         # Mocks
         exception_presenter = MagicMock()
         login_presenter = MagicMock()
-        qe_repo = MagicMock()
+        runtime_repo = MagicMock()
         config_repo = MagicMock()
-        qe_repo.get_login_url.return_value = config_url
+        runtime_repo.get_login_url.return_value = config_url
 
         action = _login.Action(
             exception_presenter=exception_presenter,
             login_presenter=login_presenter,
-            qe_repo=qe_repo,
+            runtime_repo=runtime_repo,
             config_repo=config_repo,
         )
 
         # When
-        action.on_cmd_call(url=url, token=token)
+        action.on_cmd_call(url=url, token=token, ce=ce)
 
         # Then
         # We should get the login url from QE
-        assert qe_repo.mock_calls.count(call.get_login_url(url)) == 1
+        assert runtime_repo.mock_calls.count(call.get_login_url(url, ce)) == 1
         assert (
             login_presenter.mock_calls.count(call.prompt_for_login(config_url, url))
             == 1
         )
 
     @staticmethod
-    def test_passed_server_and_token():
+    @pytest.mark.parametrize("ce", [True, False])
+    def test_passed_server_and_token(ce):
         """
         Verifies how we pass variables between subcomponents.
         """
@@ -62,23 +64,26 @@ class TestAction:
         config_name = "cfg"
         exception_presenter = MagicMock()
         login_presenter = MagicMock()
-        qe_repo = MagicMock()
+        runtime_repo = MagicMock()
         config_repo = MagicMock()
         config_repo.store_token_in_config.return_value = config_name
 
         action = _login.Action(
             exception_presenter=exception_presenter,
             login_presenter=login_presenter,
-            qe_repo=qe_repo,
+            runtime_repo=runtime_repo,
             config_repo=config_repo,
         )
 
         # When
-        action.on_cmd_call(url=url, token=token)
+        action.on_cmd_call(url=url, token=token, ce=ce)
 
         # Then
         # We should get the login url from QE
-        assert config_repo.mock_calls.count(call.store_token_in_config(url, token)) == 1
+        assert (
+            config_repo.mock_calls.count(call.store_token_in_config(url, token, ce))
+            == 1
+        )
         assert (
             login_presenter.mock_calls.count(call.prompt_config_saved(url, config_name))
             == 1

--- a/tests/cli/dorq/test_login.py
+++ b/tests/cli/dorq/test_login.py
@@ -1,9 +1,13 @@
-from unittest.mock import MagicMock, Mock, PropertyMock, call
+from unittest.mock import MagicMock, Mock, call, create_autospec
 
 import pytest
 
 from orquestra.sdk._base.cli._dorq._login import _login
-from orquestra.sdk.schema.responses import ResponseStatusCode
+from orquestra.sdk._base.cli._dorq._repos import ConfigRepo, RuntimeRepo
+from orquestra.sdk._base.cli._dorq._ui._presenters import (
+    LoginPresenter,
+    WrappedCorqOutputPresenter,
+)
 
 
 class TestAction:
@@ -26,10 +30,11 @@ class TestAction:
         token = None
 
         # Mocks
-        exception_presenter = MagicMock()
-        login_presenter = MagicMock()
-        runtime_repo = MagicMock()
-        config_repo = MagicMock()
+        exception_presenter = create_autospec(WrappedCorqOutputPresenter)
+        login_presenter = create_autospec(LoginPresenter)
+        runtime_repo = create_autospec(RuntimeRepo)
+        config_repo = create_autospec(ConfigRepo)
+
         runtime_repo.get_login_url.return_value = config_url
 
         action = _login.Action(
@@ -45,10 +50,8 @@ class TestAction:
         # Then
         # We should get the login url from QE
         assert runtime_repo.mock_calls.count(call.get_login_url(url, ce)) == 1
-        assert (
-            login_presenter.mock_calls.count(call.prompt_for_login(config_url, url))
-            == 1
-        )
+        exception_presenter.show_error.assert_not_called()
+        login_presenter.prompt_for_login.assert_called_once_with(config_url, url, ce)
 
     @staticmethod
     @pytest.mark.parametrize("ce", [True, False])
@@ -62,10 +65,11 @@ class TestAction:
         token = "my_token"
 
         config_name = "cfg"
-        exception_presenter = MagicMock()
-        login_presenter = MagicMock()
-        runtime_repo = MagicMock()
-        config_repo = MagicMock()
+        exception_presenter = create_autospec(WrappedCorqOutputPresenter)
+        login_presenter = create_autospec(LoginPresenter)
+        runtime_repo = create_autospec(RuntimeRepo)
+        config_repo = create_autospec(ConfigRepo)
+
         config_repo.store_token_in_config.return_value = config_name
 
         action = _login.Action(
@@ -80,11 +84,6 @@ class TestAction:
 
         # Then
         # We should get the login url from QE
-        assert (
-            config_repo.mock_calls.count(call.store_token_in_config(url, token, ce))
-            == 1
-        )
-        assert (
-            login_presenter.mock_calls.count(call.prompt_config_saved(url, config_name))
-            == 1
-        )
+        exception_presenter.show_error.assert_not_called()
+        config_repo.store_token_in_config.assert_called_once_with(url, token, ce)
+        login_presenter.prompt_config_saved.assert_called_once_with(url, config_name)

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -367,7 +367,7 @@ class TestConfigRepo:
                 assert content["configs"][config_name]["runtime_name"] == runtime_name
 
 
-class TestQEClientRepo:
+class TestRuntimeRepo:
     @pytest.mark.parametrize("ce", [True, False])
     def test_return_valid_token(self, monkeypatch, ce):
         # Given

--- a/tests/cli/dorq/ui/test_presenters.py
+++ b/tests/cli/dorq/ui/test_presenters.py
@@ -5,6 +5,8 @@ import sys
 import typing as t
 from unittest.mock import Mock
 
+import pytest
+
 from orquestra import sdk
 from orquestra.sdk._base.cli._corq._format import per_command
 from orquestra.sdk._base.cli._dorq._ui import _errors, _presenters
@@ -149,21 +151,25 @@ class TestServicesPresneter:
 
 
 class TestLoginPresenter:
-    def test_prompt_for_login(self, capsys):
+    @pytest.mark.parametrize("ce", [True, False])
+    def test_prompt_for_login(self, capsys, ce):
         # Given
         url = "cool_url"
         login_url = "cool_login_url"
         presenter = _presenters.LoginPresenter()
 
         # When
-        presenter.prompt_for_login(login_url, url)
+        presenter.prompt_for_login(login_url, url, ce)
 
         # Then
         captured = capsys.readouterr()
         assert "Please follow this URL to proceed with login" in captured.out
         assert login_url in captured.out
         assert "Then save the token using command:" in captured.out
-        assert f"orq login -s {url} -t <paste your token here>" in captured.out
+        assert (
+            f"orq login -s {url} -t <paste your token here>" + (" --ce" if ce else "")
+            in captured.out
+        )
 
     def test_prompt_config_saved(self, capsys):
         # Given


### PR DESCRIPTION
# The problem

No user interface to login into CE

# This PR's solution

Add flag, when user uses dorq login [..] --ce, they will be logged into with CE configuration

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
