### PR TITLE
!Feat: Dorq task logs command. get_logs() function accepts task invocation ID instead of task run ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 🚨 *Breaking Changes*
-*  `get_logs` - public API function accepts TaskInvocationID instead of TaskRunID - attempt to remove TaskRunID from all API calls
+*  `sdk.WorkflowRun.get_logs()` now accepts TaskInvocationID instead of TaskRunID
 
 🔥 *Features*
 * `list_workflow_runs` added to the Public API. This lets you list the workflows for a given config, for example `sdk.list_workflow_runs("ray")` or `sdk.list_workflow_runs("prod-d")`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 🚨 *Breaking Changes*
-
+*  `get_logs` - public API function accepts TaskInvocationID instead of TaskRunID - attempt to remove TaskRunID from all API calls
 
 🔥 *Features*
 * `list_workflow_runs` added to the Public API. This lets you list the workflows for a given config, for example `sdk.list_workflow_runs("ray")` or `sdk.list_workflow_runs("prod-d")`.
@@ -16,7 +16,7 @@
 * Dorq wf submit now properly prompts users for config selection
 * New CLI command: `python -m orquestra.sdk._base.cli._dorq._entry workflow results`. It shows a preview of the workflow run output artifact and can download the result values to the provided directory.
 * New CLI command: `python -m orquestra.sdk._base.cli._dorq._entry workflow logs`.
-
+* New CLI command: `python -m orquestra.sdk._base.cli._dorq._entry task logs`.
 
 🐛 *Bug Fixes*
 * Fixed broken link on docs landing page.

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -610,7 +610,7 @@ class WorkflowRun:
         tasks: t.Union[TaskInvocationId, t.List[TaskInvocationId]],
         *,
         only_available: bool = False,
-    ) -> t.Dict[TaskRunId, t.List[str]]:
+    ) -> t.Dict[TaskInvocationId, t.List[str]]:
         """
         Unstable: this API will change.
 

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -631,7 +631,7 @@ class WorkflowRun:
                 task_invocation_id: List[log lines]
         """
         try:
-            run_id = self.run_id
+            _ = self.run_id
         except WorkflowRunNotStarted as e:
             message = (
                 "Cannot get the logs of a workflow run that hasn't started yet. "

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -26,7 +26,7 @@ from orquestra.sdk.schema.configs import (
     RuntimeName,
 )
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
-from orquestra.sdk.schema.workflow_run import State, TaskRunId, TaskInvocationId
+from orquestra.sdk.schema.workflow_run import State, TaskInvocationId, TaskRunId
 from orquestra.sdk.schema.workflow_run import WorkflowRun as WorkflowRunModel
 from orquestra.sdk.schema.workflow_run import WorkflowRunId
 
@@ -646,7 +646,9 @@ class WorkflowRun:
         for task_inv_id in task_list:
             all_task_runs = self.get_status_model().task_runs
             # find taskRunID based on task invocation ID
-            task_run_id = next(task.id for task in all_task_runs if task.invocation_id == task_inv_id)
+            task_run_id = next(
+                task.id for task in all_task_runs if task.invocation_id == task_inv_id
+            )
             try:
                 # Get a single task run logs
                 # Unfortunately, we return TaskInvocationId: List[str] from

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -646,18 +646,20 @@ class WorkflowRun:
         for task_inv_id in task_list:
             all_task_runs = self.get_status_model().task_runs
             # find taskRunID based on task invocation ID
-            task_run_id = next(
-                task.id for task in all_task_runs if task.invocation_id == task_inv_id
-            )
             try:
                 # Get a single task run logs
                 # Unfortunately, we return TaskInvocationId: List[str] from
                 # get_full_logs. so we do this hack to get the first value from the dict
                 # which (in this case) the task logs for the task_run_id.
+                task_run_id = next(
+                    task.id
+                    for task in all_task_runs
+                    if task.invocation_id == task_inv_id
+                )
                 task_logs[task_inv_id] = next(
                     iter(self._runtime.get_full_logs(task_run_id).values())
                 )
-            except NotFoundError as e:
+            except (NotFoundError, StopIteration) as e:
                 if only_available:
                     continue
                 else:

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -257,7 +257,7 @@ def task():
     pass
 
 
-@task.command()
+@task.command()  # type: ignore[no-redef]
 @cloup.argument("wf_run_id", required=False)
 @cloup.argument("task_inv_id", required=False)
 @cloup.argument("fn_name", required=False)

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -269,7 +269,7 @@ def logs(
     fn_name,
     config: t.Optional[str],
     download_dir: t.Optional[Path],
-):
+):  # noqa: F811
     """
     Shows logs gathered during execution of a workflow produced by all tasks.
     """

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -263,13 +263,13 @@ def task():
 @cloup.argument("fn_name", required=False)
 @CONFIG_OPTION
 @DOWNLOAD_DIR_OPTION
