### PR TITLE
feat!: return all logs from WorkflowRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,25 @@
 ## Unreleased
 
 🚨 *Breaking Changes*
-* `sdk.WorkflowRun.get_logs()` now accepts TaskInvocationID instead of TaskRunID
+* `sdk.WorkflowRun.get_logs()` doesn't accept any arguments anymore. Now, it returns all the logs produced by the tasks in the workflow. If you're interested in only a subset of your workflow's logs, please consider using one of the following filtering options:
+```
+from orquestra import sdk
+from orquestra.sdk.schema.workflow_run import State
+
+wf_run = sdk.WorkflowRun.by_id("foo")
+
+logs = wf_run.get_logs()
+# Option 1
+single_task_logs = logs["my_inv_id"]
+
+# Option 2
+logs_subset = {id: lines for id, lines in logs.items() if id in ["foo", "bar", "baz"]}
+
+# Option 3
+for task in wf_run.get_tasks():
+    if task.get_status() == State.FAILED:
+        print(task.get_logs())
+```
 * `sdk.WorkflowRun.get_artifacts()` doesn't accept any arguments anymore. Now, it returns all the artifacts produced by the tasks in the workflow.
 * `sdk.TaskRun.get_logs()` returns a list of log lines produced by this task. Previously, it returned a dictionary with one entry.
 

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -35,7 +35,6 @@ from orquestra.sdk.schema.workflow_run import WorkflowRunId
 from ..exceptions import (
     ConfigFileNotFoundError,
     ConfigNameNotFoundError,
-    NotFoundError,
     RuntimeConfigError,
     TaskRunNotFound,
     UnauthorizedError,
@@ -612,7 +611,7 @@ class WorkflowRun:
         except WorkflowRunNotSucceeded:
             raise
 
-    def get_artifacts(self) -> t.Dict[ir.TaskInvocationId, t.Any]:
+    def get_artifacts(self) -> t.Mapping[ir.TaskInvocationId, t.Any]:
         """
         Unstable: this API will change.
 
@@ -644,45 +643,29 @@ class WorkflowRun:
 
         # The runtime always returns tuples, even of the task has n_outputs = 1. We
         # need to unwrap it for user's convenience.
-        unwrapped_artifacts: t.Dict[ir.TaskInvocationId, t.Any] = {}
-        for inv_id, outputs in workflow_artifacts.items():
-            inv = self._wf_def.task_invocations[inv_id]
-            if len(inv.output_ids) == 1:
-                unwrapped = outputs[0]
-            else:
-                unwrapped = outputs
+        return _unwrap(
+            artifacts=workflow_artifacts, task_invocations=self._wf_def.task_invocations
+        )
 
-            unwrapped_artifacts[inv_id] = unwrapped
-
-        return unwrapped_artifacts
-
-    def get_logs(
-        self,
-        tasks: t.Union[TaskInvocationId, t.List[TaskInvocationId]],
-        *,
-        only_available: bool = False,
-    ) -> t.Dict[TaskInvocationId, t.List[str]]:
+    def get_logs(self) -> t.Mapping[TaskInvocationId, t.List[str]]:
         """
         Unstable: this API will change.
 
-        Returns the task run logs from a workflow.
-        Args:
-            tasks: A task invocation ID or a list of task invocation IDs to return.
-                   An empty list implies no task logs.
-            only_available: If true, logs for tasks that haven't been started yet won't
-                            be returned. If false, and `tasks` contain IDs of task runs
-                            that haven't been started yet, this will raise an error.
+        Returns logs produced by all task runs in this workflow. If you're interested in
+        only subset of tasks, consider using ``WorkflowRun.get_tasks()`` and
+        ``TaskRun.get_logs()``.
+
         Raises:
             WorkflowRunNotStarted: when the workflow has not started
-            TaskRunNotFound: when only_available is False and a requested task run
-                            cannot be found, either because it does not exist or has not
-                            been completed yet.
+
         Returns:
-            A dictionary of the task run logs with the shape::
-                task_invocation_id: List[log lines]
+            A dictionary where each key-value entry correponds to a single task run.
+            The key identifies a task invocation, a single node in the workflow graph.
+            The value is a list of log lines produced by the corresponding task
+            invocation while running this workflow.
         """
         try:
-            _ = self.run_id
+            wf_run_id = self.run_id
         except WorkflowRunNotStarted as e:
             message = (
                 "Cannot get the logs of a workflow run that hasn't started yet. "
@@ -691,33 +674,7 @@ class WorkflowRun:
             )
             raise WorkflowRunNotStarted(message) from e
 
-        task_list = [tasks] if isinstance(tasks, str) else tasks
-        task_logs: t.Dict[TaskInvocationId, t.List[str]] = {}
-
-        for task_inv_id in task_list:
-            all_task_runs = self.get_status_model().task_runs
-            # find taskRunID based on task invocation ID
-            try:
-                # Get a single task run logs
-                # Unfortunately, we return TaskInvocationId: List[str] from
-                # get_full_logs. so we do this hack to get the first value from the dict
-                # which (in this case) the task logs for the task_run_id.
-                task_run_id = next(
-                    task.id
-                    for task in all_task_runs
-                    if task.invocation_id == task_inv_id
-                )
-                task_logs[task_inv_id] = next(
-                    iter(self._runtime.get_full_logs(task_run_id).values())
-                )
-            except (NotFoundError, StopIteration) as e:
-                if only_available:
-                    continue
-                else:
-                    raise TaskRunNotFound(
-                        f"Task run with id `{task_run_id}` not found. "
-                        "It may not be completed or does not exist in this WorkflowRun."
-                    ) from e
+        task_logs = self._runtime.get_full_logs(wf_run_id)
 
         return task_logs
 

--- a/src/orquestra/sdk/_base/_api.py
+++ b/src/orquestra/sdk/_base/_api.py
@@ -41,6 +41,7 @@ from ..exceptions import (
     UnsavedConfigChangesError,
     WorkflowRunCanNotBeTerminated,
     WorkflowRunNotFinished,
+    WorkflowRunNotFoundError,
     WorkflowRunNotStarted,
     WorkflowRunNotSucceeded,
 )
@@ -154,7 +155,16 @@ class TaskRun:
 
     def get_logs(self) -> t.List[str]:
         logs_dict = self._runtime.get_full_logs(self.task_run_id)
-        return logs_dict[self.task_invocation_id]
+        # NOTE: the line below will fail for Ray-produced logs until
+        # https://zapatacomputing.atlassian.net/browse/ORQSDK-676 is fixed.
+        # However, this is a bug, so we don't describe this exception in this method's
+        # signature, nor the functions that wrap it.
+        try:
+            return logs_dict[self.task_invocation_id]
+        except KeyError as e:
+            raise NotImplementedError(
+                "Reading single task logs isn't supported yet for this runtime."
+            ) from e
 
     def get_outputs(self) -> t.Any:
         """
@@ -327,6 +337,11 @@ class WorkflowRun:
 
     @staticmethod
     def _get_stored_run(_project_dir: Path, run_id: WorkflowRunId) -> StoredWorkflowRun:
+        """
+        Raises:
+            orquestra.sdk.exceptions.WorkflowNotFoundError: raised when no matching
+            workflow exists in the database.
+        """
         from orquestra.sdk._base._db import WorkflowDB
 
         # Get the run details from the database. Extracted from by_id method
@@ -356,11 +371,14 @@ class WorkflowRun:
                 saved. If omitted, the default config file path is used.
 
         Raises:
-            NotFoundError: when the run_id doesn't match a stored run ID.
-            ConfigNameNotFoundError: when the named config is not found in the file.
-
-        Returns:
-            WorkflowRun
+            orquestra.sdk.exceptions.WorkflowRunNotFoundError: when the run_id doesn't
+                match a stored run ID.
+            orquestra.sdk.exceptions.UnauthorizedError: when authorization with the
+                remote runtime failed.
+            orquestra.sdk.exceptions.ConfigFileNotFoundError: when the config file
+                couldn't be read
+            orquestra.sdk.exceptions.ConfigNameNotFoundError: when there's no
+                corresponding config entry in the config file.
         """
         _project_dir = Path(project_dir or Path.cwd())
 
@@ -370,10 +388,17 @@ class WorkflowRun:
             # Shorthand: use the cached value.
             # We need to read the config name from the local DB and load the config
             # entry.
-            stored_run = cls._get_stored_run(_project_dir, run_id)
-            resolved_config = RuntimeConfig.load(
-                stored_run.config_name, config_save_file=config_save_file
-            )
+            try:
+                stored_run = cls._get_stored_run(_project_dir, run_id)
+            except WorkflowRunNotFoundError:
+                raise
+
+            try:
+                resolved_config = RuntimeConfig.load(
+                    stored_run.config_name, config_save_file=config_save_file
+                )
+            except (ConfigFileNotFoundError, ConfigNameNotFoundError):
+                raise
         else:
             resolved_config = _resolve_config(config, config_save_file)
 
@@ -384,13 +409,16 @@ class WorkflowRun:
         # - QE probably won't have endpoints for this, but the single-user limitation
         #   will be an implementation detail of `QERuntime`.
         runtime = resolved_config._get_runtime(_project_dir)
-        wf_def = runtime.get_workflow_run_status(run_id).workflow_def
+        try:
+            wf_run_model = runtime.get_workflow_run_status(run_id)
+        except (UnauthorizedError, WorkflowRunNotFoundError):
+            raise
 
         workflow_run = WorkflowRun(
-            run_id,
-            wf_def,
-            runtime,
-            resolved_config,
+            run_id=run_id,
+            wf_def=wf_run_model.workflow_def,
+            runtime=runtime,
+            config=resolved_config,
         )
 
         return workflow_run
@@ -1167,6 +1195,10 @@ class RuntimeConfig:
             config_name: The name of the configuration to be loaded.
             config_save_file (optional): The path to the file in which configurations
                 are stored. If omitted, the default file location is used.
+
+        Raises:
+            orquestra.sdk.exceptions.ConfigFileNotFoundError
+            orquestra.sdk.exceptions.ConfigNameNotFoundError
 
         Returns:
             RuntimeConfig: The configuration as loaded from the file.

--- a/src/orquestra/sdk/_base/cli/_dorq/_dumpers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_dumpers.py
@@ -84,7 +84,7 @@ class LogsDumper:
 
     def dump(
         self,
-        logs: t.Dict[TaskInvocationId, t.List[str]],
+        logs: t.Mapping[TaskInvocationId, t.Sequence[str]],
         wf_run_id: WorkflowRunId,
         dir_path: Path,
     ) -> Path:

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -335,15 +335,15 @@ class WorkflowRunRepo:
     ) -> t.Mapping[TaskInvocationId, t.Sequence[str]]:
         """
         Raises:
-            orquestra.sdk.exceptions.NotFoundError: when the wf_run_id doesn't match a
-                stored run ID.
-            orquestra.sdk.exceptions.ConfigNameNotFoundError: when the named config is
-                not found in the file.
+            orquestra.sdk.exceptions.WorkflowRunNotFoundError
+            orquestra.sdk.exceptions.ConfigmeNotFoundError
+            orquestra.sdk.exceptions.ConfigNameNotFoundError
         """
         try:
             wf_run = sdk.WorkflowRun.by_id(wf_run_id, config_name)
         except (
             exceptions.NotFoundError,
+            exceptions.ConfigFileNotFoundError,
             exceptions.ConfigNameNotFoundError,
         ):
             raise
@@ -356,7 +356,6 @@ class WorkflowRunRepo:
         except StopIteration as e:
             raise exceptions.TaskInvocationNotFoundError(task_inv_id) from e
 
-        # TODO: handle and document exceptions
         log_lines = task_run.get_logs()
 
         # Single k-v dict might seem weird but Using the same data shape for single

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -10,13 +10,12 @@ import sys
 import typing
 import typing as t
 import warnings
-from pathlib import Path
 
 import requests
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import _config, _db, _factory, loader
+from orquestra.sdk._base import _config, _db, loader
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._qe import _client
 from orquestra.sdk._base.abc import ArtifactValue
@@ -306,47 +305,65 @@ class WorkflowRunRepo:
 
         return matching_inv_ids
 
-    def get_wf_logs(self, wf_run_id: WorkflowRunId, config_name: ConfigName):
+    def get_wf_logs(
+        self, wf_run_id: WorkflowRunId, config_name: ConfigName
+    ) -> t.Mapping[TaskInvocationId, t.Sequence[str]]:
         """
-        Asks the runtime for workflow logs
-
         Raises:
             ConnectionError: when connection with Ray failed.
             orquestra.sdk.exceptions.UnauthorizedError: when connection with runtime
                 failed because of an auth error.
         """
-        # TODO ORQSDK-574: Switch to single api call when its possible for whole WF
-        runtime_configuration = _config.read_config(config_name)
-        project_dir = Path.cwd()
-
-        runtime = _factory.build_runtime_from_config(
-            project_dir=project_dir, config=runtime_configuration
-        )
-
-        try:
-            logs = runtime.get_full_logs(wf_run_id)
-        except (ConnectionError, exceptions.UnauthorizedError):
-            raise
-
-        return logs
-
-    def get_task_logs(
-        self,
-        wf_run_id: WorkflowRunId,
-        task_inv_id: TaskInvocationId,
-        config_name: ConfigName,
-    ):
         try:
             wf_run = sdk.WorkflowRun.by_id(wf_run_id, config_name)
         except (exceptions.NotFoundError, exceptions.ConfigNameNotFoundError):
             raise
 
         try:
-            logs = wf_run.get_logs(tasks=task_inv_id)
-        except (exceptions.WorkflowRunNotStarted, exceptions.TaskRunNotFound):
+            # While this method can also raise WorkflowRunNotStarted error we don't ever
+            # expect it to happen, because we're getting workflow run by ID. Workflows
+            # get their IDs at the start time.
+            return wf_run.get_logs()
+        except (ConnectionError, exceptions.UnauthorizedError):
             raise
 
-        return logs
+    def get_task_logs(
+        self,
+        wf_run_id: WorkflowRunId,
+        task_inv_id: TaskInvocationId,
+        config_name: ConfigName,
+    ) -> t.Mapping[TaskInvocationId, t.Sequence[str]]:
+        """
+        Raises:
+            orquestra.sdk.exceptions.NotFoundError: when the wf_run_id doesn't match a
+                stored run ID.
+            orquestra.sdk.exceptions.ConfigNameNotFoundError: when the named config is
+                not found in the file.
+        """
+        try:
+            wf_run = sdk.WorkflowRun.by_id(wf_run_id, config_name)
+        except (
+            exceptions.NotFoundError,
+            exceptions.ConfigNameNotFoundError,
+        ):
+            raise
+
+        task_runs = wf_run.get_tasks()
+        try:
+            task_run: sdk.TaskRun = _find_first(
+                lambda task: task.task_invocation_id == task_inv_id, task_runs
+            )
+        except StopIteration as e:
+            raise exceptions.TaskInvocationNotFoundError(task_inv_id) from e
+
+        # TODO: handle and document exceptions
+        log_lines = task_run.get_logs()
+
+        # Single k-v dict might seem weird but Using the same data shape for single
+        # task logs and full workflow logs allows easier code sharing.
+        logs_dict = {task_inv_id: log_lines}
+
+        return logs_dict
 
 
 class ConfigRepo:

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -74,14 +74,14 @@ class WrappedCorqOutputPresenter:
         click.echo(f"Workflow logs saved at {path}")
 
     @staticmethod
-    def _format_log_dict(logs: t.Dict[TaskInvocationId, t.List[str]]):
+    def _format_log_dict(logs: t.Mapping[TaskInvocationId, t.Sequence[str]]):
         return [
             line
             for invocation_id, invocation_lines in logs.items()
             for line in (f"task-invocation-id: {invocation_id}", *invocation_lines)
         ]
 
-    def show_logs(self, logs: t.Dict[TaskInvocationId, t.List[str]]):
+    def show_logs(self, logs: t.Mapping[TaskInvocationId, t.Sequence[str]]):
         resp = responses.GetLogsResponse(
             meta=responses.ResponseMetadata(
                 success=True,

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -733,11 +733,15 @@ class RayRuntime(RuntimeInterface):
         return wf_runs
 
     def get_workflow_run_status(self, workflow_run_id: WorkflowRunId) -> WorkflowRun:
+        """
+        Raises:
+            orquestra.sdk.exceptions.WorkflowRunNotFoundError
+        """
         try:
             wf_status = self._client.get_workflow_status(workflow_id=workflow_run_id)
             wf_meta = self._client.get_workflow_metadata(workflow_id=workflow_run_id)
         except (_client.workflow_exceptions.WorkflowNotFoundError, ValueError) as e:
-            raise exceptions.NotFoundError(
+            raise exceptions.WorkflowRunNotFoundError(
                 f"Workflow run {workflow_run_id} wasn't found"
             ) from e
 

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -93,7 +93,7 @@ class _RayLogs:
 
     def get_full_logs(self):
         # This is bad. The key should be a task invocation ID. To be fixed in the Jira
-        # ticket: https://zapatacomputing.atlassian.net/browse/ORQSDK-570
+        # ticket: https://zapatacomputing.atlassian.net/browse/ORQSDK-676
         return {"logs": self._read_log_files()}
 
 


### PR DESCRIPTION
# The problem

* Getting logs for the whole workflow is a common scenario during development.
* Current API required the users to first grab `TaskInvocationId`s from _somewhere_, and only then the user could fetch logs.
* There was no straightforward, nor documented way to get `TaskInvocationId`s of interest.

# This PR's solution

This PR avoids the problem altogether by simplifying the `sdk.WorkflowRun.get_logs()` signature. Now, we no longer require the user to pass any IDs, we just return everything we've got. When the user is interested in logs for only a subset of tasks, they can either get the item by filtering the output on their own:
```python

wf_run = sdk.WorkflowRun.by_id("foo")

logs = wf_run.get_logs()
# Option 1
single_task_logs = logs["my_inv_id"]

# Option 2
logs_subset = {id: lines for id, lines in logs.items() if id in ["foo", "bar", "baz"]}

# Option 3
for task in wf_run.get_tasks():
    if task.get_status() == State.FAILED:
        print(task.get_logs())
```

Bonus points:
* we no longer have to worry about users passing invalid IDs
* we no longer have to document what kind of input we expect, and what are the implications passing `tasks=[]`, `tasks=["invalid_id", "valid_id"]`, etc.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
