### PR TITLE
fix: Disable Ray logging via runtime config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 🐛 *Bug Fixes*
 * Fixed broken link on docs landing page.
+* Internal logs from Ray are no longer displayed.
 
 
 *Internal*

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -993,6 +993,7 @@ class RuntimeConfig:
             )
         config = RuntimeConfig("RAY_LOCAL", "local", True)
         setattr(config, "log_to_driver", False)
+        setattr(config, "configure_logging", False)
 
         # The paths for 'storage' and 'temp_dir' should have been passed when starting
         # the cluster, not here. Let's keep these attributes on our config object anyway

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -41,6 +41,7 @@ LOCAL_RUNTIME_CONFIGURATION = RuntimeConfiguration(
         "log_to_driver": False,
         "storage": None,
         "temp_dir": None,
+        "configure_logging": False,
     },
 )
 IN_PROCESS_RUNTIME_CONFIGURATION = RuntimeConfiguration(
@@ -66,6 +67,7 @@ RAY_RUNTIME_OPTIONS: List[str] = [
     "log_to_driver",
     "storage",
     "temp_dir",
+    "configure_logging",
 ]
 QE_RUNTIME_OPTIONS: List[str] = [
     "uri",
@@ -84,7 +86,7 @@ RUNTIME_OPTION_NAMES: List[str] = list(
         + CE_RUNTIME_OPTIONS
     )
 )
-BOOLEAN_RUNTIME_OPTIONS: List[str] = ["log_to_driver"]
+BOOLEAN_RUNTIME_OPTIONS: List[str] = ["log_to_driver", "configure_logging"]
 # endregion
 
 

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -61,6 +61,7 @@ else:
             log_to_driver: bool,
             storage: t.Union[None, str, Storage],
             _temp_dir: t.Optional[str],
+            configure_logging: bool,
         ):
             ray.init(
                 address=address,
@@ -68,6 +69,7 @@ else:
                 storage=storage,
                 _temp_dir=_temp_dir,
                 ignore_reinit_error=True,
+                configure_logging=configure_logging,
             )
 
         def shutdown(self):

--- a/tests/runtime/corq/test_cli_with_ray.py
+++ b/tests/runtime/corq/test_cli_with_ray.py
@@ -760,6 +760,7 @@ class TestCLIWithRay:
                     runtime_options={
                         "address": "auto",
                         "log_to_driver": False,
+                        "configure_logging": False,
                         "storage": None,
                         "temp_dir": None,
                     },
@@ -945,6 +946,7 @@ class TestCLIAgainstRuntimeMock:
                         runtime_options={
                             "address": "shouldnt-matter",
                             "log_to_driver": True,
+                            "configure_logging": False,
                             "storage": "shouldnt-matter",
                             "_temp_dir": "shouldnt-matter",
                         },
@@ -1064,6 +1066,7 @@ class TestCLIWithRayFailures:
                 runtime_options={
                     "address": LOCAL_RAY_ADDRESS,
                     "log_to_driver": False,
+                    "configure_logging": False,
                     "storage": None,
                     "temp_dir": None,
                 },

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -65,6 +65,39 @@ def _count_task_runs(wf_run, state: State) -> int:
 
 
 @pytest.mark.slow
