### PR TITLE
feat: convert structured ray logs to plain text when reading.

### DIFF
--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -111,7 +111,7 @@ class _RayLogs:
                 log = self._load_structured_log_record(line)
             else:
                 log = self._load_unstructured_log_record(line)
-            return LINE_FORMAT.format(log=log)
+            return LINE_FORMAT.format(log=log).replace("[]", "").strip()
 
     def _read_log_files(self):
         lines = []

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -5,6 +5,7 @@
 Class to get logs from Ray for particular Workflow, both historical and live.
 """
 import glob
+import json
 import os
 import time
 import typing as t
@@ -64,6 +65,18 @@ class _RayLogs:
         elif (
             self.workflow_or_task_run_id is None
         ) or self.workflow_or_task_run_id in line:
+            try:
+                data = json.loads(line)
+                _line = "{timestamp} {level} {filename} -- {message}	[{run_id}]".format(
+                    timestamp=data["timestamp"],
+                    level=data["level"],
+                    filename=data["filename"],
+                    message=data["message"]["logs"],
+                    run_id=data["message"]["run_id"],
+                )
+                line = _line
+            except json.decoder.JSONDecodeError:
+                return line
             return line
 
     def _read_log_files(self):

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -88,6 +88,10 @@ class _RayLogs:
                 "}",
                 record,
             )
+
+            if m is None:
+                return
+
             data = {
                 "timestamp": m.group("timestamp"),
                 "level": m.group("level"),
@@ -105,7 +109,7 @@ class _RayLogs:
             message=LogMessage(data["message"]["run_id"], data["message"]["logs"]),
         )
 
-    def _load_unstructured_log_record(self, record: str) -> StructuredLog:
+    def _load_unstructured_log_record(self, record: str):
         """
         Read in a plain-text log record and convert to a StructuredLog object.
 


### PR DESCRIPTION
[ORQSDK-677]

# The problem

Ray logs are a mix of plain text (as output by Ray) and structured logs (as output by us). 

# This PR's solution

When reading ray logs, we check for lines that are parseable as json (indicating that they're structured) and convert them into plain text. 

This PR is a bare-minimum solution to the problem to serve as a fallback if other, preferable approaches prove impractical. 

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`


[ORQSDK-677]: https://zapatacomputing.atlassian.net/browse/ORQSDK-677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