### PR TITLE
internal: fix all the warnings!

### DIFF
--- a/docs/examples/tests/test_local_ray.py
+++ b/docs/examples/tests/test_local_ray.py
@@ -66,7 +66,7 @@ class TestSnippets:
     @staticmethod
     @pytest.mark.dependency()
     # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-    # unraisable exceptions. Last tested with Ray 2.0.1.
+    # unraisable exceptions. Last tested with Ray 2.2.0.
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_execute_workflow(change_test_dir, shared_ray_conn, change_db_location):
         # Given
@@ -91,7 +91,7 @@ class TestSnippets:
     @staticmethod
     @pytest.mark.dependency(depends=["TestSnippets::test_execute_workflow"])
     # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-    # unraisable exceptions. Last tested with Ray 2.0.1.
+    # unraisable exceptions. Last tested with Ray 2.2.0.
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_get_results(change_test_dir, shared_ray_conn, change_db_location):
         # Given

--- a/docs/examples/tests/test_local_ray.py
+++ b/docs/examples/tests/test_local_ray.py
@@ -65,6 +65,9 @@ class TestSnippets:
 
     @staticmethod
     @pytest.mark.dependency()
+    # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+    # unraisable exceptions. Last tested with Ray 2.0.1.
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_execute_workflow(change_test_dir, shared_ray_conn, change_db_location):
         # Given
 
@@ -87,6 +90,9 @@ class TestSnippets:
 
     @staticmethod
     @pytest.mark.dependency(depends=["TestSnippets::test_execute_workflow"])
+    # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+    # unraisable exceptions. Last tested with Ray 2.0.1.
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_get_results(change_test_dir, shared_ray_conn, change_db_location):
         # Given
 

--- a/docs/examples/tests/test_parametrized_workflows.py
+++ b/docs/examples/tests/test_parametrized_workflows.py
@@ -87,6 +87,9 @@ class TestSnippets:
 
     @staticmethod
     @pytest.mark.dependency()
+    # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+    # unraisable exceptions. Last tested with Ray 2.0.1.
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_execute_workflow(change_test_dir, shared_ray_conn, change_db_location):
         # Given
         # Prepare the project dir: 'workflow_defs.py' and 'script.py' files
@@ -130,6 +133,9 @@ class TestSnippets:
         assert "(3,)" in std_out
 
     @staticmethod
+    # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+    # unraisable exceptions. Last tested with Ray 2.0.1.
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_execute_multiple_workflows(
         change_test_dir, shared_ray_conn, change_db_location
     ):

--- a/docs/examples/tests/test_parametrized_workflows.py
+++ b/docs/examples/tests/test_parametrized_workflows.py
@@ -88,7 +88,7 @@ class TestSnippets:
     @staticmethod
     @pytest.mark.dependency()
     # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-    # unraisable exceptions. Last tested with Ray 2.0.1.
+    # unraisable exceptions. Last tested with Ray 2.2.0.
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_execute_workflow(change_test_dir, shared_ray_conn, change_db_location):
         # Given
@@ -134,7 +134,7 @@ class TestSnippets:
 
     @staticmethod
     # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-    # unraisable exceptions. Last tested with Ray 2.0.1.
