### PR TITLE
feat: GitImports in RayRuntime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 🚨 *Breaking Changes*
-* `sdk.WorkflowRun.get_logs()` doesn't accept any arguments anymore. Now, it returns all the logs produced by the tasks in the workflow. If you're interested in only a subset of your workflow's logs, please consider using one of the following filtering options:
+* `sdk.WorkflowRun.get_logs()` doesn't accept any arguments any more. Now, it returns all the logs produced by the tasks in the workflow. If you're interested in only a subset of your workflow's logs, please consider using one of the following filtering options:
 ```
 from orquestra import sdk
 from orquestra.sdk.schema.workflow_run import State
@@ -22,8 +22,9 @@ for task in wf_run.get_tasks():
     if task.get_status() == State.FAILED:
         print(task.get_logs())
 ```
-* `sdk.WorkflowRun.get_artifacts()` doesn't accept any arguments anymore. Now, it returns all the artifacts produced by the tasks in the workflow.
+* `sdk.WorkflowRun.get_artifacts()` doesn't accept any arguments any more. Now, it returns all the artifacts produced by the tasks in the workflow.
 * `sdk.TaskRun.get_logs()` returns a list of log lines produced by this task. Previously, it returned a dictionary with one entry.
+* Executing a workflow on Ray with Git imports will now install them. A known limition is that this will only work for Git repositories that are Python packages and will fail for Git repositories that are not Python packages.
 
 
 🔥 *Features*

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -57,6 +57,14 @@ def task_with_import():
     return 2
 
 
+@sdk.task(dependency_imports=[sdk.GithubImport("alexjuda/piccup")])
+def task_with_git_import():
+    import piccup  # type: ignore # noqa
+
+    # return whatever - make sure it just doesnt assert on import
+    return 2
+
+
 @sdk.workflow
 def complicated_wf():
     first_name = "emiliano"
@@ -156,6 +164,11 @@ def wf_using_inline_imports():
 
 @sdk.workflow
 def wf_using_python_imports():
+    return [task_with_import()]
+
+
+@sdk.workflow
+def wf_using_git_imports():
     return [task_with_import()]
 
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -271,7 +271,7 @@ def _import_pip_env(ir_invocation: ir.TaskInvocation, wf: ir.WorkflowDef):
             *(task_def.dependency_import_ids or []),
         )
     ]
