### PR TITLE
chore: Get workflow def in workflow run methods in CE driver

### DIFF
--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -17,6 +17,7 @@ from orquestra.sdk.schema.workflow_run import (
     TaskRunId,
     WorkflowRun,
     WorkflowRunId,
+    WorkflowRunMinimal,
 )
 
 from . import _client, _exceptions, _models
@@ -276,7 +277,7 @@ class CERuntime(RuntimeInterface):
         limit: Optional[int] = None,
         max_age: Optional[timedelta] = None,
         state: Optional[Union[State, List[State]]] = None,
-    ) -> List[WorkflowRun]:
+    ) -> List[WorkflowRunMinimal]:
         """
         List the workflow runs, with some filters
 

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -17,7 +17,7 @@ from requests import codes
 
 from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.responses import WorkflowResult
-from orquestra.sdk.schema.workflow_run import WorkflowRun
+from orquestra.sdk.schema.workflow_run import WorkflowRun, WorkflowRunMinimal
 
 from . import _exceptions, _models
 
@@ -320,7 +320,7 @@ class DriverClient:
         workflow_def_id: Optional[_models.WorkflowDefID] = None,
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
-    ) -> Paginated[WorkflowRun]:
+    ) -> Paginated[WorkflowRunMinimal]:
         """
         List workflow runs with a specified workflow def ID from the workflow driver
 

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -350,8 +350,13 @@ class DriverClient:
             prev_token = None
             next_token = None
 
+        workflow_runs = []
+        for r in parsed_response.data:
+            workflow_def = self.get_workflow_def(r.definitionId)
+            workflow_runs.append(r.to_ir(workflow_def))
+
         return Paginated(
-            contents=[r.to_ir() for r in parsed_response.data],
+            contents=workflow_runs,
             prev_page_token=prev_token,
             next_page_token=next_token,
         )
@@ -383,7 +388,9 @@ class DriverClient:
             _models.WorkflowRunResponse, _models.MetaEmpty
         ].parse_obj(resp.json())
 
-        return parsed_response.data.to_ir()
+        workflow_def = self.get_workflow_def(parsed_response.data.definitionId)
+
+        return parsed_response.data.to_ir(workflow_def)
 
     def terminate_workflow_run(self, wf_run_id: _models.WorkflowRunID):
         """

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -168,7 +168,7 @@ class TaskRunResponse(pydantic.BaseModel):
         )
 
 
-class WorkflowRunResponse(pydantic.BaseModel):
+class MinimalWorkflowRunResponse(pydantic.BaseModel):
     """
     Implements:
         https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/schemas/WorkflowRun.yaml#L1
@@ -176,15 +176,32 @@ class WorkflowRunResponse(pydantic.BaseModel):
 
     id: WorkflowRunID
     status: RunStatusResponse
+    definitionId: WorkflowDefID
+
+    def to_ir(self, workflow_def: Optional[WorkflowDef] = None) -> WorkflowRun:
+        return WorkflowRun(
+            id=self.id,
+            status=self.status.to_ir(),
+            task_runs=[],
+            workflow_def=workflow_def,
+        )
+
+
+class WorkflowRunResponse(MinimalWorkflowRunResponse):
+    """
+    Implements:
+        https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/schemas/WorkflowRun.yaml#L1
+    """
+
     owner: str
     taskRuns: List[TaskRunResponse]
 
-    def to_ir(self) -> WorkflowRun:
+    def to_ir(self, workflow_def: Optional[WorkflowDef] = None) -> WorkflowRun:
         return WorkflowRun(
             id=self.id,
             status=self.status.to_ir(),
             task_runs=[t.to_ir() for t in self.taskRuns],
-            workflow_def=None,
+            workflow_def=workflow_def,
         )
 
 
@@ -227,7 +244,7 @@ class ListWorkflowRunsRequest(pydantic.BaseModel):
     pageToken: Optional[str]
 
 
