### PR TITLE
fix: orq up timing out

### DIFF
--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -88,7 +88,7 @@ def _compose_path():
 
 
 # Timeout for inter-process commands (seconds).
-IPC_TIMEOUT = 10
+IPC_TIMEOUT = 20
 
 
 class DockerException(Exception):


### PR DESCRIPTION
# The problem

Sometimes `dorq up` raised timeout errors on my machine. Even when if it succeeds, the command time is dangerously close to our timeout threshold. I'm using Python 3.10.2.

```
$ time dorq up
  [####################################]  100%
Ray  Running  Started!

real    0m11.279s
user    0m2.972s
sys     0m0.894s
```

# This PR's solution

Increases the timeout threshold for `dorq {up,down,services}` by the factor of 2. Let our future selves deal with the root problem.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [ ] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
