### PR TITLE
refactor!: fix TaskInvocationID vs TaskRunID mismatch in _api.TaskRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 * `sdk.WorkflowRun.get_logs()` now accepts TaskInvocationID instead of TaskRunID
 * `sdk.WorkflowRun.get_artifacts()` doesn't accept any arguments anymore. Now, it returns all the artifacts produced by the tasks in the workflow.
+* `sdk.TaskRun.get_logs()` returns a list of log lines produced by this task. Previously, it returned a dictionary with one entry.
 
 
 🔥 *Features*

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -156,6 +156,9 @@ class RuntimeInterface(ABC):
         artifacts only for the steps that did success. Might raise an exception if
         runtime doesn't support getting artifacts from in-progress workflow.
 
+        Either we have access to all outputs of a given task, or none. In other words,
+        the number of values in the tuple should always match the number of output IDs
+        in the corresponding task invocation.
 
         Careful: This method does NOT return status of a workflow. Verify it beforehand
         to make sure if workflow failed/succeeded/is running. You might get incomplete


### PR DESCRIPTION
# The problem

* `_api.TaskRun` had `task_invocation_id` and `task_run_id` all mixed up. Variables meant to contain invocation IDs containted task run IDs and vice versa.
* `TaskRun`'s routines for getting logs and artifacts weren't consistent with the latest form of `RuntimeInterface`.

# This PR's solution

_Please describe the PR's content. Bonus points for code examples, error messages, screenshots._
* Adds `task_run_id` to `_api.TaskRun`'s init.
* Fixes usage of `task_run_id` and `task_invocation_id`.
* Fixes getting task outputs.

This PR is a refactor pre-requirement for another one that updates `_api.WorkflowRun.get_logs()`.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
