### PR TITLE
fix: Return a single result (as expected) from CERuntime, in a tuple

### DIFF
--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -190,10 +190,8 @@ class CERuntime(RuntimeInterface):
         assert len(result_ids) == 1, "We're currently expecting a single result."
 
         try:
-            return tuple(
-                wf_result = self._client.get_workflow_run_result(result_ids[0])
-                serde.deserialize(wf_result)
-            )
+            wf_result = self._client.get_workflow_run_result(result_ids[0])
+            return tuple(serde.deserialize(wf_result))
         except _exceptions.InvalidTokenError as e:
             raise exceptions.UnauthorizedError(f"{e}") from e
 

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -187,11 +187,10 @@ class CERuntime(RuntimeInterface):
                 wf_run.status.state,
             )
 
+        assert len(result_ids) == 1, "We're currently expecting a single result."
+
         try:
-            return [
-                serde.deserialize(self._client.get_workflow_run_result(result_id))
-                for result_id in result_ids
-            ]
+            return tuple(serde.deserialize(self._client.get_workflow_run_result(result_ids[0])))
         except _exceptions.InvalidTokenError as e:
             raise exceptions.UnauthorizedError(f"{e}") from e
 

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -191,7 +191,8 @@ class CERuntime(RuntimeInterface):
 
         try:
             return tuple(
-                serde.deserialize(self._client.get_workflow_run_result(result_ids[0]))
+                wf_result = self._client.get_workflow_run_result(result_ids[0])
+                serde.deserialize(wf_result)
             )
         except _exceptions.InvalidTokenError as e:
             raise exceptions.UnauthorizedError(f"{e}") from e

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -190,7 +190,9 @@ class CERuntime(RuntimeInterface):
         assert len(result_ids) == 1, "We're currently expecting a single result."
 
         try:
-            return tuple(serde.deserialize(self._client.get_workflow_run_result(result_ids[0])))
+            return tuple(
+                serde.deserialize(self._client.get_workflow_run_result(result_ids[0]))
+            )
         except _exceptions.InvalidTokenError as e:
             raise exceptions.UnauthorizedError(f"{e}") from e
 

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -322,7 +322,7 @@ class TestGetWorkflowRunResultsNonBlocking:
         # Then
         mocked_client.get_workflow_run_results.assert_called_once_with(workflow_run_id)
         mocked_client.get_workflow_run_result.assert_has_calls([call("result_id")])
-        assert results == (1,2)
+        assert results == (1, 2)
 
     class TestGetWorkflowRunResultsFailure:
         def test_bad_workflow_run_id(


### PR DESCRIPTION
# The problem

The CERuntime made an incorrect assumption about the shape of results.

It expected this workflow:

```python
@sdk.workflow
def wf():
    return 1,2,3
```

to return 3 workflow result IDs via the API.

In fact, it returned a single result ID.

This meant, `WorkflowRun.get_results()` could return `[[1,2,3]]` which looks odd.

# This PR's solution

 - Makes an assumption that there is one result per workflow run. This assumption is backed up by an assertion as a guard.
 - Also turns the JSON lists to tuples. Note: this assumes RayRuntime always returns tuples

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
