### PR TITLE
fix: Dedupe import IDs in workflow traversal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ for task in wf_run.get_tasks():
 * Internal logs from Ray are no longer displayed.
 * Fixed the docstrings for `sdk.WorkflowRun.get_artifacts()`. It returns a dictionary with `TaskInvocationID` as keys and whatever the task returns as values.
 * Fixed bug where some log line from Ray may be duplicated when viewing logs
+* Tasks with duplicate imports will no longer fail when running on QE
 
 
 *Internal*


### PR DESCRIPTION
# The problem

If a user puts duplicate imports inside a workflow task, currently the import ID will be duplicated inside the task IR.
Even if the import is not duplicated in the imports IR, these IDs are still duplicated.

This led to an issue on QE where a workflow task would fail.

# This PR's solution

- Update the traversal code to only keep the first instance of an import ID inside the task IR.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
