### PR TITLE
ci: Print stats on covered files modifed in diff

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,6 +29,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Fetch depth 0 required to compare against `main`
+          fetch-depth: 0
 
       # Load a specific version of Python
       - name: Setup python
@@ -48,6 +51,6 @@ jobs:
       - name: Comment with code coverage
         uses: zapatacomputing/command-pr-comment@baca4fb9246eaaee3e47f35f296764acc394fae7
         with:
-          command: make show-coverage-text-report
-          template: "🚀 Code Coverage\n```\n%command%```"
+          command: make github-actions-coverage-report
+          template: "🚀 Code Coverage\n```%command%```"
           update-text: "🚀 Code Coverage"

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,11 @@ coverage:
 show-coverage-text-report:
 	$(PYTHON) -m coverage report --show-missing
 
+BASE_BRANCH := $(if $(GITHUB_BASE_REF),$(GITHUB_BASE_REF),main)
+github-actions-coverage-report:
+	@$(PYTHON) -m coverage report --show-missing
+	@$(PYTHON) -m diff_cover.diff_cover_tool coverage.xml --compare-branch=origin/$(BASE_BRANCH)
+
 # We need to set PATH here because performance test calls the `orq` CLI in a subprocess.
 performance:
 	PATH="${VENV_NAME}/bin:${PATH}" $(PYTHON) -m pytest --durations=0 tests/runtime/performance

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,3 +88,4 @@ dev =
     types-tabulate
     types-Pygments
     types-psutil
+    diff_cover


### PR DESCRIPTION
# The problem

Checking coverage is becoming more difficult as the repo gets larger.

# This PR's solution

Adds a section to the PR command that looks at the diff against the base branch and posts a diff using [`diff-cover`](https://pypi.org/project/diff-cover/).

Moved from #8 to workaround CI issues. Original author: @jamesclark-Zapata.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