-def logs(
+def logs(  # noqa: F811
     wf_run_id: t.Optional[str],
     task_inv_id,
     fn_name,
     config: t.Optional[str],
     download_dir: t.Optional[Path],
-):  # noqa: F811
+):
     """
     Shows logs gathered during execution of a workflow produced by all tasks.
     """

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -249,6 +249,42 @@ dorq.section(
 )
 
 
+@dorq.group()
+def task():
+    """
+    Commands related to workflow runs.
+    """
+    pass
+
+@task.command()
+@cloup.argument("wf_run_id", required=False)
+@cloup.argument("task_inv_id", required=False)
+@cloup.argument("fn_name", required=False)
+@CONFIG_OPTION
+@DOWNLOAD_DIR_OPTION
+def logs(
+    wf_run_id: t.Optional[str],
+    task_inv_id,
+    fn_name,
+    config: t.Optional[str],
+    download_dir: t.Optional[Path],
+):
+    """
+    Shows logs gathered during execution of a workflow produced by all tasks.
+    """
+
+    from ._task._logs import Action
+
+    action = Action()
+    action.on_cmd_call(
+        wf_run_id=wf_run_id,
+        task_invocation_id=task_inv_id,
+        fn_name=fn_name,
+        config=config,
+        download_dir=download_dir,
+    )
+
+
 @dorq.command()
 @cloup.option(
     "-s", "--server", required=True, help="server URI that you want to log into"

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -256,6 +256,7 @@ def task():
     """
     pass
 
+
 @task.command()
 @cloup.argument("wf_run_id", required=False)
 @cloup.argument("task_inv_id", required=False)

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -6,8 +6,6 @@ Code for 'orq login'.
 """
 import typing as t
 
-from orquestra.sdk import exceptions
-
 from .. import _repos
 from .._ui import _presenters
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -289,7 +289,12 @@ class WorkflowRunRepo:
 
         return logs
 
-    def get_task_logs(self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId, config_name: ConfigName):
+    def get_task_logs(
+        self,
+        wf_run_id: WorkflowRunId,
+        task_inv_id: TaskInvocationId,
+        config_name: ConfigName,
+    ):
         try:
             wf_run = sdk.WorkflowRun.by_id(wf_run_id, config_name)
         except (exceptions.NotFoundError, exceptions.ConfigNameNotFoundError):
@@ -301,6 +306,7 @@ class WorkflowRunRepo:
             raise
 
         return logs
+
 
 class ConfigRepo:
     """

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -302,7 +302,7 @@ class WorkflowRunRepo:
 
         try:
             logs = wf_run.get_logs(tasks=task_inv_id)
-        except (exceptions.WorkflowRunNotFinished, exceptions.WorkflowRunNotSucceeded):
+        except (exceptions.WorkflowRunNotStarted, exceptions.TaskRunNotFound):
             raise
 
         return logs

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -289,6 +289,18 @@ class WorkflowRunRepo:
 
         return logs
 
+    def get_task_logs(self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId, config_name: ConfigName):
+        try:
+            wf_run = sdk.WorkflowRun.by_id(wf_run_id, config_name)
+        except (exceptions.NotFoundError, exceptions.ConfigNameNotFoundError):
+            raise
+
+        try:
+            logs = wf_run.get_logs(tasks=task_inv_id)
+        except (exceptions.WorkflowRunNotFinished, exceptions.WorkflowRunNotSucceeded):
+            raise
+
+        return logs
 
 class ConfigRepo:
     """

--- a/src/orquestra/sdk/_base/cli/_dorq/_task/_logs.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_task/_logs.py
@@ -38,7 +38,9 @@ class Action:
         self._wf_run_id_resolver = wf_run_id_resolver or _arg_resolvers.WFRunIDResolver(
             wf_run_repo=wf_run_repo
         )
-        self._task_inv_id_resolver = task_inv_id_resolver or _arg_resolvers.TaskInvIDResolver(wf_run_repo)
+        self._task_inv_id_resolver = (
+            task_inv_id_resolver or _arg_resolvers.TaskInvIDResolver(wf_run_repo)
+        )
 
         # output
         self._presenter = presenter
@@ -77,10 +79,18 @@ class Action:
         resolved_wf_run_id = self._wf_run_id_resolver.resolve(
             wf_run_id, resolved_config
         )
-        resolver_task_inv_id = self._task_inv_id_resolver.resolve(task_inv_id=task_invocation_id, fn_name=fn_name, wf_run_id=resolved_wf_run_id, config=resolved_config)
+        resolver_task_inv_id = self._task_inv_id_resolver.resolve(
+            task_inv_id=task_invocation_id,
+            fn_name=fn_name,
+            wf_run_id=resolved_wf_run_id,
+            config=resolved_config,
+        )
 
         logs = self._wf_run_repo.get_task_logs(
-            wf_run_id=resolved_wf_run_id, task_inv_id=resolver_task_inv_id, config_name=resolved_config)
+            wf_run_id=resolved_wf_run_id,
+            task_inv_id=resolver_task_inv_id,
+            config_name=resolved_config,
+        )
 
         breakpoint()
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_task/_logs.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_task/_logs.py
@@ -92,8 +92,6 @@ class Action:
             config_name=resolved_config,
         )
 
