### PR TITLE
Revert "Feat: Bump ray to 2.2"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 🔥 *Features*
 
 * `list_workflow_runs` added to the Public API. This lets you list the workflows for a given config, for example `sdk.list_workflow_runs("ray")` or `sdk.list_workflow_runs("prod-d")`.
-* Upgrade Ray version to 2.2
+
 
 👩‍🔬 *Experimental*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,7 +67,7 @@ where = src
 
 [options.extras_require]
 ray =
-    ray[default]==2.2.0
+    ray[default]==2.0.1
     # Ray 2.0.0 requires pyarrow but it's missing from their requirements.
     pyarrow
     python_on_whales

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -158,7 +158,6 @@ def _make_ray_dag_node(
     ray_kwargs: t.Mapping[str, t.Any],
     pos_unpack_specs: t.Sequence[PosArgUnpackSpec],
     kw_unpack_specs: t.Sequence[KwArgUnpackSpec],
-    project_dir: t.Optional[Path],
     user_fn_ref: t.Optional[ir.FunctionRef] = None,
 ) -> _client.FunctionNode:
     """
@@ -180,9 +179,6 @@ def _make_ray_dag_node(
 
     @client.remote
     def _ray_remote(*inner_args, **inner_kwargs):
-        if project_dir is not None:
-            dispatch.ensure_sys_paths([str(project_dir)])
-
         user_fn = _locate_user_fn(user_fn_ref) if user_fn_ref else _aggregate_outputs
         wrapped = TupleUnwrapper(
             fn=user_fn,
@@ -314,9 +310,7 @@ def _gather_kwargs(
     return ray_kwargs, kw_unpack_specs
 
 
-def _make_ray_dag(
-    client: RayClient, wf: ir.WorkflowDef, wf_run_id: str, project_dir: Path
-):
+def _make_ray_dag(client: RayClient, wf: ir.WorkflowDef, wf_run_id: str):
     ray_consts: t.Mapping[ir.ConstantNodeId, t.Any] = {
         id: serde.deserialize_constant(node) for id, node in wf.constant_nodes.items()
     }
@@ -374,7 +368,6 @@ def _make_ray_dag(
             ray_kwargs=ray_kwargs,
             pos_unpack_specs=pos_unpack_specs,
             kw_unpack_specs=kw_unpack_specs,
-            project_dir=project_dir,
         )
 
         for output_id in ir_invocation.output_ids:
@@ -402,7 +395,6 @@ def _make_ray_dag(
         ray_kwargs={},
         pos_unpack_specs=aggr_task_specs,
         kw_unpack_specs=[],
-        project_dir=None,
     )
 
     # Data aggregation step is run with catch_exceptions=True - so it returns tuple of
@@ -692,18 +684,31 @@ class RayRuntime(RuntimeInterface):
     def create_workflow_run(self, workflow_def: ir.WorkflowDef) -> WorkflowRunId:
         wf_run_id = _generate_wf_run_id(workflow_def)
 
-        dag = _make_ray_dag(self._client, workflow_def, wf_run_id, self._project_dir)
-        wf_user_metadata: WfUserMetadata = {
-            "workflow_def": _pydatic_to_json_dict(workflow_def),
-        }
+        # This is huge workaround for the issue:
+        # https://github.com/ray-project/ray/issues/29253
+        # where workflow fails if interpreter calling it exits before all the tasks
+        # are scheduled. It works properly when WF is created from ray.remote worker
+        @self._client.remote
+        def create_ray_workflow():
+            # adding path to the sys_path, so we can de-ref functions in workflow_defs
+            dispatch.ensure_sys_paths([str(self._project_dir)])
+            dag = _make_ray_dag(self._client, workflow_def, wf_run_id)
+            wf_user_metadata: WfUserMetadata = {
+                "workflow_def": _pydatic_to_json_dict(workflow_def),
+            }
 
-        # Unfortunately, Ray doesn't validate uniqueness of workflow IDs. Let's
-        # hope we won't get a collision.
-        _ = self._client.run_dag_async(
-            dag,
-            workflow_id=wf_run_id,
-            metadata=wf_user_metadata,
-        )
+            # Unfortunately, Ray doesn't validate uniqueness of workflow IDs. Let's
+            # hope we won't get a collision.
+            _ = self._client.run_dag_async(
+                dag,
+                workflow_id=wf_run_id,
+                metadata=wf_user_metadata,
+            )
+
+        # .get blocks for the function to be completed. This is required because:
+        # 1. We need to make sure WF is fully created and submitted into ray
+        # 2. This catch exceptions that happen at submission time (like unknown module)
+        self._client.get(create_ray_workflow.remote())
 
         config_name: str
         config_name = self._config.config_name

--- a/tests/runtime/performance/test_cli_perf.py
+++ b/tests/runtime/performance/test_cli_perf.py
@@ -14,7 +14,6 @@ import json
 import shutil
 import subprocess
 import tempfile
-import time
 import typing as t
 from pathlib import Path
 
@@ -79,32 +78,21 @@ def orq_workflow_run(ray_cluster, orq_project_dir):
     output = _run_orq_command(
         ["submit", "workflow-def", "-d", orq_project_dir, "-o", "json", "-c", "local"]
     )
-
     # Parse the stdout to get the workflow ID
     res = json.loads(output.stdout)
     workflow_id = res["workflow_runs"][0]["id"]
-
-    # Ray seems to not be in-sync with workflow submission. Lets lazily wait for it
-    # to have to workflow submitted. workflow-run-results will wait for it to complete
-    timeout = 10
-    for i in range(timeout):
-        try:
-            _run_orq_command(
-                [
-                    "get",
-                    "workflow-run-results",
-                    workflow_id,
-                    "-d",
-                    orq_project_dir,
-                    "-c",
-                    "local",
-                ]
-            )
-            break
-        except subprocess.CalledProcessError:
-            if i >= timeout:
-                raise
-
+    # Get the results to ensure the job has finished
+    _run_orq_command(
+        [
+            "get",
+            "workflow-run-results",
+            workflow_id,
+            "-d",
+            orq_project_dir,
+            "-c",
+            "local",
+        ]
+    )
     yield workflow_id
 
 


### PR DESCRIPTION
Reverts zapatacomputing/orquestra-workflow-sdk#25

Ray 2.2 upgrade seemed to break our CI - Randomly one of Windows Runners will get stuck in infinite loop