-    return list(itertools.chain(*(_pip_string(imp) for imp in imports)))
+    return [chunk for imp in imports for chunk in _pip_string(imp)]
 
 
 def _gather_args(

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -8,12 +8,14 @@ RuntimeInterface implementation that uses Ray DAG/Ray Core API.
 from __future__ import annotations
 
 import dataclasses
+import itertools
 import json
 import logging
 import re
 import traceback
 import typing as t
 from datetime import datetime, timedelta, timezone
+from functools import singledispatch
 from pathlib import Path
 
 from orquestra.sdk import exceptions
@@ -238,16 +240,35 @@ class WfUserMetadata(t.TypedDict):
     workflow_def: t.Mapping[str, t.Any]
 
 
-def _get_python_packages(invocation: ir.TaskInvocation, wf: ir.WorkflowDef):
-    if not (deps_ids := wf.tasks[invocation.task_id].dependency_import_ids):
-        return []
+@singledispatch
+def _pip_string(_: ir.Import) -> t.List[str]:
+    return []
 
-    python_imports = [
-        imp
-        for imp_id in deps_ids
-        if isinstance((imp := wf.imports[imp_id]), ir.PythonImports)
+@_pip_string.register
+def _(imp: ir.PythonImports):
+    return [serde.stringify_package_spec(package) for package in imp.packages]
+
+@_pip_string.register
+def _(imp: ir.GitImport):
+    m = re.match(
+        r"(?P<user>.+)@(?P<domain>[^/]+?):(?P<repo>.+)", imp.repo_url, re.IGNORECASE
+    )
+    if m is not None:
+        url = f"ssh://{m.group('user')}@{m.group('domain')}/{m.group('repo')}"
+    else:
+        url = imp.repo_url
+    return [f"git+{url}@{imp.git_ref}"]
+
+def _import_pip_env(ir_invocation: ir.TaskInvocation, wf: ir.WorkflowDef):
+    task_def = wf.tasks[ir_invocation.task_id]
+    imports = [
+        wf.imports[id_]
+        for id_ in (
+            task_def.source_import_id,
+            *(task_def.dependency_import_ids or []),
+        )
     ]
-    return [package for imp in python_imports for package in imp.packages]
+    return list(itertools.chain(*(_pip_string(imp) for imp in imports)))
 
 
 def _gather_args(
@@ -343,20 +364,13 @@ def _make_ray_dag(client: RayClient, wf: ir.WorkflowDef, wf_run_id: str):
             "task_invocation_id": ir_invocation.id,
         }
 
+        pip = _import_pip_env(ir_invocation, wf)
+
         ray_options = {
             "name": ir_invocation.id,
             "metadata": inv_metadata,
             # If there are any python packages to install for step - set runtime env
-            "runtime_env": (
-                _client.RuntimeEnv(
-                    pip=[
-                        serde.stringify_package_spec(package)
-                        for package in python_packages
-                    ]
-                )
-                if (python_packages := _get_python_packages(ir_invocation, wf))
-                else None
-            ),
+            "runtime_env": (_client.RuntimeEnv(pip=pip) if len(pip) > 0 else None),
             "catch_exceptions": False,
         }
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -244,9 +244,11 @@ class WfUserMetadata(t.TypedDict):
 def _pip_string(_: ir.Import) -> t.List[str]:
     return []
 
+
 @_pip_string.register
 def _(imp: ir.PythonImports):
     return [serde.stringify_package_spec(package) for package in imp.packages]
+
 
 @_pip_string.register
 def _(imp: ir.GitImport):
@@ -258,6 +260,7 @@ def _(imp: ir.GitImport):
     else:
         url = imp.repo_url
     return [f"git+{url}@{imp.git_ref}"]
+
 
 def _import_pip_env(ir_invocation: ir.TaskInvocation, wf: ir.WorkflowDef):
     task_def = wf.tasks[ir_invocation.task_id]

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1161,6 +1161,7 @@ class TestWorkflowDefRepoIntegration:
                 "exception_wf",
                 "wf_using_inline_imports",
                 "wf_using_python_imports",
+                "wf_using_git_imports",
                 "serial_wf_with_slow_middle_task",
                 "serial_wf_with_file_triggers",
                 "exception_wf_with_multiple_values",

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -514,6 +514,7 @@ class TestPipString:
             assert pip == []
 
         def test_with_package(self, monkeypatch: pytest.MonkeyPatch):
+            # We're not testing the serde package, so we're mocking it
             monkeypatch.setattr(
                 _dag.serde, "stringify_package_spec", Mock(return_value="mocked")
             )
@@ -533,6 +534,7 @@ class TestPipString:
             assert pip == ["mocked"]
 
         def test_with_two_packages(self, monkeypatch: pytest.MonkeyPatch):
+            # We're not testing the serde package, so we're mocking it
             monkeypatch.setattr(
                 _dag.serde, "stringify_package_spec", Mock(return_value="mocked")
             )

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -504,3 +504,88 @@ class TestWrapSingleOutputs:
         wrapped = _dag._wrap_single_outputs(values, invocations)
         # Then
         assert wrapped == expected_wrapped
+
+
+class TestPipString:
+    class TestPythonImports:
+        def test_empty(self):
+            imp = ir.PythonImports(id="mock-import", packages=[], pip_options=[])
+            pip = _dag._pip_string(imp)
+            assert pip == []
+
+        def test_with_package(self, monkeypatch: pytest.MonkeyPatch):
+            monkeypatch.setattr(
+                _dag.serde, "stringify_package_spec", Mock(return_value="mocked")
+            )
+            imp = ir.PythonImports(
+                id="mock-import",
+                packages=[
+                    ir.PackageSpec(
+                        name="one",
+                        extras=[],
+                        version_constraints=[],
+                        environment_markers="",
+                    )
+                ],
+                pip_options=[],
+            )
+            pip = _dag._pip_string(imp)
+            assert pip == ["mocked"]
+
+        def test_with_two_packages(self, monkeypatch: pytest.MonkeyPatch):
+            monkeypatch.setattr(
+                _dag.serde, "stringify_package_spec", Mock(return_value="mocked")
+            )
+            imp = ir.PythonImports(
+                id="mock-import",
+                packages=[
+                    ir.PackageSpec(
+                        name="one",
+                        extras=[],
+                        version_constraints=[],
+                        environment_markers="",
+                    ),
+                    ir.PackageSpec(
+                        name="one",
+                        extras=["extra"],
+                        version_constraints=["version"],
+                        environment_markers="env marker",
+                    ),
+                ],
+                pip_options=[],
+            )
+            pip = _dag._pip_string(imp)
+            assert pip == ["mocked", "mocked"]
+
+    class TestGitImports:
+        def test_http(self):
+            imp = ir.GitImport(
+                id="mock-import", repo_url="https://mock/mock/mock", git_ref="mock"
+            )
+            pip = _dag._pip_string(imp)
+            assert pip == ["git+https://mock/mock/mock@mock"]
+
+        def test_pip_ssh_format(self):
+            imp = ir.GitImport(
+                id="mock-import", repo_url="ssh://git@mock/mock/mock", git_ref="mock"
+            )
+            pip = _dag._pip_string(imp)
+            assert pip == ["git+ssh://git@mock/mock/mock@mock"]
+
+        def test_usual_ssh_format(self):
+            imp = ir.GitImport(
+                id="mock-import", repo_url="git@mock:mock/mock", git_ref="mock"
+            )
+            pip = _dag._pip_string(imp)
+            assert pip == ["git+ssh://git@mock/mock/mock@mock"]
+
+    class TestOtherImports:
+        def test_local_import(self):
+            imp = ir.LocalImport(id="mock-import")
+            pip = _dag._pip_string(imp)
+            assert pip == []
+
+        def test_inline_import(self):
+            imp = ir.InlineImport(id="mock-import")
+            pip = _dag._pip_string(imp)
+            assert pip == []


### PR DESCRIPTION
# The problem

If users want to use GitImports inside the Ray on cloud, we need to support Git repos inside the Ray runtime.

# This PR's solution

Uses the `pip` section of Ray's `RuntimeEnv` to handle Git imports.
This only works for Git repos that are also Python packages.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