+    # unraisable exceptions. Last tested with Ray 2.2.0.
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_execute_multiple_workflows(
         change_test_dir, shared_ray_conn, change_db_location

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,6 @@ markers =
    needs_separate_project: tests that need setting up a separate project repo and 'orq' configuration before running. Aren't ran on the CI.
    host_only: Tests that don't work in the dev container used by Orquestra Studio
    slow: Tests that take long time to run locally. Skipped by 'make test-fast'.
+# By default, treat warnings as errors
+filterwarnings =
+    error

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
@@ -3,11 +3,17 @@
 ################################################################################
 
 import typing as t
+import warnings
 from typing import overload
 
-import inquirer  # type: ignore
-
 from orquestra.sdk import exceptions
+
+# One of our transitive dependencies shows DeprecationWarnings related to invalid usage
+# of distutils. There's nothing we can do about it, so until it's fixed upstream we can
+# safely ignore it. See: https://github.com/fmoo/python-editor/issues/35
+warnings.filterwarnings("ignore", module="editor")
+
+import inquirer  # type: ignore # noqa
 
 SINGLE_INPUT = "single_input"
 

--- a/tests/runtime/api/test_api_with_ray.py
+++ b/tests/runtime/api/test_api_with_ray.py
@@ -42,6 +42,9 @@ class TestRunningLocalInBackground:
 
     class TestTwoStepForm:
         @staticmethod
+        # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+        # unraisable exceptions. Last tested with Ray 2.0.1.
+        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_single_run(
             patch_config_location, ray, monkeypatch, tmp_path, mock_workflow_db_location
         ):
@@ -87,6 +90,9 @@ class TestRunningLocalInBackground:
 
     class TestReconnectToPreviousRun:
         @staticmethod
+        # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+        # unraisable exceptions. Last tested with Ray 2.0.1.
+        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_custom_save_locations(
             patch_config_location,
             ray,

--- a/tests/runtime/api/test_api_with_ray.py
+++ b/tests/runtime/api/test_api_with_ray.py
@@ -43,7 +43,7 @@ class TestRunningLocalInBackground:
     class TestTwoStepForm:
         @staticmethod
         # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-        # unraisable exceptions. Last tested with Ray 2.0.1.
+        # unraisable exceptions. Last tested with Ray 2.2.0.
         @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_single_run(
             patch_config_location, ray, monkeypatch, tmp_path, mock_workflow_db_location
@@ -91,7 +91,7 @@ class TestRunningLocalInBackground:
     class TestReconnectToPreviousRun:
         @staticmethod
         # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-        # unraisable exceptions. Last tested with Ray 2.0.1.
+        # unraisable exceptions. Last tested with Ray 2.2.0.
         @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_custom_save_locations(
             patch_config_location,

--- a/tests/runtime/corq/test_cli.py
+++ b/tests/runtime/corq/test_cli.py
@@ -219,7 +219,9 @@ class TestDirtyGitRepo:
             force=True,
         )
 
-        result = action.orq_submit_workflow_def(args)
+        with pytest.warns(exceptions.DirtyGitRepo):
+            result = action.orq_submit_workflow_def(args)
+
         assert isinstance(result, SubmitWorkflowDefResponse)
         assert "mocked ID" in [run.id for run in result.workflow_runs]
 

--- a/tests/runtime/corq/test_cli_with_ray.py
+++ b/tests/runtime/corq/test_cli_with_ray.py
@@ -100,7 +100,7 @@ class TestCLIWithRay:
     """
 
     # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-    # unraisable exceptions. Last tested with Ray 2.0.1.
+    # unraisable exceptions. Last tested with Ray 2.2.0.
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_submit_v2_workflow(self, setup_ray, mock_workflow_db_location):
         args = argparse.Namespace(
@@ -1078,7 +1078,7 @@ class TestCLIWithRayFailures:
         )
 
     # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-    # unraisable exceptions. Last tested with Ray 2.0.1.
+    # unraisable exceptions. Last tested with Ray 2.2.0.
     @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     def test_ray_connection_failure(self, tmp_path, monkeypatch, capsys, patch_config):
         tell_tale = "Testing Ray Failure"

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -73,7 +73,7 @@ class TestRayRuntimeMethods:
         """
 
         # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-        # unraisable exceptions. Last tested with Ray 2.0.1.
+        # unraisable exceptions. Last tested with Ray 2.2.0.
         @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_running_same_workflow_def_twice(self, runtime: _dag.RayRuntime):
             wf_def = _example_wfs.multioutput_wf.model
@@ -663,7 +663,7 @@ class TestDirectRayReader:
 
 @pytest.mark.slow
 # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-# unraisable exceptions. Last tested with Ray 2.0.1.
+# unraisable exceptions. Last tested with Ray 2.2.0.
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_task_code_unavailable_at_building_dag(runtime: _dag.RayRuntime):
     """

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -72,6 +72,9 @@ class TestRayRuntimeMethods:
         Tests that validate .create_workflow_run().
         """
 
+        # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+        # unraisable exceptions. Last tested with Ray 2.0.1.
+        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_running_same_workflow_def_twice(self, runtime: _dag.RayRuntime):
             wf_def = _example_wfs.multioutput_wf.model
             run_id1 = runtime.create_workflow_run(wf_def)
@@ -659,6 +662,9 @@ class TestDirectRayReader:
 
 
 @pytest.mark.slow
+# Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+# unraisable exceptions. Last tested with Ray 2.0.1.
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_task_code_unavailable_at_building_dag(runtime: _dag.RayRuntime):
     """
     Verifies that the task code is required only at the task-execution time, and it is

--- a/tests/sdk/v2/data/complex_serialization/workflow_defs.py
+++ b/tests/sdk/v2/data/complex_serialization/workflow_defs.py
@@ -52,7 +52,7 @@ def invoke_callables(fns: t.List[t.Callable]) -> t.List[t.Any]:
     return [fn() for fn in fns]
 
 
-@sdk.task
+@sdk.task(n_outputs=1)
 def generate_simple_callable(num: int = 1) -> t.Callable:
     def _inner():
         return 42 + num
@@ -60,7 +60,7 @@ def generate_simple_callable(num: int = 1) -> t.Callable:
     return _inner
 
 
-@sdk.task
+@sdk.task(n_outputs=2)
 def generate_simple_callables(num: int = 1) -> t.List[t.Callable]:
     def _inner_1():
         return 42 + num

--- a/tests/sdk/v2/test_artifact_future_methods.py
+++ b/tests/sdk/v2/test_artifact_future_methods.py
@@ -7,6 +7,7 @@ import pytest
 
 import orquestra.sdk as sdk
 from orquestra.sdk import exceptions
+from orquestra.sdk._base import _workflow
 from orquestra.sdk._base._dsl import DEFAULT_IMAGE
 
 resources_no_default = {
@@ -175,8 +176,12 @@ class TestArifactFutureMethodsCalls:
         """Check the proper formatting of the workflow syntax error
         associated to calling a task that is a method of an object
         """
+        with pytest.warns(_workflow.NotATaskWarning):
+            wf_def = wf_with_method_task()
+
         with pytest.raises(exceptions.WorkflowSyntaxError) as excinfo:
-            wf_with_method_task().model
+            wf_def.model
+
         print(str(excinfo.value))
 
         error_message = [
@@ -191,8 +196,12 @@ class TestArifactFutureMethodsCalls:
         """Check the proper formatting of the workflow syntax error
         associated to calling a task that is a method of an object
         """
+        with pytest.warns(_workflow.NotATaskWarning):
+            wf_def = wf_with_mixed_calls()
+
         with pytest.raises(exceptions.WorkflowSyntaxError) as excinfo:
-            wf_with_mixed_calls().model
+            wf_def.model
+
         error_message = [
             "The task get_id seems to be a method, if so modify it to not be a method.",
             "Error message: missing a required argument: 'self'",

--- a/tests/sdk/v2/test_ast.py
+++ b/tests/sdk/v2/test_ast.py
@@ -8,7 +8,7 @@ from types import FunctionType
 import numpy as np
 import pytest
 
-from orquestra.sdk._base import _ast
+from orquestra.sdk._base import _ast, _workflow
 
 from .test_artifact_future_methods import (
     ObjWithTask,
@@ -171,8 +171,12 @@ class TestCallVisitor:
     @staticmethod
     def test_identify_calls_from_workflow_function():
         """Test the identification of calls using the AST of the workflow function"""
-        assert isinstance(wf_with_mixed_calls()._fn, FunctionType)
-        source = inspect.getsource(wf_with_mixed_calls()._fn)
+        with pytest.warns(_workflow.NotATaskWarning):
+            fn = wf_with_mixed_calls()._fn
+
+        assert isinstance(fn, FunctionType)
+        source = inspect.getsource(fn)
+
         fn_body = ast.parse(_ast.normalize_indents(source))
         visitor = _ast.CallVisitor()
         visitor.visit(fn_body)

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -455,7 +455,9 @@ def test_deferred_git_import_resolved_detached_head(my_fake_repo_setup):
     # Detach HEAD
     my_fake_repo.head.reference = my_fake_repo.commit("HEAD~0")
 
-    resolved = _dsl.DeferredGitImport(my_fake_repo.working_dir).resolved()
+    with pytest.warns(UserWarning):
+        resolved = _dsl.DeferredGitImport(my_fake_repo.working_dir).resolved()
+
     assert resolved.git_ref == my_fake_repo.head.object.hexsha
 
 


### PR DESCRIPTION
# The problem

Our test suite printed a lot of warnings. This made it difficult to see which warnings were expected.

# This PR's solution

* Marks the expected warnings as `pytest.warns()`.
* Works around the warnings caused by 3rd-party libraries.

Let's merge https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/25 before this one.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
