### PR TITLE
docs: fixed broken link on docs landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * New CLI Login commands allows to login to CE with --ce flag
 
 🐛 *Bug Fixes*
+* Fixed broken link on docs landing page.
 
 
 *Internal*

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ If you'd like to report a bug/issue please create a [new issue using one of the 
 
 ## Contributing
 
-Please see our [CONTRIBUTING.md](CONTRIBUTING.md)] for more information on contributing to Orquestra Workflow SDK.
+Please see our [CONTRIBUTING.md](CONTRIBUTING.md) for more information on contributing to Orquestra Workflow SDK.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Orquestra Workflow SDK
 
 Orquestra Workflow SDK allows you to write, execute, and manage computational workflows using Python.
 
-.. button-ref:: tutorials/installation
+.. button-ref:: tutorials/installing-macos-linux
    :color: primary
    :shadow:
 


### PR DESCRIPTION
# The problem

The link on the docs landing page to get started was broken.

# This PR's solution

Updates link to point to installation tutorial.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
