### PR TITLE
chore: update arg resolvers and prompters

### DIFF
--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -11,7 +11,7 @@ import typing as t
 import orquestra.sdk._base._services as _services
 from orquestra.sdk import exceptions
 from orquestra.sdk.schema.configs import ConfigName
-from orquestra.sdk.schema.workflow_run import State, WorkflowRunId
+from orquestra.sdk.schema.workflow_run import State, WorkflowRun, WorkflowRunId
 
 from . import _repos
 from ._ui import _prompts
@@ -96,7 +96,7 @@ class WFConfigResolver:
         return ConfigResolver(self._config_repo, self._prompter).resolve(config)
 
 
-class WFRunIDResolver:
+class WFRunResolver:
     """
     Resolves value of `wf_run_id` based on `config`.
     """
@@ -109,7 +109,7 @@ class WFRunIDResolver:
         self._wf_run_repo = wf_run_repo
         self._prompter = prompter
 
-    def resolve(
+    def resolve_id(
         self, wf_run_id: t.Optional[WorkflowRunId], config: ConfigName
     ) -> WorkflowRunId:
         if wf_run_id is not None:
@@ -122,6 +122,22 @@ class WFRunIDResolver:
         ids = self._wf_run_repo.list_wf_run_ids(config)
         selected_id = self._prompter.choice(ids, message="Workflow run ID")
         return selected_id
+
+    def resolve_run(
+        self, wf_run_id: t.Optional[WorkflowRunId], config: ConfigName
+    ) -> WorkflowRun:
+        if wf_run_id is not None:
+            return self._wf_run_repo.get_wf_by_run_id(wf_run_id, config)
+
+        # Query the runtime for suitable workflow run IDs.
+        # TODO: figure out sensible filters when listing workflow runs is implemented
+        # in the public API.
+        # Related ticket: https://zapatacomputing.atlassian.net/browse/ORQSDK-671
+        runs = self._wf_run_repo.list_wf_runs(config)
+        selected_run = self._prompter.choice(
+            [(run.id, run) for run in runs], message="Workflow run ID"
+        )
+        return selected_run
 
 
 class ServiceResolver:

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -91,3 +91,8 @@ def _(e: ConnectionError) -> ResponseStatusCode:
     _print_traceback(e)
     click.echo("Unable to connect to Ray.")
     return ResponseStatusCode.CONNECTION_ERROR
+
+
+@pretty_print_exception.register
+def _(e: exceptions.UserCancelledPrompt) -> ResponseStatusCode:
+    return ResponseStatusCode.USER_CANCELLED

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
@@ -3,6 +3,7 @@
 ################################################################################
 
 import typing as t
+from typing import overload
 
 import inquirer  # type: ignore
 
@@ -23,7 +24,7 @@ class Prompter:
     isn't covered by tests.
     """
 
-    @t.overload
+    @overload
     def choice(
         self,
         choices: t.Sequence[ChoiceID],
@@ -32,7 +33,7 @@ class Prompter:
     ) -> ChoiceID:
         ...
 
-    @t.overload
+    @overload
     def choice(
         self,
         choices: t.Sequence[t.Tuple[ChoiceID, T]],

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
@@ -7,6 +7,8 @@ from typing import overload
 
 import inquirer  # type: ignore
 
+from orquestra.sdk import exceptions
+
 SINGLE_INPUT = "single_input"
 
 
@@ -48,6 +50,25 @@ class Prompter:
         message: str,
         default: t.Optional[str] = None,
     ) -> t.Union[ChoiceID, T]:
+        """
+        Presents the user a choice and returns what they selected
+
+        Args:
+            choices: The list of choices to present to the user. If this is of the shape
+                ``(label, value)`` then the ``label`` is shown to the user, but
+                ``value`` is what is returned.
+            message: The message to prompt the user.
+            default: The value to return as the default, if the user doesn't choose
+                anything.
+
+        Returns:
+            The item the user chose, either a ChoiceID or an object if ``choices`` was
+            a tuple.
+
+        Raises:
+            UserCancelledPrompt if the user cancels the prompt
+        """
+
         question = inquirer.List(
             SINGLE_INPUT,
             message=message,
@@ -57,20 +78,80 @@ class Prompter:
         )
         answers = inquirer.prompt([question])
 
-        # Workaround bad typing inside inquirer.
-        assert answers is not None
+        # If the user cancels the prompt, via ctrl-c, answers will be `None`.
+        if answers is None:
+            raise exceptions.UserCancelledPrompt(f"User cancelled {message} prompt")
 
         return answers[SINGLE_INPUT]
 
     def confirm(self, message: str, default: bool) -> bool:
-        return inquirer.confirm(message, default=default)
+        """
+        Ask the user for confirmation
 
+        Args:
+            message: The message to prompt the user.
+            default: The value to return as the default.
+
+        Returns:
+            The result from the prompt
+
+        Raises:
+            UserCancelledPrompt if the user cancels the prompt
+        """
+        answer = inquirer.confirm(message, default=default)
+
+        # If the user cancels the prompt, via ctrl-c, answers will be `None`.
+        if answer is None:
+            raise exceptions.UserCancelledPrompt(f"User cancelled {message} prompt")
+
+        # Fixing typing issues from inquirer
+        assert isinstance(answer, bool)
+
+        return answer
+
+    @overload
     def checkbox(
         self,
         choices: t.Sequence[ChoiceID],
         message: str,
         default: t.Optional[t.Union[str, t.List[str]]] = None,
     ) -> t.List[ChoiceID]:
+        ...
+
+    @overload
+    def checkbox(
+        self,
+        choices: t.Sequence[t.Tuple[ChoiceID, T]],
+        message: str,
+        default: t.Optional[t.Union[str, t.List[str]]] = None,
+    ) -> t.List[T]:
+        ...
+
+    def checkbox(
+        self,
+        choices: t.Sequence[t.Union[ChoiceID, t.Tuple[ChoiceID, T]]],
+        message: str,
+        default: t.Optional[t.Union[str, t.List[str]]] = None,
+    ) -> t.Union[t.List[ChoiceID], t.List[T]]:
+        """
+        Presents the user a multiple choice and returns what they selected
+
+        Args:
+            choices: The list of choices to present to the user. If this is of the shape
+                ``(label, value)`` then the ``label`` is shown to the user, but
+                ``value`` is what is returned.
+            message: The message to prompt the user.
+            default: The value to return as the default, if the user doesn't choose
+                anything.
+
+        Returns:
+            The list of items the user chose, either ChoiceIDs or objects if
+            ``choices`` was a tuple.
+
+        Raises:
+            UserCancelledPrompt if the user cancels the prompt
+        """
+
         question = inquirer.Checkbox(
             SINGLE_INPUT,
             message=message
@@ -81,12 +162,30 @@ class Prompter:
         )
         answers = inquirer.prompt([question])
 
-        # Workaround bad typing inside inquirer.
-        assert answers is not None
+        # If the user cancels the prompt, via ctrl-c, answers will be `None`.
+        if answers is None:
+            raise exceptions.UserCancelledPrompt(f"User cancelled {message} prompt")
 
         return answers[SINGLE_INPUT]
 
     def ask_for_int(self, message: str, default: t.Optional[int]):
+        """
+        Asks the user to enter an integer
+
+        If the user's input is not an integer, the prompt will ask again
+
+        Args:
+            message: The message to prompt the user.
+            default: The value to return as the default, if the user doesn't choose
+                anything.
+
+        Returns:
+            an integer parsed from the user's input
+
+        Raises:
+            UserCancelledPrompt if the user cancels the prompt
+        """
+
         def validate(_, current):
             try:
                 int(current)
@@ -99,5 +198,11 @@ class Prompter:
         question = inquirer.Text(
             name=SINGLE_INPUT, message=message, default=default, validate=validate
         )
+
         answers = inquirer.prompt([question])
+
+        # If the user cancels the prompt, via ctrl-c, answers will be `None`.
+        if answers is None:
+            raise exceptions.UserCancelledPrompt(f"User cancelled {message} prompt")
+
         return int(answers[SINGLE_INPUT])

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
@@ -10,6 +10,7 @@ SINGLE_INPUT = "single_input"
 
 
 ChoiceID = str
+T = t.TypeVar("T")
 
 
 class Prompter:
@@ -22,12 +23,30 @@ class Prompter:
     isn't covered by tests.
     """
 
+    @t.overload
     def choice(
         self,
         choices: t.Sequence[ChoiceID],
         message: str,
         default: t.Optional[str] = None,
     ) -> ChoiceID:
+        ...
+
+    @t.overload
+    def choice(
+        self,
+        choices: t.Sequence[t.Tuple[ChoiceID, T]],
+        message: str,
+        default: t.Optional[str] = None,
+    ) -> T:
+        ...
+
+    def choice(
+        self,
+        choices: t.Sequence[t.Union[ChoiceID, t.Tuple[ChoiceID, T]]],
+        message: str,
+        default: t.Optional[str] = None,
+    ) -> t.Union[ChoiceID, T]:
         question = inquirer.List(
             SINGLE_INPUT,
             message=message,

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_list.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_list.py
@@ -51,6 +51,27 @@ class Action:
         show_all: t.Optional[bool] = False,
         interactive: t.Optional[bool] = False,
     ):
+        try:
+            self._on_cmd_call_with_exceptions(
+                config=config,
+                limit=limit,
+                max_age=max_age,
+                state=state,
+                show_all=show_all,
+                interactive=interactive,
+            )
+        except Exception as e:
+            self._presenter.show_error(e)
+
+    def _on_cmd_call_with_exceptions(
+        self,
+        config: t.Optional[t.Sequence[str]],
+        limit: t.Optional[int],
+        max_age: t.Optional[str],
+        state: t.Optional[t.List[str]],
+        show_all: t.Optional[bool] = False,
+        interactive: t.Optional[bool] = False,
+    ):
         # This should be handled by the mutually exclusive constraint in the entry, but
         # we'll keep this here to be safe.
         assert not (show_all and interactive)

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_results.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_results.py
@@ -25,7 +25,7 @@ class Action:
         dumper=_dumpers.ArtifactDumper(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
-        wf_run_id_resolver: t.Optional[_arg_resolvers.WFRunIDResolver] = None,
+        wf_run_resolver: t.Optional[_arg_resolvers.WFRunResolver] = None,
     ):
         # data sources
         self._wf_run_repo = wf_run_repo
@@ -34,7 +34,7 @@ class Action:
         self._config_resolver = config_resolver or _arg_resolvers.WFConfigResolver(
             wf_run_repo=wf_run_repo
         )
-        self._wf_run_id_resolver = wf_run_id_resolver or _arg_resolvers.WFRunIDResolver(
+        self._wf_run_resolver = wf_run_resolver or _arg_resolvers.WFRunResolver(
             wf_run_repo=wf_run_repo
         )
 
@@ -66,7 +66,7 @@ class Action:
         # The order of resolving config and run ID is important. It dictactes the flow
         # user sees, and possible choices in the prompts.
         resolved_config = self._config_resolver.resolve(wf_run_id, config)
-        resolved_wf_run_id = self._wf_run_id_resolver.resolve(
+        resolved_wf_run_id = self._wf_run_resolver.resolve_id(
             wf_run_id, resolved_config
         )
         output_values = self._wf_run_repo.get_wf_outputs(

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_stop.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_stop.py
@@ -27,7 +27,7 @@ class Action:
         presenter=_presenters.WrappedCorqOutputPresenter(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
-        wf_run_id_resolver: t.Optional[_arg_resolvers.WFRunIDResolver] = None,
+        wf_run_resolver: t.Optional[_arg_resolvers.WFRunResolver] = None,
     ):
         # data sources
         self._wf_run_repo = wf_run_repo
@@ -36,7 +36,7 @@ class Action:
         self._config_resolver = config_resolver or _arg_resolvers.WFConfigResolver(
             wf_run_repo=wf_run_repo
         )
-        self._wf_run_id_resolver = wf_run_id_resolver or _arg_resolvers.WFRunIDResolver(
+        self._wf_run_resolver = wf_run_resolver or _arg_resolvers.WFRunResolver(
             wf_run_repo=wf_run_repo
         )
 
@@ -57,10 +57,10 @@ class Action:
         """
         Implementation of the command action. Doesn't catch exceptions.
         """
-        # The order of resolving config and run ID is important. It dictactes the flow
+        # The order of resolving config and run ID is important. It dictates the flow
         # user sees, and possible choices in the prompts.
         resolved_config = self._config_resolver.resolve(wf_run_id, config)
-        resolved_id = self._wf_run_id_resolver.resolve(wf_run_id, resolved_config)
+        resolved_id = self._wf_run_resolver.resolve_id(wf_run_id, resolved_config)
 
         try:
             self._wf_run_repo.stop(resolved_id, resolved_config)

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_view.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_view.py
@@ -28,7 +28,7 @@ class Action:
         presenter=_presenters.WrappedCorqOutputPresenter(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
-        wf_run_id_resolver: t.Optional[_arg_resolvers.WFRunIDResolver] = None,
+        wf_run_resolver: t.Optional[_arg_resolvers.WFRunResolver] = None,
     ):
         # data sources
         self._wf_run_repo = wf_run_repo
@@ -37,7 +37,7 @@ class Action:
         self._config_resolver = config_resolver or _arg_resolvers.WFConfigResolver(
             wf_run_repo=wf_run_repo
         )
-        self._wf_run_id_resolver = wf_run_id_resolver or _arg_resolvers.WFRunIDResolver(
+        self._wf_run_resolver = wf_run_resolver or _arg_resolvers.WFRunResolver(
             wf_run_repo=wf_run_repo
         )
 
@@ -50,10 +50,5 @@ class Action:
         # The order of resolving config and run ID is important. It dictactes the flow
         # user sees, and possible choices in the prompts.
         resolved_config = self._config_resolver.resolve(wf_run_id, config)
-        resolved_id = self._wf_run_id_resolver.resolve(wf_run_id, resolved_config)
-
-        wf_run = self._wf_run_repo.get_wf_by_run_id(
-            wf_run_id=resolved_id, config_name=resolved_config
-        )
-
-        self._presenter.show_wf_run(wf_run)
+        resolved_run = self._wf_run_resolver.resolve_run(wf_run_id, resolved_config)
+        self._presenter.show_wf_run(resolved_run)

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_view.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_view.py
@@ -47,6 +47,14 @@ class Action:
     def on_cmd_call(
         self, wf_run_id: t.Optional[WorkflowRunId], config: t.Optional[ConfigName]
     ):
+        try:
+            self._on_cmd_call_with_exceptions(wf_run_id=wf_run_id, config=config)
+        except Exception as e:
+            self._presenter.show_error(e)
+
+    def _on_cmd_call_with_exceptions(
+        self, wf_run_id: t.Optional[WorkflowRunId], config: t.Optional[ConfigName]
+    ):
         # The order of resolving config and run ID is important. It dictactes the flow
         # user sees, and possible choices in the prompts.
         resolved_config = self._config_resolver.resolve(wf_run_id, config)

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -157,3 +157,8 @@ class RayActorNameClashError(BaseRuntimeError):
 class ParseError(RuntimeError):
     def __init__(self, message):
         super(ParseError, self).__init__(message)
+
+
+# CLI Exceptions
+class UserCancelledPrompt(BaseRuntimeError):
+    pass

--- a/src/orquestra/sdk/schema/responses.py
+++ b/src/orquestra/sdk/schema/responses.py
@@ -49,6 +49,7 @@ class ResponseStatusCode(enum.Enum):
     UNAUTHORIZED = 12
     SERVICES_ERROR = 13
     INVALID_CLI_COMMAND_ERROR = 14
+    USER_CANCELLED = 15
 
 
 class ResponseMetadata(BaseModel):

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -366,7 +366,8 @@ class TestWFRunResolver:
             # We should pass config value to wf_run_repo.
             wf_run_repo.list_wf_run_ids.assert_called_with(config)
 
-            # We should prompt for selecting workflow ID from the ones returned by the repo.
+            # We should prompt for selecting workflow ID from the ones returned
+            # by the repo.
             prompter.choice.assert_called_with(
                 listed_run_ids, message="Workflow run ID"
             )
@@ -428,7 +429,8 @@ class TestWFRunResolver:
             # We should pass config value to wf_run_repo.
             wf_run_repo.list_wf_runs.assert_called_with(config)
 
-            # We should prompt for selecting workflow ID from the ones returned by the repo.
+            # We should prompt for selecting workflow run from the IDs returned
+            # by the repo.
             prompter.choice.assert_called_with(
                 [(run.id, run) for run in listed_runs], message="Workflow run ID"
             )

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -315,6 +315,7 @@ class TestWFRunResolver:
 
     ``config`` is assumed to be resolved to a valid value at this point.
     """
+
     class TestResolveID:
         @staticmethod
         def test_passing_id_directly():
@@ -366,7 +367,9 @@ class TestWFRunResolver:
             wf_run_repo.list_wf_run_ids.assert_called_with(config)
 
             # We should prompt for selecting workflow ID from the ones returned by the repo.
-            prompter.choice.assert_called_with(listed_run_ids, message="Workflow run ID")
+            prompter.choice.assert_called_with(
+                listed_run_ids, message="Workflow run ID"
+            )
 
             # Resolver should return the user's choice.
             assert resolved_id == selected_id
@@ -426,7 +429,9 @@ class TestWFRunResolver:
             wf_run_repo.list_wf_runs.assert_called_with(config)
 
             # We should prompt for selecting workflow ID from the ones returned by the repo.
-            prompter.choice.assert_called_with([(run.id, run) for run in listed_runs], message="Workflow run ID")
+            prompter.choice.assert_called_with(
+                [(run.id, run) for run in listed_runs], message="Workflow run ID"
+            )
 
             # Resolver should return the user's choice.
             assert resolved_run == selected_run

--- a/tests/cli/dorq/workflow/test_results.py
+++ b/tests/cli/dorq/workflow/test_results.py
@@ -48,15 +48,15 @@ class TestAction:
             config_resolver = Mock()
             config_resolver.resolve.return_value = resolved_config
 
-            wf_run_id_resolver = Mock()
-            wf_run_id_resolver.resolve.return_value = resolved_id
+            wf_run_resolver = Mock()
+            wf_run_resolver.resolve_id.return_value = resolved_id
 
             action = _results.Action(
                 presenter=presenter,
                 dumper=dumper,
                 wf_run_repo=wf_run_repo,
                 config_resolver=config_resolver,
-                wf_run_id_resolver=wf_run_id_resolver,
+                wf_run_resolver=wf_run_resolver,
             )
 
             # When
@@ -69,7 +69,7 @@ class TestAction:
             config_resolver.resolve.assert_called_with(wf_run_id, config)
 
             # We should pass resolved_config to run ID resolver.
-            wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
+            wf_run_resolver.resolve_id.assert_called_with(wf_run_id, resolved_config)
 
             # We should pass resolved values to run repo.
             wf_run_repo.get_wf_outputs.assert_called_with(
@@ -107,15 +107,15 @@ class TestAction:
             config_resolver = Mock()
             config_resolver.resolve.return_value = resolved_config
 
-            wf_run_id_resolver = Mock()
-            wf_run_id_resolver.resolve.return_value = resolved_id
+            wf_run_resolver = Mock()
+            wf_run_resolver.resolve_id.return_value = resolved_id
 
             action = _results.Action(
                 presenter=presenter,
                 dumper=dumper,
                 wf_run_repo=wf_run_repo,
                 config_resolver=config_resolver,
-                wf_run_id_resolver=wf_run_id_resolver,
+                wf_run_resolver=wf_run_resolver,
             )
 
             # When
@@ -128,7 +128,7 @@ class TestAction:
             config_resolver.resolve.assert_called_with(wf_run_id, config)
 
             # We should pass resolved_config to run ID resolver.
-            wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
+            wf_run_resolver.resolve_id.assert_called_with(wf_run_id, resolved_config)
 
             # We should pass resolved values to run repo.
             wf_run_repo.get_wf_outputs.assert_called_with(

--- a/tests/cli/dorq/workflow/test_stop.py
+++ b/tests/cli/dorq/workflow/test_stop.py
@@ -38,14 +38,14 @@ class TestAction:
         config_resolver = Mock()
         config_resolver.resolve.return_value = resolved_config
 
-        wf_run_id_resolver = Mock()
-        wf_run_id_resolver.resolve.return_value = resolved_id
+        wf_run_resolver = Mock()
+        wf_run_resolver.resolve_id.return_value = resolved_id
 
         action = _stop.Action(
             presenter=presenter,
             wf_run_repo=wf_run_repo,
             config_resolver=config_resolver,
-            wf_run_id_resolver=wf_run_id_resolver,
+            wf_run_resolver=wf_run_resolver,
         )
 
         # When
@@ -56,7 +56,7 @@ class TestAction:
         config_resolver.resolve.assert_called_with(wf_run_id, config)
 
         # We should pass resolved_config to run ID resolver.
-        wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
+        wf_run_resolver.resolve_id.assert_called_with(wf_run_id, resolved_config)
 
         # We should pass resolved values to run repo.
         wf_run_repo.stop.assert_called_with(resolved_id, resolved_config)
@@ -79,13 +79,13 @@ class TestAction:
 
         config_resolver = Mock()
 
-        wf_run_id_resolver = Mock()
+        wf_run_resolver = Mock()
 
         action = _stop.Action(
             presenter=presenter,
             wf_run_repo=wf_run_repo,
             config_resolver=config_resolver,
-            wf_run_id_resolver=wf_run_id_resolver,
+            wf_run_resolver=wf_run_resolver,
         )
 
         # When

--- a/tests/cli/dorq/workflow/test_view.py
+++ b/tests/cli/dorq/workflow/test_view.py
@@ -29,26 +29,24 @@ class TestAction:
         config = "<config sentinel>"
 
         # Resolved values
-        resolved_id = "<resolved ID>"
         resolved_config = "<resolved config>"
 
         # Mocks
         presenter = Mock()
         wf_run_repo = Mock()
         wf_run = "<wf run sentinel>"
-        wf_run_repo.get_wf_by_run_id.return_value = wf_run
 
         config_resolver = Mock()
         config_resolver.resolve.return_value = resolved_config
 
-        wf_run_id_resolver = Mock()
-        wf_run_id_resolver.resolve.return_value = resolved_id
+        wf_run_resolver = Mock()
+        wf_run_resolver.resolve_run.return_value = wf_run
 
         action = _view.Action(
             presenter=presenter,
             wf_run_repo=wf_run_repo,
             config_resolver=config_resolver,
-            wf_run_id_resolver=wf_run_id_resolver,
+            wf_run_resolver=wf_run_resolver,
         )
 
         # When
@@ -59,12 +57,7 @@ class TestAction:
         config_resolver.resolve.assert_called_with(wf_run_id, config)
 
         # We should pass resolved_config to run ID resolver.
-        wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
-
-        # We should pass resolved values to run repo.
-        wf_run_repo.get_wf_by_run_id.assert_called_with(
-            wf_run_id=resolved_id, config_name=resolved_config
-        )
+        wf_run_resolver.resolve_run.assert_called_with(wf_run_id, resolved_config)
 
         # We expect printing the workflow run returned from the repo.
         presenter.show_wf_run.assert_called_with(wf_run)


### PR DESCRIPTION
# The problem

In some cases, we need to list workflow runs in the CLI and then use the workflow run.

Previously, we listed the IDs (by getting the runs and then printing the IDs) and then calling the runtime to get the actual workflow run.

If a user cancelled a request in an arg resolver, we would get an ugly error message.

# This PR's solution

 - Adds a new resolver to either resolve an ID or a run
 - Adds an exception for when a user cancels the prompting in the arg resolvers.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