-        breakpoint()
-
         if download_dir is not None:
             dump_path = self._dumper.dump(
                 logs=logs,

--- a/src/orquestra/sdk/_base/cli/_dorq/_task/_logs.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_task/_logs.py
@@ -1,0 +1,95 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Code for 'orq workflow logs'.
+"""
+import typing as t
+from pathlib import Path
+
+from orquestra.sdk.schema.configs import ConfigName
+from orquestra.sdk.schema.workflow_run import TaskInvocationId, WorkflowRunId
+
+from .. import _arg_resolvers, _dumpers, _repos
+from .._ui import _presenters
+
+
+class Action:
+    """
+    Encapsulates app-related logic for handling ``orq workflow logs``.
+    """
+
+    def __init__(
+        self,
+        presenter=_presenters.WrappedCorqOutputPresenter(),
+        dumper=_dumpers.LogsDumper(),
+        wf_run_repo=_repos.WorkflowRunRepo(),
+        config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
+        wf_run_id_resolver: t.Optional[_arg_resolvers.WFRunIDResolver] = None,
+        task_inv_id_resolver: t.Optional[_arg_resolvers.TaskInvIDResolver] = None,
+    ):
+        # data sources
+        self._wf_run_repo = wf_run_repo
+
+        # arg resolvers
+        self._config_resolver = config_resolver or _arg_resolvers.WFConfigResolver(
+            wf_run_repo=wf_run_repo
+        )
+        self._wf_run_id_resolver = wf_run_id_resolver or _arg_resolvers.WFRunIDResolver(
+            wf_run_repo=wf_run_repo
+        )
+        self._task_inv_id_resolver = task_inv_id_resolver or _arg_resolvers.TaskInvIDResolver(wf_run_repo)
+
+        # output
+        self._presenter = presenter
+        self._dumper = dumper
+
+    def on_cmd_call(
+        self,
+        wf_run_id: t.Optional[WorkflowRunId],
+        task_invocation_id: t.Optional[TaskInvocationId],
+        fn_name: t.Optional[str],
+        config: t.Optional[ConfigName],
+        download_dir: t.Optional[Path],
+    ):
+        try:
+            self._on_cmd_call_with_exceptions(
+                wf_run_id=wf_run_id,
+                task_invocation_id=task_invocation_id,
+                fn_name=fn_name,
+                download_dir=download_dir,
+                config=config,
+            )
+        except Exception as e:
+            self._presenter.show_error(e)
+
+    def _on_cmd_call_with_exceptions(
+        self,
+        wf_run_id: t.Optional[WorkflowRunId],
+        task_invocation_id: t.Optional[TaskInvocationId],
+        fn_name: t.Optional[str],
+        config: t.Optional[ConfigName],
+        download_dir: t.Optional[Path],
+    ):
+        # The order of resolving config and run ID is important. It dictates the flow
+        # user sees, and possible choices in the prompts.
+        resolved_config = self._config_resolver.resolve(wf_run_id, config)
+        resolved_wf_run_id = self._wf_run_id_resolver.resolve(
+            wf_run_id, resolved_config
+        )
+        resolver_task_inv_id = self._task_inv_id_resolver.resolve(task_inv_id=task_invocation_id, fn_name=fn_name, wf_run_id=resolved_wf_run_id, config=resolved_config)
+
+        logs = self._wf_run_repo.get_task_logs(
+            wf_run_id=resolved_wf_run_id, task_inv_id=resolver_task_inv_id, config_name=resolved_config)
+
+        breakpoint()
+
+        if download_dir is not None:
+            dump_path = self._dumper.dump(
+                logs=logs,
+                wf_run_id=resolved_wf_run_id,
+                dir_path=download_dir,
+            )
+            self._presenter.show_dumped_wf_logs(dump_path)
+        else:
+            self._presenter.show_logs(logs)

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_logs.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_logs.py
@@ -8,7 +8,7 @@ import typing as t
 from pathlib import Path
 
 from orquestra.sdk.schema.configs import ConfigName
-from orquestra.sdk.schema.workflow_run import TaskInvocationId, WorkflowRunId
+from orquestra.sdk.schema.workflow_run import WorkflowRunId
 
 from .. import _arg_resolvers, _dumpers, _repos
 from .._ui import _presenters

--- a/tests/cli/dorq/task/test_task_logs.py
+++ b/tests/cli/dorq/task/test_task_logs.py
@@ -9,14 +9,14 @@ from pathlib import Path
 from unittest.mock import create_autospec
 
 from orquestra.sdk._base.cli._dorq._arg_resolvers import (
+    TaskInvIDResolver,
     WFConfigResolver,
     WFRunIDResolver,
-    TaskInvIDResolver,
 )
 from orquestra.sdk._base.cli._dorq._dumpers import LogsDumper
 from orquestra.sdk._base.cli._dorq._repos import WorkflowRunRepo
-from orquestra.sdk._base.cli._dorq._ui._presenters import WrappedCorqOutputPresenter
 from orquestra.sdk._base.cli._dorq._task import _logs
+from orquestra.sdk._base.cli._dorq._ui._presenters import WrappedCorqOutputPresenter
 
 
 class TestAction:
@@ -76,7 +76,11 @@ class TestAction:
 
             # When
             action.on_cmd_call(
-                wf_run_id=wf_run_id, config=config, download_dir=download_dir, fn_name=fn_name, task_invocation_id=task_inv_id
+                wf_run_id=wf_run_id,
+                config=config,
+                download_dir=download_dir,
+                fn_name=fn_name,
+                task_invocation_id=task_inv_id,
             )
 
             # Then
@@ -88,11 +92,15 @@ class TestAction:
             # We should pass resolved_config to run ID resolver.
             wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
 
-            task_inv_id_resolver.resolve.assert_called_with(task_inv_id, fn_name, resolved_id, resolved_config)
+            task_inv_id_resolver.resolve.assert_called_with(
+                task_inv_id, fn_name, resolved_id, resolved_config
+            )
 
             # We should pass resolved values to run repo.
             wf_run_repo.get_task_logs.assert_called_with(
-                wf_run_id=resolved_id, config_name=resolved_config, task_inv_id=resolved_invocation_id,
+                wf_run_id=resolved_id,
+                config_name=resolved_config,
+                task_inv_id=resolved_invocation_id,
             )
 
             # We expect printing the workflow run returned from the repo.
@@ -148,7 +156,11 @@ class TestAction:
 
             # When
             action.on_cmd_call(
-                wf_run_id=wf_run_id, config=config, download_dir=download_dir, fn_name=fn_name, task_invocation_id=task_inv_id
+                wf_run_id=wf_run_id,
+                config=config,
+                download_dir=download_dir,
+                fn_name=fn_name,
+                task_invocation_id=task_inv_id,
             )
 
             # Then
@@ -159,11 +171,14 @@ class TestAction:
             # We should pass resolved_config to run ID resolver.
             wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
 
-            task_inv_id_resolver.resolve.assert_called_with(task_inv_id, fn_name, resolved_id, resolved_config)
+            task_inv_id_resolver.resolve.assert_called_with(
+                task_inv_id, fn_name, resolved_id, resolved_config
+            )
 
             # We should pass resolved values to run repo.
             wf_run_repo.get_task_logs.assert_called_with(
-                wf_run_id=resolved_id, config_name=resolved_config,
+                wf_run_id=resolved_id,
+                config_name=resolved_config,
                 task_inv_id=resolved_invocation_id,
             )
 

--- a/tests/cli/dorq/task/test_task_logs.py
+++ b/tests/cli/dorq/task/test_task_logs.py
@@ -1,0 +1,173 @@
+################################################################################
+# © Copyright 2022-2023 Zapata Computing Inc.
+################################################################################
+"""
+Unit tests for 'orq task logs' glue code.
+"""
+
+from pathlib import Path
+from unittest.mock import create_autospec
+
+from orquestra.sdk._base.cli._dorq._arg_resolvers import (
+    WFConfigResolver,
+    WFRunIDResolver,
+    TaskInvIDResolver,
+)
+from orquestra.sdk._base.cli._dorq._dumpers import LogsDumper
+from orquestra.sdk._base.cli._dorq._repos import WorkflowRunRepo
+from orquestra.sdk._base.cli._dorq._ui._presenters import WrappedCorqOutputPresenter
+from orquestra.sdk._base.cli._dorq._task import _logs
+
+
+class TestAction:
+    """
+    Test boundaries::
+        [_output.Action]->[arg resolvers]
+                        ->[repos]
+                        ->[dumper]
+                        ->[presenter]
+    """
+
+    class TestDataPassing:
+        """
+        Verifies how we pass variables between subcomponents.
+        """
+
+        @staticmethod
+        def test_no_download_dir():
+            # Given
+            # CLI inputs
+            wf_run_id = "<wf run ID sentinel>"
+            config = "<config sentinel>"
+            download_dir = None
+            task_inv_id = "<my inv ID>"
+            fn_name = "<my task fn name>"
+
+            # Resolved values
+            resolved_id = "<resolved ID>"
+            resolved_config = "<resolved config>"
+            resolved_invocation_id = "<resolved invocation id>"
+
+            # Mocks
+            presenter = create_autospec(WrappedCorqOutputPresenter)
+            dumper = create_autospec(LogsDumper)
+            wf_run_repo = create_autospec(WorkflowRunRepo)
+
+            fake_logs = {"task_inv": ["my_log_1", "my_log_2"]}
+            wf_run_repo.get_task_logs.return_value = fake_logs
+
+            config_resolver = create_autospec(WFConfigResolver)
+            config_resolver.resolve.return_value = resolved_config
+
+            wf_run_id_resolver = create_autospec(WFRunIDResolver)
+            wf_run_id_resolver.resolve.return_value = resolved_id
+
+            task_inv_id_resolver = create_autospec(TaskInvIDResolver)
+            task_inv_id_resolver.resolve.return_value = resolved_invocation_id
+
+            action = _logs.Action(
+                presenter=presenter,
+                dumper=dumper,
+                wf_run_repo=wf_run_repo,
+                config_resolver=config_resolver,
+                wf_run_id_resolver=wf_run_id_resolver,
+                task_inv_id_resolver=task_inv_id_resolver,
+            )
+
+            # When
+            action.on_cmd_call(
+                wf_run_id=wf_run_id, config=config, download_dir=download_dir, fn_name=fn_name, task_invocation_id=task_inv_id
+            )
+
+            # Then
+            # We should pass input CLI args to config resolver.
+            presenter.show_error.assert_not_called()
+
+            config_resolver.resolve.assert_called_with(wf_run_id, config)
+
+            # We should pass resolved_config to run ID resolver.
+            wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
+
+            task_inv_id_resolver.resolve.assert_called_with(task_inv_id, fn_name, resolved_id, resolved_config)
+
+            # We should pass resolved values to run repo.
+            wf_run_repo.get_task_logs.assert_called_with(
+                wf_run_id=resolved_id, config_name=resolved_config, task_inv_id=resolved_invocation_id,
+            )
+
+            # We expect printing the workflow run returned from the repo.
+            presenter.show_logs.assert_called_with(fake_logs)
+
+            # We don't expect any dumps.
+            assert dumper.mock_calls == []
+
+        @staticmethod
+        def test_download_dir_passed():
+            # Given
+            # CLI inputs
+            wf_run_id = "<wf run ID sentinel>"
+            config = "<config sentinel>"
+            download_dir = Path("/tmp/my/awesome/dir")
+            task_inv_id = "<my inv ID>"
+            fn_name = "<my task fn name>"
+
+            # Resolved values
+            resolved_id = "<resolved ID>"
+            resolved_config = "<resolved config>"
+            resolved_invocation_id = "<resolved invocation id>"
+
+            # Mocks
+            presenter = create_autospec(WrappedCorqOutputPresenter)
+
+            path_to_logs = "returns whatever"
+            dumper = create_autospec(LogsDumper)
+            dumper.dump.return_value = path_to_logs
+
+            wf_run_repo = create_autospec(WorkflowRunRepo)
+
+            fake_logs = {"task_inv": ["my_log_1", "my_log_2"]}
+            wf_run_repo.get_task_logs.return_value = fake_logs
+
+            config_resolver = create_autospec(WFConfigResolver)
+            config_resolver.resolve.return_value = resolved_config
+
+            wf_run_id_resolver = create_autospec(WFRunIDResolver)
+            wf_run_id_resolver.resolve.return_value = resolved_id
+
+            task_inv_id_resolver = create_autospec(TaskInvIDResolver)
+            task_inv_id_resolver.resolve.return_value = resolved_invocation_id
+
+            action = _logs.Action(
+                presenter=presenter,
+                dumper=dumper,
+                wf_run_repo=wf_run_repo,
+                config_resolver=config_resolver,
+                wf_run_id_resolver=wf_run_id_resolver,
+                task_inv_id_resolver=task_inv_id_resolver,
+            )
+
+            # When
+            action.on_cmd_call(
+                wf_run_id=wf_run_id, config=config, download_dir=download_dir, fn_name=fn_name, task_invocation_id=task_inv_id
+            )
+
+            # Then
+            # We should pass input CLI args to config resolver.
+            presenter.show_error.assert_not_called()
+            config_resolver.resolve.assert_called_with(wf_run_id, config)
+
+            # We should pass resolved_config to run ID resolver.
+            wf_run_id_resolver.resolve.assert_called_with(wf_run_id, resolved_config)
+
+            task_inv_id_resolver.resolve.assert_called_with(task_inv_id, fn_name, resolved_id, resolved_config)
+
+            # We should pass resolved values to run repo.
+            wf_run_repo.get_task_logs.assert_called_with(
+                wf_run_id=resolved_id, config_name=resolved_config,
+                task_inv_id=resolved_invocation_id,
+            )
+
+            # Do not print logs to stdout
+            presenter.show_logs.assert_not_called()
+            presenter.show_dumped_wf_logs.assert_called_with(path_to_logs)
+            dumper.dump.assert_called_with(fake_logs, resolved_id, download_dir)

--- a/tests/cli/dorq/test_entrypoint.py
+++ b/tests/cli/dorq/test_entrypoint.py
@@ -37,6 +37,7 @@ class TestCommandTreeAssembly:
             ["down"],
             ["status"],
             ["login"],
+            ["task", "logs"],
         ],
     )
     @pytest.mark.parametrize(

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -34,6 +34,25 @@ from ...sdk.v2.data.configs import TEST_CONFIG_JSON
 
 
 class TestWorkflowRunRepo:
+    @staticmethod
+    @pytest.fixture
+    def mock_wf_run(monkeypatch):
+        """
+        Returns a mock of shape of sdk.WorkflowRun. Used by other fixtures.
+        """
+        return Mock(sdk.WorkflowRun)
+
+    @staticmethod
+    @pytest.fixture
+    def mock_by_id(monkeypatch, mock_wf_run):
+        """
+        Returns a mock of sdk.WorkflowRun.by_id.
+        """
+        by_id = Mock(return_value=mock_wf_run)
+        monkeypatch.setattr(sdk.WorkflowRun, "by_id", by_id)
+
+        return by_id
+
     class TestIsolation:
         """
         Isolated unit tests for WorkflowRunRepo.
@@ -60,25 +79,6 @@ class TestWorkflowRunRepo:
             monkeypatch.setattr(_db.WorkflowDB, "open_db", ctx_manager)
 
             return db
-
-        @staticmethod
-        @pytest.fixture
-        def mock_wf_run(monkeypatch):
-            """
-            Returns a mock of shape of sdk.WorkflowRun. Used by other fixtures.
-            """
-            return Mock(sdk.WorkflowRun)
-
-        @staticmethod
-        @pytest.fixture
-        def mock_by_id(monkeypatch, mock_wf_run):
-            """
-            Returns a mock of sdk.WorkflowRun.by_id.
-            """
-            by_id = Mock(return_value=mock_wf_run)
-            monkeypatch.setattr(sdk.WorkflowRun, "by_id", by_id)
-
-            return by_id
 
         @staticmethod
         def test_get_config_name_by_run_id(db_mock):
@@ -568,6 +568,65 @@ class TestWorkflowRunRepo:
                 with pytest.raises(type(exc)):
                     # When
                     _ = repo.get_wf_logs(wf_run_id, config)
+
+        class TestGetTaskLogs:
+            @staticmethod
+            def test_passing_values(monkeypatch, mock_by_id, mock_wf_run):
+                # Given
+                config = "<config sentinel>"
+                wf_run_id = "<id sentinel>"
+                task_run_id = "<task id sentinel>"
+                logs = {"task_id": ["my_log", "my_another_log"]}
+
+                mock_wf_run.get_logs.return_value = logs
+
+                # When
+                repo = _repos.WorkflowRunRepo()
+
+                # Then
+                assert repo.get_task_logs(wf_run_id, task_run_id, config) == logs
+
+            @staticmethod
+            @pytest.mark.parametrize(
+                "exc",
+                [exceptions.WorkflowRunNotStarted(), exceptions.TaskRunNotFound()],
+            )
+            def test_passing_errors(monkeypatch, mock_by_id, mock_wf_run, exc):
+                # Given
+                config = "<config sentinel>"
+                wf_run_id = "<id sentinel>"
+                task_run_id = "<task id sentinel>"
+
+                mock_wf_run.get_logs.side_effect = exc
+
+                # When
+                repo = _repos.WorkflowRunRepo()
+
+                # Then
+                with pytest.raises(type(exc)):
+                    # When
+                    _ = repo.get_task_logs(wf_run_id, task_run_id, config)
+
+            @staticmethod
+            @pytest.mark.parametrize(
+                "exc",
+                [exceptions.NotFoundError(), exceptions.ConfigNameNotFoundError()],
+            )
+            def test_wf_not_found(monkeypatch, mock_by_id, exc):
+                # Given
+                config = "<config sentinel>"
+                wf_run_id = "<id sentinel>"
+                task_run_id = "<task id sentinel>"
+
+                mock_by_id.side_effect = exc
+
+                # When
+                repo = _repos.WorkflowRunRepo()
+
+                # Then
+                with pytest.raises(type(exc)):
+                    # When
+                    _ = repo.get_task_logs(wf_run_id, task_run_id, config)
 
     class TestIntegration:
         @staticmethod

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -571,7 +571,7 @@ class TestWorkflowRunRepo:
 
         class TestGetTaskLogs:
             @staticmethod
-            def test_passing_values(monkeypatch, mock_by_id, mock_wf_run):
+            def test_passing_values(mock_by_id, mock_wf_run):
                 # Given
                 config = "<config sentinel>"
                 wf_run_id = "<id sentinel>"
@@ -591,7 +591,7 @@ class TestWorkflowRunRepo:
                 "exc",
                 [exceptions.WorkflowRunNotStarted(), exceptions.TaskRunNotFound()],
             )
