### PR TITLE
fix: Turn down logger in AST module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ for task in wf_run.get_tasks():
 * Internal logs from Ray are no longer displayed.
 * Fixed the docstrings for `sdk.WorkflowRun.get_artifacts()`. It returns a dictionary with `TaskInvocationID` as keys and whatever the task returns as values.
 * Fixed bug where some log line from Ray may be duplicated when viewing logs
+* AST parser will no longer print a lot of "Info" messages
 
 
 *Internal*

--- a/src/orquestra/sdk/_base/_ast.py
+++ b/src/orquestra/sdk/_base/_ast.py
@@ -61,7 +61,7 @@ class _ReturnExprVisitor(ast.NodeVisitor):
         node: ast.AST,
         message: str,
     ):
-        LOG.info(message)
+        LOG.debug(message)
         self.outputs.add(_AstReturnMetadata(is_subscriptable=False, n_outputs=1))
 
     def visit_Constant(self, node):

--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -15,7 +15,6 @@ from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRunId
 RAY_LOGS_FORMAT = '{"timestamp": "%(asctime)s", "level": "%(levelname)s", "filename": "%(filename)s:%(lineno)s", "message": %(message)s}'  # noqa
 logging.basicConfig(
     format=RAY_LOGS_FORMAT,
-    level=logging.INFO,
 )
 
 

--- a/tests/sdk/v2/test_task_ast_parsing.py
+++ b/tests/sdk/v2/test_task_ast_parsing.py
@@ -151,7 +151,7 @@ class TestNOutputsByNodeType:
 
         assert _a_task.output_metadata.n_outputs == 1
         assert not _a_task.output_metadata.is_subscriptable
-        assert "Assuming a single output for node" in caplog.text
+        assert "Assuming a single output for node" not in caplog.text
 
     def test_fstring(self):
         @sdk.task


### PR DESCRIPTION
# The problem

The AST module prints a bunch of messages when (for any reason) an assumption was made about parsing the task code.

# This PR's solution

- Removes the configuration of the logger level to INFO
- Changes the AST module log output to DEBUG

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
