### PR TITLE
fix: Use realpath to avoid duplicate log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ for task in wf_run.get_tasks():
 * Fixed broken link on docs landing page.
 * Internal logs from Ray are no longer displayed.
 * Fixed the docstrings for `sdk.WorkflowRun.get_artifacts()`. It returns a dictionary with `TaskInvocationID` as keys and whatever the task returns as values.
+* Fixed bug where some log line from Ray may be duplicated when viewing logs
 
 
 *Internal*

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -45,11 +45,12 @@ class _RayLogs:
         path_glob = self.ray_temp / "session**" / "logs" / "worker*[.out|.err]"
         log_file_paths = glob.glob(str(path_glob))
         for file_path in log_file_paths:
-            if os.path.isfile(file_path) and file_path not in self.log_filenames:
-                self.log_filenames.add(file_path)
+            real_path = os.path.realpath(file_path)
+            if os.path.isfile(file_path) and real_path not in self.log_filenames:
+                self.log_filenames.add(real_path)
                 self.log_file_infos.append(
                     _LogFileInfo(
-                        filename=file_path,
+                        filename=real_path,
                         size_when_last_opened=0,
                         file_position=0,
                     )

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -660,12 +660,14 @@ class TestDirectRayReader:
 
         assert tell_tale in log_lines_joined
 
+
 @pytest.mark.slow
 # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
 # unraisable exceptions. Last tested with Ray 2.2.0.
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 def test_ray_direct_reader_no_duplicate_lines(
-    shared_ray_conn, runtime,
+    shared_ray_conn,
+    runtime,
 ):
     """
     This ensures that `session_latest` and `session_<current date>` are not searched
@@ -687,11 +689,14 @@ def test_ray_direct_reader_no_duplicate_lines(
 
     # Then
     # First check for the tell_tale in all log lines
-    matches = [tell_tale in log_line for task_log_lines in logs_dict.values() for log_line in task_log_lines]
+    matches = [
+        tell_tale in log_line
+        for task_log_lines in logs_dict.values()
+        for log_line in task_log_lines
+    ]
 
     # Assert the tell_tale was only found once
     assert matches.count(True) == 1
-
 
 
 @pytest.mark.slow


### PR DESCRIPTION
# The problem

Our Ray logger can display duplicate logs when querying logs from the latest session.

# This PR's solution

Uses `os.path.realpath` to get the actual location of logs within the `session_latest` symlink.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