-            def test_passing_errors(monkeypatch, mock_by_id, mock_wf_run, exc):
+            def test_passing_errors(mock_by_id, mock_wf_run, exc):
                 # Given
                 config = "<config sentinel>"
                 wf_run_id = "<id sentinel>"
@@ -612,7 +612,7 @@ class TestWorkflowRunRepo:
                 "exc",
                 [exceptions.NotFoundError(), exceptions.ConfigNameNotFoundError()],
             )
-            def test_wf_not_found(monkeypatch, mock_by_id, exc):
+            def test_wf_not_found(mock_by_id, exc):
                 # Given
                 config = "<config sentinel>"
                 wf_run_id = "<id sentinel>"

--- a/tests/sdk/v2/test_api.py
+++ b/tests/sdk/v2/test_api.py
@@ -154,9 +154,9 @@ class TestWorkflowRun:
         }
         # Get logs, the runtime interface returns invocation IDs
         runtime.get_full_logs.return_value = {
-            "task_run1": ["woohoo!\n"],
-            "task_run2": ["another\n", "line\n"],
-            "task_run3": ["hello\n", "a log\n"],
+            "task_invocation1": ["woohoo!\n"],
+            "task_invocation2": ["another\n", "line\n"],
+            "task_invocation3": ["hello\n", "a log\n"],
         }
         _running.task_runs = [
             TaskRun(

--- a/tests/sdk/v2/test_api.py
+++ b/tests/sdk/v2/test_api.py
@@ -6,6 +6,7 @@ Tests for orquestra.sdk._base._api.
 """
 
 import builtins
+import itertools
 import json
 import subprocess
 import sys
@@ -129,20 +130,22 @@ class TestWorkflowRun:
         runtime.get_workflow_run_outputs_non_blocking.return_value = "woohoo!"
         # for simulating a workflow running
         _succeeded = MagicMock()
+
         # Default value is "SUCCEEDED"
         _succeeded.status.state = State.SUCCEEDED
         runtime.get_workflow_run_status.return_value = _succeeded
         # Use side effects to simulate a running workflow
-        # Note: if you call get_workflow_run_status too many times, you may see a
-        #       StopIteration exception
+
         _running = MagicMock()
         _running.status.state = State.RUNNING
-        runtime.get_workflow_run_status.side_effect = [
-            _running,
-            _running,
-            DEFAULT,
-            DEFAULT,
-        ]
+        runtime.get_workflow_run_status.side_effect = itertools.chain(
+            (
+                _running,
+                _running,
+            ),
+            itertools.repeat(DEFAULT),
+        )
+
         # got getting task run artifacts
         runtime.get_available_outputs.return_value = {
             "task_run1": "woohoo!",
@@ -151,10 +154,28 @@ class TestWorkflowRun:
         }
         # Get logs, the runtime interface returns invocation IDs
         runtime.get_full_logs.return_value = {
-            "task_invocation1": ["woohoo!\n"],
-            "task_invocation2": ["another\n", "line\n"],
-            "task_invocation3": ["hello\n", "a log\n"],
+            "task_run1": ["woohoo!\n"],
+            "task_run2": ["another\n", "line\n"],
+            "task_run3": ["hello\n", "a log\n"],
         }
+        _running.task_runs = [
+            TaskRun(
+                id="task_run1",
+                invocation_id="task_invocation1",
+                status=RunStatus(state=State.SUCCEEDED),
+            ),
+            TaskRun(
+                id="task_run2",
+                invocation_id="task_invocation2",
+                status=RunStatus(state=State.FAILED),
+            ),
+            TaskRun(
+                id="task_run3",
+                invocation_id="task_invocation3",
+                status=RunStatus(state=State.FAILED),
+            ),
+        ]
+
         return runtime
 
     @staticmethod
@@ -580,22 +601,22 @@ class TestWorkflowRun:
             # Given
             run.start()
             # When
-            logs = run.get_logs(tasks=["task_run1"])
+            logs = run.get_logs(tasks=["task_invocation1"])
             # Then
             assert len(logs) == 1
-            assert "task_run1" in logs
-            assert len(logs["task_run1"]) == 1
-            assert logs["task_run1"][0] == "woohoo!\n"
+            assert "task_invocation1" in logs
+            assert len(logs["task_invocation1"]) == 1
+            assert logs["task_invocation1"][0] == "woohoo!\n"
 
         @staticmethod
         def test_get_logs_str(run):
             # Given
             run.start()
             # When
-            logs = run.get_logs(tasks="task_run1")
+            logs = run.get_logs(tasks="task_invocation1")
             # Then
             assert len(logs) == 1
-            assert "task_run1" in logs
+            assert "task_invocation1" in logs
 
         @staticmethod
         def test_get_logs_missing_only_available_false(run, mock_runtime):
@@ -604,7 +625,7 @@ class TestWorkflowRun:
             run.start()
             # When
             with pytest.raises(TaskRunNotFound) as exc_info:
-                _ = run.get_logs(tasks=["task_run1", "doesn't exist"])
+                _ = run.get_logs(tasks=["task_invocation1", "doesn't exist"])
             # Then
             assert exc_info.match("Task run with id `.*` not found")
 
@@ -615,11 +636,11 @@ class TestWorkflowRun:
             run.start()
             # When
             logs = run.get_logs(
-                tasks=["task_run1", "doesn't exist"], only_available=True
+                tasks=["task_invocation1", "doesn't exist"], only_available=True
             )
             # Then
             assert len(logs) == 1
-            assert "task_run1" in logs
+            assert "task_invocation1" in logs
             assert "doesn't exist" not in logs
 
     class TestGetConfig:


### PR DESCRIPTION
# The problem

User needs to have CLI command to get logs for individual task

# This PR's solution

Create dorq task logs command.
Also refactor API function get_logs as it was inconsistent with other commands

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