+class TestRayLogger:
+    def test_ray_logs_silenced(self, capsys: pytest.CaptureFixture):
+        # Given
+        params = _dag.RayParams(configure_logging=False)
+        # Ensure Ray is down
+        _dag.RayRuntime.shutdown()
+
+        # When
+        _ = _dag.RayRuntime.startup(params)
+        # Then
+        capture = capsys.readouterr()
+        # Seen when conencting to an existing cluster
+        assert "Connecting to existing Ray cluster at address" not in capture.err
+        # Seen when the Ray workflows is starting for the first time
+        assert "Initializing workflow manager" not in capture.err
+
+    def test_ray_logs_not_silenced(self, capsys: pytest.CaptureFixture):
+        # Given
+        params = _dag.RayParams(configure_logging=True)
+        # Ensure Ray is down
+        _dag.RayRuntime.shutdown()
+
+        # When
+        _ = _dag.RayRuntime.startup(params)
+        # Then
+        capture = capsys.readouterr()
+        # Seen when conencting to an existing cluster
+        assert "Connecting to existing Ray cluster at address" in capture.err
+        # Seen when the Ray workflows is starting for the first time
+        assert "Initializing workflow manager" in capture.err
+
+
+@pytest.mark.slow
 class TestRayRuntimeMethods:
     """
     Tests that call RayRuntime methods with a real Ray connection and

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -65,39 +65,6 @@ def _count_task_runs(wf_run, state: State) -> int:
 
 
 @pytest.mark.slow
-class TestRayLogger:
-    def test_ray_logs_silenced(self, capsys: pytest.CaptureFixture):
-        # Given
-        params = _dag.RayParams(configure_logging=False)
-        # Ensure Ray is down
-        _dag.RayRuntime.shutdown()
-
-        # When
-        _ = _dag.RayRuntime.startup(params)
-        # Then
-        capture = capsys.readouterr()
-        # Seen when conencting to an existing cluster
-        assert "Connecting to existing Ray cluster at address" not in capture.err
-        # Seen when the Ray workflows is starting for the first time
-        assert "Initializing workflow manager" not in capture.err
-
-    def test_ray_logs_not_silenced(self, capsys: pytest.CaptureFixture):
-        # Given
-        params = _dag.RayParams(configure_logging=True)
-        # Ensure Ray is down
-        _dag.RayRuntime.shutdown()
-
-        # When
-        _ = _dag.RayRuntime.startup(params)
-        # Then
-        capture = capsys.readouterr()
-        # Seen when conencting to an existing cluster
-        assert "Connecting to existing Ray cluster at address" in capture.err
-        # Seen when the Ray workflows is starting for the first time
-        assert "Initializing workflow manager" in capture.err
-
-
-@pytest.mark.slow
 class TestRayRuntimeMethods:
     """
     Tests that call RayRuntime methods with a real Ray connection and

--- a/tests/runtime/ray/test_logger.py
+++ b/tests/runtime/ray/test_logger.py
@@ -1,0 +1,36 @@
+import pytest
+
+from orquestra.sdk._ray import _dag
+
+
+@pytest.mark.slow
+class TestRayLogger:
+    def test_ray_logs_silenced(self, capsys: pytest.CaptureFixture):
+        # Given
+        params = _dag.RayParams(configure_logging=False)
+        # Ensure Ray is down
+        _dag.RayRuntime.shutdown()
+
+        # When
+        _ = _dag.RayRuntime.startup(params)
+        # Then
+        capture = capsys.readouterr()
+        # Seen when connecting to an existing cluster
+        assert "Connecting to existing Ray cluster at address" not in capture.err
+        # Seen when the Ray workflows is starting for the first time
+        assert "Initializing workflow manager" not in capture.err
+
+    def test_ray_logs_not_silenced(self, capsys: pytest.CaptureFixture):
+        # Given
+        params = _dag.RayParams(configure_logging=True)
+        # Ensure Ray is down
+        _dag.RayRuntime.shutdown()
+
+        # When
+        _ = _dag.RayRuntime.startup(params)
+        # Then
+        capture = capsys.readouterr()
+        # Seen when connecting to an existing cluster
+        assert "Started a local Ray instance" in capture.err
+        # Seen when the Ray workflows is starting for the first time
+        assert "Initializing workflow manager" in capture.err


### PR DESCRIPTION
# The problem

Ray can sometimes print out a log of unrelated messaged when we use it.
This is confusing for users in Jupyter notebooks because these messages end up in red boxes because it is printed to std err.

# This PR's solution

Switches Ray's logger to log level ERROR and disables Ray's configuration of its logger, with the option to leave it configured.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