-ListWorkflowRunsResponse = List[WorkflowRunResponse]
+ListWorkflowRunsResponse = List[MinimalWorkflowRunResponse]
 
 
 class GetWorkflowRunResponse(pydantic.BaseModel):

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -178,7 +178,7 @@ class MinimalWorkflowRunResponse(pydantic.BaseModel):
     status: RunStatusResponse
     definitionId: WorkflowDefID
 
-    def to_ir(self, workflow_def: Optional[WorkflowDef] = None) -> WorkflowRun:
+    def to_ir(self, workflow_def: WorkflowDef) -> WorkflowRun:
         return WorkflowRun(
             id=self.id,
             status=self.status.to_ir(),
@@ -196,7 +196,7 @@ class WorkflowRunResponse(MinimalWorkflowRunResponse):
     owner: str
     taskRuns: List[TaskRunResponse]
 
-    def to_ir(self, workflow_def: Optional[WorkflowDef] = None) -> WorkflowRun:
+    def to_ir(self, workflow_def: WorkflowDef) -> WorkflowRun:
         return WorkflowRun(
             id=self.id,
             status=self.status.to_ir(),

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -12,7 +12,13 @@ import pydantic
 from pydantic.generics import GenericModel
 
 from orquestra.sdk.schema.ir import WorkflowDef
-from orquestra.sdk.schema.workflow_run import RunStatus, State, TaskRun, WorkflowRun
+from orquestra.sdk.schema.workflow_run import (
+    RunStatus,
+    State,
+    TaskRun,
+    WorkflowRun,
+    WorkflowRunMinimal,
+)
 
 WorkflowDefID = str
 WorkflowRunID = str
@@ -175,14 +181,11 @@ class MinimalWorkflowRunResponse(pydantic.BaseModel):
     """
 
     id: WorkflowRunID
-    status: RunStatusResponse
     definitionId: WorkflowDefID
 
-    def to_ir(self, workflow_def: WorkflowDef) -> WorkflowRun:
-        return WorkflowRun(
+    def to_ir(self, workflow_def: WorkflowDef) -> WorkflowRunMinimal:
+        return WorkflowRunMinimal(
             id=self.id,
-            status=self.status.to_ir(),
-            task_runs=[],
             workflow_def=workflow_def,
         )
 
@@ -194,6 +197,7 @@ class WorkflowRunResponse(MinimalWorkflowRunResponse):
     """
 
     owner: str
+    status: RunStatusResponse
     taskRuns: List[TaskRunResponse]
 
     def to_ir(self, workflow_def: WorkflowDef) -> WorkflowRun:

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -23,6 +23,7 @@ from orquestra.sdk.schema.workflow_run import (
     TaskRunId,
     WorkflowRun,
     WorkflowRunId,
+    WorkflowRunMinimal,
 )
 
 
@@ -202,7 +203,7 @@ class RuntimeInterface(ABC):
         limit: t.Optional[int] = None,
         max_age: t.Optional[timedelta] = None,
         state: t.Optional[t.Union[State, t.List[State]]] = None,
-    ) -> t.List[WorkflowRun]:
+    ) -> t.Sequence[WorkflowRunMinimal]:
         """
         List the workflow runs, with some filters
 

--- a/src/orquestra/sdk/_base/cli/_corq/action/_stop_workflow_run.py
+++ b/src/orquestra/sdk/_base/cli/_corq/action/_stop_workflow_run.py
@@ -18,7 +18,7 @@ from orquestra.sdk.schema.responses import (
     ResponseStatusCode,
     StopWorkflowRunResponse,
 )
-from orquestra.sdk.schema.workflow_run import WorkflowRunMinimal
+from orquestra.sdk.schema.workflow_run import WorkflowRunOnlyID
 
 
 def orq_stop_workflow_run(
@@ -47,5 +47,5 @@ def orq_stop_workflow_run(
             code=ResponseStatusCode.OK,
             message="Successfully terminated workflow.",
         ),
-        workflow_runs=[WorkflowRunMinimal(id=run_id)],
+        workflow_runs=[WorkflowRunOnlyID(id=run_id)],
     )

--- a/src/orquestra/sdk/_base/cli/_corq/action/_submit_workflow_def.py
+++ b/src/orquestra/sdk/_base/cli/_corq/action/_submit_workflow_def.py
@@ -23,7 +23,7 @@ from orquestra.sdk.schema.responses import (
     ResponseStatusCode,
     SubmitWorkflowDefResponse,
 )
-from orquestra.sdk.schema.workflow_run import WorkflowRunMinimal
+from orquestra.sdk.schema.workflow_run import WorkflowRunOnlyID
 
 
 def submit(
@@ -95,7 +95,7 @@ def submit(
             code=ResponseStatusCode.OK,
             message="Successfully submitted workflow.",
         ),
-        workflow_runs=[WorkflowRunMinimal(id=workflow_run_id)],
+        workflow_runs=[WorkflowRunOnlyID(id=workflow_run_id)],
     )
 
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -22,7 +22,7 @@ from orquestra.sdk.schema.workflow_run import (
     TaskInvocationId,
     WorkflowRun,
     WorkflowRunId,
-    WorkflowRunMinimal,
+    WorkflowRunOnlyID,
 )
 
 from ..._corq._format import per_command
@@ -63,7 +63,7 @@ class WrappedCorqOutputPresenter:
                 code=responses.ResponseStatusCode.OK,
                 message="Success",
             ),
-            workflow_runs=[WorkflowRunMinimal(id=wf_run_id)],
+            workflow_runs=[WorkflowRunOnlyID(id=wf_run_id)],
         )
         per_command.pretty_print_response(resp, project_dir=None)
 

--- a/src/orquestra/sdk/schema/responses.py
+++ b/src/orquestra/sdk/schema/responses.py
@@ -23,7 +23,7 @@ from .ir import (
     TaskInvocationId,
     WorkflowDef,
 )
-from .workflow_run import WorkflowRun, WorkflowRunMinimal
+from .workflow_run import WorkflowRun, WorkflowRunOnlyID
 
 
 class ResponseFormat(enum.Enum):
@@ -75,7 +75,7 @@ class GetTaskDefResponse(BaseModel):
 
 class SubmitWorkflowDefResponse(BaseModel):
     meta: ResponseMetadata
-    workflow_runs: t.List[WorkflowRunMinimal]
+    workflow_runs: t.List[WorkflowRunOnlyID]
 
 
 class GetWorkflowRunResponse(BaseModel):

--- a/src/orquestra/sdk/schema/workflow_run.py
+++ b/src/orquestra/sdk/schema/workflow_run.py
@@ -43,7 +43,7 @@ class TaskRun(BaseModel):
 
 class WorkflowRun(BaseModel):
     id: WorkflowRunId
-    workflow_def: t.Optional[WorkflowDef]
+    workflow_def: WorkflowDef
     task_runs: t.List[TaskRun]
     status: RunStatus
 

--- a/src/orquestra/sdk/schema/workflow_run.py
+++ b/src/orquestra/sdk/schema/workflow_run.py
@@ -41,12 +41,26 @@ class TaskRun(BaseModel):
     message: t.Optional[str] = None
 
 
-class WorkflowRun(BaseModel):
+class WorkflowRunOnlyID(BaseModel):
+    """
+    A WorkflowRun that only contains the ID
+    """
+
     id: WorkflowRunId
+
+
+class WorkflowRunMinimal(WorkflowRunOnlyID):
+    """
+    The minimal amount of information to create a WorkflowRun in the public API
+    """
+
     workflow_def: WorkflowDef
+
+
+class WorkflowRun(WorkflowRunMinimal):
+    """
+    A full workflow run with TaskRuns and WorkflowRun status
+    """
+
     task_runs: t.List[TaskRun]
     status: RunStatus
-
-
-class WorkflowRunMinimal(BaseModel):
-    id: WorkflowRunId

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -10,7 +10,7 @@ import sys
 import typing as t
 import warnings
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import Mock, create_autospec
 
 import pytest
 import requests
@@ -634,7 +634,7 @@ class TestWorkflowRunRepo:
                 wf_run = Mock()
                 wf_run.get_status_model.return_value = WorkflowRun(
                     id=stub_id,
-                    workflow_def=None,
+                    workflow_def=create_autospec(ir.WorkflowDef),
                     task_runs=[],
                     status=RunStatus(state=state, start_time=None, end_time=None),
                 )
@@ -678,7 +678,7 @@ class TestWorkflowRunRepo:
                 wf_run = Mock()
                 wf_run.get_status_model.return_value = WorkflowRun(
                     id=stub_id,
-                    workflow_def=None,
+                    workflow_def=create_autospec(ir.WorkflowDef),
                     task_runs=[],
                     status=RunStatus(state=state, start_time=None, end_time=None),
                 )

--- a/tests/runtime/corq/test_cli_main.py
+++ b/tests/runtime/corq/test_cli_main.py
@@ -21,7 +21,7 @@ from orquestra.sdk.schema.responses import (
     ResponseStatusCode,
     SubmitWorkflowDefResponse,
 )
-from orquestra.sdk.schema.workflow_run import State, WorkflowRunMinimal
+from orquestra.sdk.schema.workflow_run import State, WorkflowRunOnlyID
 
 # v2 actions
 V2_ACTIONS_ATTRS = [
@@ -202,7 +202,7 @@ class TestOrqSubmit:
                     code=ResponseStatusCode.OK,
                     message="Successfully submitted workflow.",
                 ),
-                workflow_runs=[WorkflowRunMinimal(id=workflow_run_id)],
+                workflow_runs=[WorkflowRunOnlyID(id=workflow_run_id)],
             )
 
         monkeypatch.setattr(

--- a/tests/runtime/corq/test_format.py
+++ b/tests/runtime/corq/test_format.py
@@ -87,7 +87,7 @@ class TestPrettyPrintResponse:
                     responses.SubmitWorkflowDefResponse(
                         meta=OK_META,
                         workflow_runs=[
-                            workflow_run.WorkflowRunMinimal(id="a_run_id"),
+                            workflow_run.WorkflowRunOnlyID(id="a_run_id"),
                         ],
                     ),
                     ["a_run_id"],

--- a/tests/sdk/v2/driver/resp_mocks.py
+++ b/tests/sdk/v2/driver/resp_mocks.py
@@ -72,6 +72,16 @@ def _wf_run_resp(
     }
 
 
+def _list_wf_run_resp(
+    id_: WorkflowRunID,
+    workflow_def_id: WorkflowDefID,
+):
+    return {
+        "id": id_,
+        "definitionId": workflow_def_id,
+    }
+
+
 # --- Workflow Definitions ---
 
 
@@ -161,7 +171,6 @@ def make_get_wf_run_missing_task_run_status(
 def make_list_wf_run_response(
     ids: List[WorkflowRunID],
     workflow_def_ids: List[WorkflowDefID],
-    statuses: List[RunStatus],
 ):
     """
     Based on:
@@ -170,8 +179,8 @@ def make_list_wf_run_response(
     # Assume empty task runs for now
     return {
         "data": [
-            _wf_run_resp(id_, wf_def_id, status, [])
-            for id_, wf_def_id, status in zip(ids, workflow_def_ids, statuses)
+            _list_wf_run_resp(id_, wf_def_id)
+            for id_, wf_def_id, in zip(ids, workflow_def_ids)
         ]
     }
 
@@ -179,7 +188,6 @@ def make_list_wf_run_response(
 def make_list_wf_run_paginated_response(
     ids: List[WorkflowRunID],
     workflow_def_ids: List[WorkflowDefID],
-    statuses: List[RunStatus],
 ):
     """
     Based on:
@@ -188,8 +196,8 @@ def make_list_wf_run_paginated_response(
     # Assume empty task runs for now
     return {
         "data": [
-            _wf_run_resp(id_, wf_def_id, status, [])
-            for id_, wf_def_id, status in zip(ids, workflow_def_ids, statuses)
+            _list_wf_run_resp(id_, wf_def_id)
+            for id_, wf_def_id in zip(ids, workflow_def_ids)
         ],
         "meta": {
             "pagination": {

--- a/tests/sdk/v2/driver/resp_mocks.py
+++ b/tests/sdk/v2/driver/resp_mocks.py
@@ -7,9 +7,14 @@ takes a lot of lines. Kept as a Python file for some DRY-ness.
 """
 
 
-from datetime import datetime
-from typing import Any, List, Optional, Tuple
+from typing import Any, List
 
+from orquestra.sdk._base._driver._models import (
+    TaskInvocationID,
+    TaskRunID,
+    WorkflowDefID,
+    WorkflowRunID,
+)
 from orquestra.sdk._base.serde import result_from_artifact
 from orquestra.sdk.schema.ir import ArtifactFormat, WorkflowDef
 from orquestra.sdk.schema.workflow_run import RunStatus, TaskRun
@@ -20,7 +25,7 @@ from orquestra.sdk.schema.workflow_run import RunStatus, TaskRun
 PLATFORM_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
-def _wf_def_resp(id_: str, wf_def: WorkflowDef):
+def _wf_def_resp(id_: WorkflowDefID, wf_def: WorkflowDef):
     return {
         "id": id_,
         "created": "2022-11-23T18:58:13.86752161Z",
@@ -39,8 +44,8 @@ def _status_resp(status: RunStatus):
 
 
 def _task_run_resp(
-    id_: str,
-    task_invocation_id: str,
+    id_: TaskRunID,
+    task_invocation_id: TaskInvocationID,
     status: RunStatus,
 ):
     return {
@@ -51,8 +56,8 @@ def _task_run_resp(
 
 
 def _wf_run_resp(
-    id_: str,
-    workflow_def_id: str,
+    id_: WorkflowRunID,
+    workflow_def_id: WorkflowDefID,
     status: RunStatus,
     task_runs: List[TaskRun],
 ):
@@ -70,23 +75,25 @@ def _wf_run_resp(
 # --- Workflow Definitions ---
 
 
-def make_get_wf_def_response(id_: str, wf_def: WorkflowDef):
+def make_get_wf_def_response(id_: WorkflowDefID, wf_def: WorkflowDef):
     """
     Based on:
-    https://github.com/zapatacomputing/workflow-driver/blob/2b353476d5b0161da31584533be208611a131bdc/openapi/src/schemas/WorkflowDefinition.yaml
+    https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/schemas/WorkflowDefinition.yaml
     """
     return {
         "data": _wf_def_resp(id_, wf_def),
     }
 
 
-def make_list_wf_def_response(ids: List[str], wf_defs: List[WorkflowDef]):
+def make_list_wf_def_response(ids: List[WorkflowDefID], wf_defs: List[WorkflowDef]):
     return {
         "data": [_wf_def_resp(id_, wf_def) for id_, wf_def in zip(ids, wf_defs)],
     }
 
 
-def make_list_wf_def_paginated_response(ids: List[str], wf_defs: List[WorkflowDef]):
+def make_list_wf_def_paginated_response(
+    ids: List[WorkflowDefID], wf_defs: List[WorkflowDef]
+):
     return {
         "data": [_wf_def_resp(id_, wf_def) for id_, wf_def in zip(ids, wf_defs)],
         "meta": {
@@ -99,10 +106,10 @@ def make_list_wf_def_paginated_response(ids: List[str], wf_defs: List[WorkflowDe
     }
 
 
-def make_create_wf_def_response(id_: str):
+def make_create_wf_def_response(id_: WorkflowDefID):
     """
     Based on:
-    https://github.com/zapatacomputing/workflow-driver/blob/2b353476d5b0161da31584533be208611a131bdc/openapi/src/responses/CreateWorkflowDefinitionResponse.yaml
+    https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/responses/CreateWorkflowDefinitionResponse.yaml
     """
     return {"data": {"id": id_}}
 
@@ -110,7 +117,7 @@ def make_create_wf_def_response(id_: str):
 def make_error_response(message: str, detail: str):
     """
     Based on:
-    https://github.com/zapatacomputing/workflow-driver/blob/2b353476d5b0161da31584533be208611a131bdc/openapi/src/schemas/Error.yaml
+    https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/schemas/Error.yaml
     """
 
     return {
@@ -119,7 +126,10 @@ def make_error_response(message: str, detail: str):
     }
 
 
-def make_submit_wf_run_response(id_: str):
+# --- Workflow Runs ---
+
+
+def make_submit_wf_run_response(id_: WorkflowRunID):
     """
     Based on:
         https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/responses/CreateWorkflowRunResponse.yaml
@@ -128,7 +138,10 @@ def make_submit_wf_run_response(id_: str):
 
 
 def make_get_wf_run_response(
-    id_: str, workflow_def_id: str, status: RunStatus, task_runs: List[TaskRun]
+    id_: WorkflowRunID,
+    workflow_def_id: WorkflowDefID,
+    status: RunStatus,
+    task_runs: List[TaskRun],
 ):
     """
     Based on:
@@ -138,7 +151,7 @@ def make_get_wf_run_response(
 
 
 def make_get_wf_run_missing_task_run_status(
-    id_: str, workflow_def_id: str, status: RunStatus
+    id_: WorkflowRunID, workflow_def_id: WorkflowDefID, status: RunStatus
 ):
     wf_run = {"data": _wf_run_resp(id_, workflow_def_id, status, [])}
     wf_run["data"]["taskRuns"].append({"id": "xyz", "invocationId": "abc"})
@@ -146,7 +159,9 @@ def make_get_wf_run_missing_task_run_status(
 
 
 def make_list_wf_run_response(
-    ids: List[str], workflow_def_ids: List[str], statuses: List[RunStatus]
+    ids: List[WorkflowRunID],
+    workflow_def_ids: List[WorkflowDefID],
+    statuses: List[RunStatus],
 ):
     """
     Based on:
@@ -162,7 +177,9 @@ def make_list_wf_run_response(
 
 
 def make_list_wf_run_paginated_response(
-    ids: List[str], workflow_def_ids: List[str], statuses: List[RunStatus]
+    ids: List[WorkflowRunID],
+    workflow_def_ids: List[WorkflowDefID],
+    statuses: List[RunStatus],
 ):
     """
     Based on:

--- a/tests/sdk/v2/driver/resp_mocks.py
+++ b/tests/sdk/v2/driver/resp_mocks.py
@@ -52,11 +52,13 @@ def _task_run_resp(
 
 def _wf_run_resp(
     id_: str,
+    workflow_def_id: str,
     status: RunStatus,
     task_runs: List[TaskRun],
 ):
     return {
         "id": id_,
+        "definitionId": workflow_def_id,
         "status": _status_resp(status),
         "owner": "evil/emiliano.zapata@zapatacomputing.com",
         "taskRuns": [
@@ -125,39 +127,53 @@ def make_submit_wf_run_response(id_: str):
     return {"data": {"id": id_}}
 
 
-def make_get_wf_run_response(id_: str, status: RunStatus, task_runs: List[TaskRun]):
+def make_get_wf_run_response(
+    id_: str, workflow_def_id: str, status: RunStatus, task_runs: List[TaskRun]
+):
     """
     Based on:
         https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/schemas/WorkflowRun.yaml
     """
-    return {"data": _wf_run_resp(id_, status, task_runs)}
+    return {"data": _wf_run_resp(id_, workflow_def_id, status, task_runs)}
 
 
-def make_get_wf_run_missing_task_run_status(id_: str, status: RunStatus):
-    wf_run = {"data": _wf_run_resp(id_, status, [])}
+def make_get_wf_run_missing_task_run_status(
+    id_: str, workflow_def_id: str, status: RunStatus
+):
+    wf_run = {"data": _wf_run_resp(id_, workflow_def_id, status, [])}
     wf_run["data"]["taskRuns"].append({"id": "xyz", "invocationId": "abc"})
     return wf_run
 
 
-def make_list_wf_run_response(ids: List[str], statuses: List[RunStatus]):
+def make_list_wf_run_response(
+    ids: List[str], workflow_def_ids: List[str], statuses: List[RunStatus]
+):
     """
     Based on:
         https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/resources/workflow-runs.yaml#L1
     """
     # Assume empty task runs for now
     return {
-        "data": [_wf_run_resp(id_, status, []) for id_, status in zip(ids, statuses)]
+        "data": [
+            _wf_run_resp(id_, wf_def_id, status, [])
+            for id_, wf_def_id, status in zip(ids, workflow_def_ids, statuses)
+        ]
     }
 
 
-def make_list_wf_run_paginated_response(ids: List[str], statuses: List[RunStatus]):
+def make_list_wf_run_paginated_response(
+    ids: List[str], workflow_def_ids: List[str], statuses: List[RunStatus]
+):
     """
     Based on:
         https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/resources/workflow-runs.yaml#L1
     """
     # Assume empty task runs for now
     return {
-        "data": [_wf_run_resp(id_, status, []) for id_, status in zip(ids, statuses)],
+        "data": [
+            _wf_run_resp(id_, wf_def_id, status, [])
+            for id_, wf_def_id, status in zip(ids, workflow_def_ids, statuses)
+        ],
         "meta": {
             "pagination": {
                 "total": len(ids),

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -701,7 +701,6 @@ class TestClient:
                 client: DriverClient,
                 workflow_run_id: str,
                 workflow_def_id: str,
-                workflow_run_status: RunStatus,
             ):
                 endpoint_mocker(
                     # Specified in:
@@ -709,7 +708,6 @@ class TestClient:
                     json=resp_mocks.make_list_wf_run_response(
                         ids=[workflow_run_id] * 10,
                         workflow_def_ids=[workflow_def_id] * 10,
-                        statuses=[workflow_run_status] * 10,
                     )
                 )
 
@@ -718,7 +716,6 @@ class TestClient:
                 assert isinstance(defs, Paginated)
                 assert len(defs.contents) == 10
                 assert defs.contents[0].id == workflow_run_id
-                assert defs.contents[0].status == workflow_run_status
                 assert defs.next_page_token is None
                 assert defs.prev_page_token is None
 
@@ -729,7 +726,6 @@ class TestClient:
                 client: DriverClient,
                 workflow_run_id: str,
                 workflow_def_id: str,
-                workflow_run_status: RunStatus,
             ):
                 endpoint_mocker(
                     # Specified in:
@@ -737,7 +733,6 @@ class TestClient:
                     json=resp_mocks.make_list_wf_run_paginated_response(
                         ids=[workflow_run_id] * 10,
                         workflow_def_ids=[workflow_def_id] * 10,
-                        statuses=[workflow_run_status] * 10,
                     )
                 )
 
@@ -746,7 +741,6 @@ class TestClient:
                 assert isinstance(defs, Paginated)
                 assert len(defs.contents) == 10
                 assert defs.contents[0].id == workflow_run_id
-                assert defs.contents[0].status == workflow_run_status
                 assert defs.next_page_token == "nikkei-est-273_35438"
                 assert defs.prev_page_token == "nikkei-est-273_35438"
 
@@ -794,13 +788,11 @@ class TestClient:
                 token,
                 workflow_run_id,
                 workflow_def_id,
-                workflow_run_status,
             ):
                 endpoint_mocker(
                     json=resp_mocks.make_list_wf_run_response(
                         ids=[workflow_run_id] * 10,
                         workflow_def_ids=[workflow_def_id] * 10,
-                        statuses=[workflow_run_status] * 10,
                     ),
                     match=[
                         responses.matchers.header_matcher(


### PR DESCRIPTION
# The problem

We need the workflow defintion to drive some UI

# This PR's solution

- Updates the CE driver to grab the workflow def for a workflow run

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
