### PR TITLE
fix: stop tests writing to workflows.db

### DIFF
--- a/tests/runtime/ray/conftest.py
+++ b/tests/runtime/ray/conftest.py
@@ -1,0 +1,23 @@
+################################################################################
+# © Copyright 2022 Zapata Computing Inc.
+################################################################################
+import os
+
+import pytest
+
+from orquestra.sdk._base._testing import _connections
+
+
+@pytest.fixture(scope="module")
+def change_test_dir(tmp_path_factory, request):
+    project_dir = tmp_path_factory.mktemp("project")
+    os.chdir(project_dir)
+    yield project_dir
+    os.chdir(request.config.invocation_dir)
+
+
+@pytest.fixture(scope="module")
+def change_db_location(change_test_dir):
+    os.environ["ORQ_DB_LOCATION"] = os.path.join(change_test_dir, "db.db")
+    yield
+    del os.environ["ORQ_DB_LOCATION"]

--- a/tests/runtime/ray/conftest.py
+++ b/tests/runtime/ray/conftest.py
@@ -17,6 +17,12 @@ def change_test_dir(tmp_path_factory, request):
 
 
 @pytest.fixture(scope="module")
+def shared_ray_conn():
+    with _connections.make_ray_conn() as ray_params:
+        yield ray_params
+
+
+@pytest.fixture(scope="module")
 def change_db_location(change_test_dir):
     os.environ["ORQ_DB_LOCATION"] = os.path.join(change_test_dir, "db.db")
     yield

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -21,12 +21,6 @@ from orquestra.sdk.schema.workflow_run import State
 
 
 @pytest.fixture(scope="module")
-def shared_ray_conn():
-    with make_ray_conn() as ray_params:
-        yield ray_params
-
-
-@pytest.fixture(scope="module")
 def runtime(
     shared_ray_conn, tmp_path_factory: pytest.TempPathFactory, change_db_location
 ):

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -27,7 +27,9 @@ def shared_ray_conn():
 
 
 @pytest.fixture(scope="module")
-def runtime(shared_ray_conn, tmp_path_factory: pytest.TempPathFactory):
+def runtime(
+    shared_ray_conn, tmp_path_factory: pytest.TempPathFactory, change_db_location
+):
     project_dir = tmp_path_factory.mktemp("ray-integration")
     config = configs.RuntimeConfiguration(
         config_name="test-config",


### PR DESCRIPTION
# The problem

Running integration tests writes ~40 new entries to workflows.db

# This PR's solution

Mocks the .orquestra location for the integration tests.

# Checklist

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
