### PR TITLE
Feat: Prompt users for configs in all DORQ commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 👩‍🔬 *Experimental*
 * New CLI command: `python -m orquestra.sdk._base.cli._dorq._entry login`.
 * New CLI Login commands allows to login to CE with --ce flag
+* Dorq wf submit now properly prompts users for config selection
 
 🐛 *Bug Fixes*
 * Fixed broken link on docs landing page.

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -1122,7 +1122,7 @@ class RuntimeConfig:
             list: list of configurations within the save file.
         """
         return _config.read_config_names(config_save_file) + list(
-            _config.SPECIAL_CONFIG_NAME_DICT.keys()
+            _config.UNIQUE_CONFIGS
         )
 
     @classmethod
@@ -1225,7 +1225,10 @@ class RuntimeConfig:
             _config.load()).
         """
         if config.runtime_name == RuntimeName.IN_PROCESS:
-            return RuntimeConfig.in_process(config.config_name)
+            return RuntimeConfig.in_process()
+        elif config.runtime_name == RuntimeName.RAY_LOCAL:
+            return RuntimeConfig.ray()
+
         interpreted_config = RuntimeConfig(
             config.runtime_name,
             config.config_name,

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -54,6 +54,11 @@ SPECIAL_CONFIG_NAME_DICT = {
     BUILT_IN_CONFIG_NAME: LOCAL_RUNTIME_CONFIGURATION,
     RAY_CONFIG_NAME_ALIAS: LOCAL_RUNTIME_CONFIGURATION,
 }
+# Unique config list to prompt to the users. Separate from SPECIAL_CONFIG_NAME_DICT
+# as SPECIAL_CONFIG_NAME_DICT might have duplicate names which could be confusing for
+# the user
+UNIQUE_CONFIGS = {RAY_CONFIG_NAME_ALIAS, IN_PROCESS_CONFIG_NAME}
+
 
 # region: runtime options
 RAY_RUNTIME_OPTIONS: List[str] = [

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -19,6 +19,29 @@ from ._ui import _prompts
 
 class ConfigResolver:
     """
+    Resolves value of `config` CLI arg, using only config name passed
+    """
+
+    def __init__(
+        self,
+        config_repo=_repos.ConfigRepo(),
+        prompter=_prompts.Prompter(),
+    ):
+        self._config_repo = config_repo
+        self._prompter = prompter
+
+    def resolve(self, config: t.Optional[ConfigName]) -> ConfigName:
+        if config is not None:
+            return config
+
+        # 1.2. Prompt the user.
+        config_names = self._config_repo.list_config_names()
+        selected_config = self._prompter.choice(config_names, message="Runtime config")
+        return selected_config
+
+
+class WFConfigResolver:
+    """
     Resolves value of `config` CLI arg, making use of `wf_run_id` if already passed.
     """
 
@@ -48,10 +71,8 @@ class ConfigResolver:
                 # need to ask the user for the config.
                 pass
 
-        # 1.2. Prompt the user.
-        config_names = self._config_repo.list_config_names()
-        selected_config = self._prompter.choice(config_names, message="Runtime config")
-        return selected_config
+        # 1.2. Prompt the user
+        return ConfigResolver(self._config_repo, self._prompter).resolve(config)
 
 
 class WFRunIDResolver:

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -38,9 +38,6 @@ class ConfigResolver:
         if config is not None:
             return config
 
-        # TODO: make sure it works with `ray` and `in_process` runtimes.
-        # Jira ticket: https://zapatacomputing.atlassian.net/browse/ORQSDK-674
-
         if wf_run_id is not None:
             # 1.1. Attempt to get config from local cache.
             try:

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_stop.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_stop.py
@@ -26,14 +26,14 @@ class Action:
         self,
         presenter=_presenters.WrappedCorqOutputPresenter(),
         wf_run_repo=_repos.WorkflowRunRepo(),
-        config_resolver: t.Optional[_arg_resolvers.ConfigResolver] = None,
+        config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
         wf_run_id_resolver: t.Optional[_arg_resolvers.WFRunIDResolver] = None,
     ):
         # data sources
         self._wf_run_repo = wf_run_repo
 
         # arg resolvers
-        self._config_resolver = config_resolver or _arg_resolvers.ConfigResolver(
+        self._config_resolver = config_resolver or _arg_resolvers.WFConfigResolver(
             wf_run_repo=wf_run_repo
         )
         self._wf_run_id_resolver = wf_run_id_resolver or _arg_resolvers.WFRunIDResolver(

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_submit.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_submit.py
@@ -36,7 +36,7 @@ class Action:
         self._wf_run_repo = wf_run_repo
         self._wf_def_repo = wf_def_repo
         self._config_resolver = config_resolver or _arg_resolvers.ConfigResolver(
-            wf_run_repo=wf_run_repo, prompter=prompter
+            prompter=prompter
         )
 
     def on_cmd_call(
@@ -58,7 +58,7 @@ class Action:
         Implementation of the command action. Doesn't catch exceptions.
         """
         # 1. Resolve config
-        resolved_config = self._config_resolver.resolve(None, config)
+        resolved_config = self._config_resolver.resolve(config)
 
         # 2. Resolve module with workflow defs
         try:

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_view.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_view.py
@@ -27,14 +27,14 @@ class Action:
         self,
         presenter=_presenters.WrappedCorqOutputPresenter(),
         wf_run_repo=_repos.WorkflowRunRepo(),
-        config_resolver: t.Optional[_arg_resolvers.ConfigResolver] = None,
+        config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
         wf_run_id_resolver: t.Optional[_arg_resolvers.WFRunIDResolver] = None,
     ):
         # data sources
         self._wf_run_repo = wf_run_repo
 
         # arg resolvers
-        self._config_resolver = config_resolver or _arg_resolvers.ConfigResolver(
+        self._config_resolver = config_resolver or _arg_resolvers.WFConfigResolver(
             wf_run_repo=wf_run_repo
         )
         self._wf_run_id_resolver = wf_run_id_resolver or _arg_resolvers.WFRunIDResolver(

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -39,9 +39,8 @@ class TestConfigResolver:
         assert resolved_config == config
 
     @staticmethod
-    def test_no_wf_run_id():
+    def test_no_config():
         # Given
-        wf_run_id = None
         config = None
 
         config_repo = Mock()

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -28,6 +28,65 @@ class TestConfigResolver:
         config = "<config sentinel>"
 
         resolver = _arg_resolvers.ConfigResolver(
+            config_repo=Mock(),
+            prompter=Mock(),
+        )
+
+        # When
+        resolved_config = resolver.resolve(config=config)
+
+        # Then
+        assert resolved_config == config
+
+    @staticmethod
+    def test_no_wf_run_id():
+        # Given
+        wf_run_id = None
+        config = None
+
+        config_repo = Mock()
+        local_config_names = ["cfg1", "cfg2"]
+        config_repo.list_config_names.return_value = local_config_names
+
+        prompter = Mock()
+        selected_config = local_config_names[1]
+        prompter.choice.return_value = selected_config
+
+        resolver = _arg_resolvers.ConfigResolver(
+            config_repo=config_repo,
+            prompter=prompter,
+        )
+
+        # When
+        resolved_config = resolver.resolve(config=config)
+
+        # Then
+        # We expect prompt for selecting config.
+        prompter.choice.assert_called_with(local_config_names, message="Runtime config")
+
+        # Resolver should return the user's choice.
+        assert resolved_config == selected_config
+
+
+class TestWFConfigResolver:
+    """
+    Test boundaries::
+        [ConfigResolver]->[repos]
+                        ->[prompter]
+    """
+
+    @staticmethod
+    @pytest.mark.parametrize("wf_run_id", ["<wf run ID sentinel>", None])
+    def test_passing_config_directly(wf_run_id):
+        """
+        User passed `config` value directly as CLI arg.
+
+        We expect the same result regardless of ``wf_run_id``.
+        """
+        # Given
+        config = "<config sentinel>"
+
+        resolver = _arg_resolvers.WFConfigResolver(
             wf_run_repo=Mock(),
             config_repo=Mock(),
             prompter=Mock(),
@@ -56,7 +115,7 @@ class TestConfigResolver:
 
             prompter = Mock()
 
-            resolver = _arg_resolvers.ConfigResolver(
+            resolver = _arg_resolvers.WFConfigResolver(
                 wf_run_repo=wf_run_repo,
                 config_repo=Mock(),
                 prompter=prompter,
@@ -99,7 +158,7 @@ class TestConfigResolver:
             selected_config = local_config_names[1]
             prompter.choice.return_value = selected_config
 
-            resolver = _arg_resolvers.ConfigResolver(
+            resolver = _arg_resolvers.WFConfigResolver(
                 wf_run_repo=wf_run_repo,
                 config_repo=config_repo,
                 prompter=prompter,
@@ -130,7 +189,7 @@ class TestConfigResolver:
             selected_config = local_config_names[1]
             prompter.choice.return_value = selected_config
 
-            resolver = _arg_resolvers.ConfigResolver(
+            resolver = _arg_resolvers.WFConfigResolver(
                 wf_run_repo=Mock(),
                 config_repo=config_repo,
                 prompter=prompter,

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -261,7 +261,7 @@ class TestWorkflowRunRepo:
 
 
 class TestConfigRepo:
-    class TestUnitConfigRepo:
+    class TestUnit:
         """
         Test boundary::
             [ConfigRepo]->sdk._config

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -21,8 +21,8 @@ from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._qe._client import QEClient
 from orquestra.sdk._base._testing import _example_wfs
 from orquestra.sdk._base.cli._dorq import _repos
-from orquestra.sdk.schema.configs import RuntimeName
 from orquestra.sdk._ray import _dag
+from orquestra.sdk.schema.configs import RuntimeName
 
 from ... import reloaders
 from ...sdk.v2.data.configs import TEST_CONFIG_JSON
@@ -267,6 +267,7 @@ class TestConfigRepo:
             [ConfigRepo]->sdk._config
 
         """
+
         def test_list_config(self, monkeypatch):
             """
             Simple test that verifies that repo return all the configs returned by
@@ -302,16 +303,24 @@ class TestConfigRepo:
                 runtime_parameter = runtime
                 options_parameter = options
 
-            monkeypatch.setattr(sdk._base._config, "generate_config_name", lambda n, m: generated_name)
+            monkeypatch.setattr(
+                sdk._base._config, "generate_config_name", lambda n, m: generated_name
+            )
 
-            monkeypatch.setattr(sdk._base._config, "save_or_update", validate_save_parameters)
+            monkeypatch.setattr(
+                sdk._base._config, "save_or_update", validate_save_parameters
+            )
 
             # When
             config_name = repo.store_token_in_config(uri, token, ce)
 
             # Then
             assert config_parameter == generated_name
-            assert runtime_parameter == RuntimeName.CE_REMOTE if ce else RuntimeName.QE_REMOTE
+            assert (
+                runtime_parameter == RuntimeName.CE_REMOTE
+                if ce
+                else RuntimeName.QE_REMOTE
+            )
             assert options_parameter["uri"] == uri
             assert options_parameter["token"] == token
             assert config_name == generated_name
@@ -327,6 +336,7 @@ class TestConfigRepo:
 
         Mocks config file location.
         """
+
         @staticmethod
         @pytest.fixture
         def config_content():

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -292,29 +292,27 @@ class TestConfigRepo:
             token = "even_funnier_token"
             generated_name = "why_is_it_so_funny"
 
-            config_parameter = ""
-            runtime_parameter = ""
-            options_parameter = {}
-
             # Check parameters passed to _Config
-            def validate_save_parameters(config, runtime, options):
-                nonlocal config_parameter, runtime_parameter, options_parameter
-                config_parameter = config
-                runtime_parameter = runtime
-                options_parameter = options
+            mock_save_or_update = Mock()
 
             monkeypatch.setattr(
                 sdk._base._config, "generate_config_name", lambda n, m: generated_name
             )
 
             monkeypatch.setattr(
-                sdk._base._config, "save_or_update", validate_save_parameters
+                sdk._base._config, "save_or_update", mock_save_or_update
             )
 
             # When
             config_name = repo.store_token_in_config(uri, token, ce)
 
             # Then
+            (
+                config_parameter,
+                runtime_parameter,
+                options_parameter,
+            ) = mock_save_or_update.call_args[0]
+
             assert config_parameter == generated_name
             assert (
                 runtime_parameter == RuntimeName.CE_REMOTE

--- a/tests/sdk/v2/test_api.py
+++ b/tests/sdk/v2/test_api.py
@@ -1324,7 +1324,7 @@ class TestRuntimeConfiguration:
 
             assert config_names == [
                 name for name in TEST_CONFIG_JSON["configs"]
-            ] + list(_config.SPECIAL_CONFIG_NAME_DICT.keys())
+            ] + list(_config.UNIQUE_CONFIGS)
 
         @staticmethod
         def test_custom_file_location(tmp_config_json):
@@ -1333,7 +1333,7 @@ class TestRuntimeConfiguration:
 
             assert config_names == [
                 name for name in TEST_CONFIG_JSON["configs"]
-            ] + list(_config.SPECIAL_CONFIG_NAME_DICT.keys())
+            ] + list(_config.UNIQUE_CONFIGS)
 
         @staticmethod
         def test_empty_configs_key(patch_config_location):
@@ -1342,7 +1342,7 @@ class TestRuntimeConfiguration:
 
             config_names = _api.RuntimeConfig.list_configs()
 
-            assert config_names == list(_config.SPECIAL_CONFIG_NAME_DICT.keys())
+            assert config_names == list(_config.UNIQUE_CONFIGS)
 
         @staticmethod
         def test_no_configs_key(patch_config_location):
@@ -1351,7 +1351,7 @@ class TestRuntimeConfiguration:
 
             config_names = _api.RuntimeConfig.list_configs()
 
-            assert config_names == list(_config.SPECIAL_CONFIG_NAME_DICT.keys())
+            assert config_names == list(_config.UNIQUE_CONFIGS)
 
     class TestLoad:
         @pytest.mark.parametrize(


### PR DESCRIPTION
# The problem

New DORQ commands are prompt-based when the user doesnt pass the value. Configs had to be passed explicitly for now in orq submit command

# This PR's solution

Prompt user for configs in dorq submit
Also remove duplicate configs from listings (ray and local - they were only aliases on each other)
Remove warning of naming in process config when submitting wf in-process

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
