### PR TITLE
fix: return only structured logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ for task in wf_run.get_tasks():
 * Fixed bug where some log line from Ray may be duplicated when viewing logs
 * Tasks with duplicate imports will no longer fail when running on QE
 * AST parser will no longer print a lot of "Info" messages
+* `sdk.WorkflowRun.get_logs()` now only returns logs produced by the user. Previously, it included internal debug messages produced by Ray.
+* Logs from workflows submitted to Ray are now always returned as JSONL lines
 
 
 *Internal*

--- a/docs/examples/tests/test_logging.py
+++ b/docs/examples/tests/test_logging.py
@@ -63,11 +63,8 @@ class TestSnippets:
         # Then
         proc.check_returncode()
         std_out = str(proc.stderr, "utf-8")
+        assert '"message": "We\'re doing some quantum work here!"' in std_out
         assert (
-            '{"run_id": "wf.local_run.0000000@tsk.task_local-0.00000", '
-            '"logs": "We\'re doing some quantum work here!"}' in std_out
-        )
-        assert (
-            '{"run_id": "wf.local_run.0000000@tsk.task_local-0.00000", '
-            '"logs": "Another good way to use raw prints from a workflow!"}' in std_out
+            '"message": "Another good way to use raw prints from a workflow!"'
+            in std_out
         )

--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -8,14 +8,15 @@ Log adapter adds a workflow context to logs, Workflow ID and Task ID.
 import json
 import logging
 import os
-from typing import Tuple
+import typing as t
+from datetime import datetime, timezone
 
 from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRunId
 
-RAY_LOGS_FORMAT = '{"timestamp": "%(asctime)s", "level": "%(levelname)s", "filename": "%(filename)s:%(lineno)s", "message": %(message)s}'  # noqa
-logging.basicConfig(
-    format=RAY_LOGS_FORMAT,
-)
+# NOTE: the `message`, `wf_run_id`, and `task_run_id` value placeholders don't come with
+# "" quotes. We already add them when we json.dumps() the value. This ensure proper JSON
+# escaping and handling null values.
+FORMAT = '{"timestamp": "%(asctime)s", "level": "%(levelname)s", "filename": "%(filename)s:%(lineno)s", "message": %(message)s, "wf_run_id": %(wf_run_id)s, "task_run_id": %(task_run_id)s}'  # noqa
 
 
 class TaggedWorkflowTaskLogger(logging.LoggerAdapter):
@@ -23,16 +24,29 @@ class TaggedWorkflowTaskLogger(logging.LoggerAdapter):
     Adding a workflow/task context to log outputs.
     """
 
-    def process(self, msg, kwargs):
-        return (
-            json.dumps(
-                {
-                    "run_id": f'{self.extra["workflow_run_id"]}@{self.extra["task_run_id"]}',  # noqa: E501
-                    "logs": msg,
-                }
-            ),
-            kwargs,
-        )
+    def process(
+        self, msg: str, kwargs: t.Mapping[str, t.Any]
+    ) -> t.Tuple[str, t.MutableMapping[str, t.Any]]:
+        """
+        Args:
+            msg: message passed to the standard logger method calls.
+            kwargs: custom kwargs passed to the standard logger method calls.
+        """
+
+        # Ensure the message can be stored as a JSON. This will escape any
+        # JSON-forbidden chars.
+        new_msg = json.dumps(msg)
+
+        # Workaround cases where run IDs are nulls.
+        old_extra = self.extra or {}
+        new_extra = dict(old_extra)
+        new_extra["wf_run_id"] = json.dumps(old_extra["wf_run_id"])
+        new_extra["task_run_id"] = json.dumps(old_extra["task_run_id"])
+
+        # Mimick default behavior of logging.LoggerAdapter. Note we keep run IDs as
+        # extras.
+        new_kwargs = {**kwargs, "extra": new_extra}
+        return new_msg, new_kwargs
 
 
 def is_argo_backend():
@@ -44,7 +58,7 @@ def is_argo_backend():
     return "ARGO_NODE_ID" in os.environ
 
 
-def get_argo_backend_ids() -> Tuple[WorkflowRunId, TaskRunId]:
+def get_argo_backend_ids() -> t.Tuple[WorkflowRunId, TaskRunId]:
     node_id = os.environ["ARGO_NODE_ID"]
     # Argo Workflow ID is the left part of the step ID
     # [wf-id]-[retry-number]-[step-number]
@@ -57,8 +71,11 @@ def get_argo_step_name():
     return argo_template["name"]
 
 
-def get_ray_backend_ids() -> Tuple[WorkflowRunId, TaskRunId]:
+def get_ray_backend_ids() -> t.Tuple[WorkflowRunId, TaskRunId]:
     from ray.workflow import workflow_context
+
+    # The IDs returned below are likely to be invalid. See:
+    # https://zapatacomputing.atlassian.net/browse/ORQSDK-746
 
     return (
         workflow_context.get_current_workflow_id(),
@@ -66,37 +83,87 @@ def get_ray_backend_ids() -> Tuple[WorkflowRunId, TaskRunId]:
     )
 
 
-def workflow_logger():
+class ISOFormatter(logging.Formatter):
+    """
+    Overrides the default date formating to produce ISO 8601 strings.
+    """
+
+    def formatTime(self, record, datefmt=None) -> str:
+        """
+        Override for logging.Formatter.formatTime.
+
+        Example output: ``2023-02-02T11:45:21.504754+00:00``
+        """
+        utc_timestamp = record.created
+        instant = datetime.fromtimestamp(utc_timestamp, timezone.utc)
+        return instant.isoformat()
+
+
+def _make_logger(wf_run_id: WorkflowRunId, task_run_id: TaskRunId):
+    # Note: there are two loggers: "nested logger" and "main logger".
+    #
+    # The "nested logger" is a singleton managed by `logging`. It's likely to be
+    # retained across task and workflow runs, as long as the worker process lives.
+    # It knows about the log message formats and log levels.
+    #
+    # The "main logger" is the one we expose to the user. It wraps the "nested logger"
+    # to inject contextual information that changes _often_. We use it to pass
+    # `wf_run_id` and `task_run_id` because these values can be different for each
+    # executed task run. The "main logger" should not be retained. We create it every
+    # time user asks us.
+    nested_logger = logging.getLogger(__name__)
+
+    # Note: `logging.basicConfig` does a similar thing like the following few lines. We
+    # can't use the shorthand because it would configure the root logger. Here, we only
+    # want to affect the workflow logger.
+    formatter = ISOFormatter(FORMAT)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    # We need to ensure that a proper handler with proper formatter is hooked up with
+    # the logger. The only way to that is to remove all handlers from the logger and add
+    # the one we care about.
+    nested_logger.handlers.clear()
+    nested_logger.addHandler(handler)
+
+    nested_logger.setLevel(logging.INFO)
+
+    main_logger = TaggedWorkflowTaskLogger(
+        nested_logger,
+        extra={
+            "wf_run_id": wf_run_id,
+            "task_run_id": task_run_id,
+        },
+    )
+
+    return main_logger
+
+
+def workflow_logger() -> logging.LoggerAdapter:
     """
     Returns a Logger instance with a context of current workflow/task.
-    """
-    logger = logging.getLogger(__name__)
-    logger.setLevel(logging.INFO)
 
-    # Fallback workflow and task IDs
-    workflow_run_id = "wf.local_run.0000000"
-    task_run_id = "tsk.task_local-0.00000"
+    Each call of this function creates a new object. It shouldn't be retained across
+    task runs.
+    """
 
     if is_argo_backend():
         # Workflow is running in the Orquestra QE environment
-        workflow_run_id, task_run_id = get_argo_backend_ids()
+        wf_run_id, task_run_id = get_argo_backend_ids()
     else:
         try:
             # Workflow may be running in the Ray environment
-            workflow_run_id, task_run_id = get_ray_backend_ids()
+            wf_run_id, task_run_id = get_ray_backend_ids()
         except (ModuleNotFoundError, AssertionError):
             # Ray is not installed or not in a running Ray workflow:
             # Workflow running via `local_run()` or InProcessRuntime
             # Continue with fallback
-            pass
+            wf_run_id = task_run_id = json.dumps(None)
 
-    return TaggedWorkflowTaskLogger(
-        logger,
-        {
-            "workflow_run_id": workflow_run_id,
-            "task_run_id": task_run_id,
-        },
-    )
+    logger = _make_logger(wf_run_id=wf_run_id, task_run_id=task_run_id)
+
+    return logger
 
 
 def wfprint(*values):

--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -25,17 +25,19 @@ class TaggedWorkflowTaskLogger(logging.LoggerAdapter):
     """
 
     def process(
-        self, msg: str, kwargs: t.Mapping[str, t.Any]
+        self, msg, kwargs: t.Mapping[str, t.Any]
     ) -> t.Tuple[str, t.MutableMapping[str, t.Any]]:
         """
         Args:
-            msg: message passed to the standard logger method calls.
+            msg: message passed to the standard logger method calls. The type of this
+                object depends on internals of ``logging``, but we're assuming it's a
+                string, or something close to it.
             kwargs: custom kwargs passed to the standard logger method calls.
         """
 
         # Ensure the message can be stored as a JSON. This will escape any
         # JSON-forbidden chars.
-        new_msg = json.dumps(msg)
+        new_msg = json.dumps(str(msg))
 
         # Workaround cases where run IDs are nulls.
         old_extra = self.extra or {}

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -8,7 +8,6 @@ RuntimeInterface implementation that uses Ray DAG/Ray Core API.
 from __future__ import annotations
 
 import dataclasses
-import itertools
 import json
 import logging
 import re
@@ -370,6 +369,8 @@ def _make_ray_dag(client: RayClient, wf: ir.WorkflowDef, wf_run_id: str):
         pip = _import_pip_env(ir_invocation, wf)
 
         ray_options = {
+            # The task name should probably be the task run ID, not invocation ID. See:
+            # https://zapatacomputing.atlassian.net/browse/ORQSDK-746
             "name": ir_invocation.id,
             "metadata": inv_metadata,
             # If there are any python packages to install for step - set runtime env

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -5,20 +5,86 @@
 Class to get logs from Ray for particular Workflow, both historical and live.
 """
 import glob
+import json
 import os
 import time
 import typing as t
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
+
+import pydantic
+
+from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRunId
 
 from . import _client
 
 
 @dataclass
 class _LogFileInfo:
-    filename: str
+    """
+    Keeps track where we stopped reading a log file the last time we looked at it.
+
+    Mutated every time we read a log file.
+    """
+
+    # Absolute filepath without symlinks.
+    filepath: str
     size_when_last_opened: int
+    # Last read index.
     file_position: int
+
+
+class WFLog(pydantic.BaseModel):
+    """
+    Log line produced inside a task run. Parsed. Coupled with the logging format set in
+    ``orquestra.sdk._base._log_adater``.
+    """
+
+    # Timezone-aware date+time.
+    timestamp: datetime
+    # Log level name, consistent with Python logging.
+    level: str
+    filename: str
+    # User-specified message string.
+    message: str
+    # ID of the workflow that was run when this line was produced.
+    wf_run_id: t.Optional[WorkflowRunId]
+    # ID of the task that was run when this line was produced.
+    task_run_id: t.Optional[TaskRunId]
+
+
+def _parse_obj_or_none(model_class, json_dict):
+    try:
+        return model_class.parse_obj(json_dict)
+    except pydantic.error_wrappers.ValidationError:
+        return None
+
+
+def parse_log_line(
+    raw_line: bytes, searched_id: t.Union[WorkflowRunId, TaskRunId, None]
+) -> t.Optional[WFLog]:
+    line = raw_line.decode("utf-8", "replace").rstrip("\r\n")
+    if line.startswith(_client.LogPrefixActorName) or line.startswith(
+        _client.LogPrefixTaskName
+    ):
+        return None
+
+    try:
+        json_dict = json.loads(line)
+    except (ValueError, TypeError):
+        return None
+
+    if searched_id is not None:
+        if (
+            json_dict.get("wf_run_id") == searched_id
+            or json_dict.get("task_run_id") == searched_id
+        ):
+            return _parse_obj_or_none(WFLog, json_dict)
+        else:
+            return None
+    else:
+        return _parse_obj_or_none(WFLog, json_dict)
 
 
 class _RayLogs:
@@ -50,52 +116,46 @@ class _RayLogs:
                 self.log_filenames.add(real_path)
                 self.log_file_infos.append(
                     _LogFileInfo(
-                        filename=real_path,
+                        filepath=real_path,
                         size_when_last_opened=0,
                         file_position=0,
                     )
                 )
 
-    def _refine_log_line(self, line):
-        line = line.decode("utf-8", "replace").rstrip("\r\n")
-        if line.startswith(_client.LogPrefixActorName) or line.startswith(
-            _client.LogPrefixTaskName
-        ):
-            return
-        elif (
-            self.workflow_or_task_run_id is None
-        ) or self.workflow_or_task_run_id in line:
-            return line
-
-    def _read_log_files(self):
-        lines = []
+    def _read_log_files(self) -> t.Sequence[WFLog]:
+        logs: t.List[WFLog] = []
 
         self._update_log_filenames()
 
         for file_info in self.log_file_infos:
-            file_size = os.path.getsize(file_info.filename)
+            file_size = os.path.getsize(file_info.filepath)
             if file_size > file_info.size_when_last_opened:
                 file_info.size_when_last_opened = file_size
 
-                with open(file_info.filename, "rb") as f:
+                with open(file_info.filepath, "rb") as f:
                     f.seek(file_info.file_position)
                     for next_line in f:
-                        next_line = self._refine_log_line(next_line)
-                        if next_line:
-                            lines.append(next_line)
+                        parsed_log = parse_log_line(
+                            next_line, searched_id=self.workflow_or_task_run_id
+                        )
+                        if parsed_log is not None:
+                            logs.append(parsed_log)
                     file_info.file_position = f.tell()
 
-        return lines
+        return logs
 
     def iter_logs(self):
         while True:
-            yield self._read_log_files()
+            parsed_logs = self._read_log_files()
+            yield [log.json() for log in parsed_logs]
             time.sleep(2)
 
     def get_full_logs(self):
+        parsed_logs = self._read_log_files()
+        formatted = [log.json() for log in parsed_logs]
         # This is bad. The key should be a task invocation ID. To be fixed in the Jira
         # ticket: https://zapatacomputing.atlassian.net/browse/ORQSDK-676
-        return {"logs": self._read_log_files()}
+        return {"logs": formatted}
 
 
 class DirectRayReader:

--- a/tests/runtime/ray/ray_logs/data/worker1.err
+++ b/tests/runtime/ray/ray_logs/data/worker1.err
@@ -1,0 +1,35 @@
+:actor_name:WorkflowManagementActor
+2023-02-01 16:04:57,663	INFO workflow_executor.py:86 -- Workflow job [id=wf.orquestra_basic_demo.e82cbfa] started.
+2023-02-01 16:04:59,442	ERROR workflow_executor.py:306 -- Task status [FAILED] due to an exception raised by the task.	[wf.orquestra_basic_demo.e82cbfa@invocation-0-task-generate-data]
+2023-02-01 16:04:59,449	ERROR workflow_executor.py:352 -- Workflow 'wf.orquestra_basic_demo.e82cbfa' failed due to [36mray::_workflow_task_executor_remote()[39m (pid=74588, ip=127.0.0.1)
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 115, in _workflow_task_executor_remote
+    return _workflow_task_executor(
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 84, in _workflow_task_executor
+    raise e
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 79, in _workflow_task_executor
+    output = func(*args, **kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 198, in _ray_remote
+    raise e
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
+    return wrapped(*inner_args, **inner_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
+    return self._fn(*unpacked_args, **unpacked_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
+    foo = 1 / 0
+ZeroDivisionError: division by zero
+2023-02-01 16:14:24,732	ERROR worker.py:399 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): [36mray::_workflow_task_executor_remote()[39m (pid=74588, ip=127.0.0.1)
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 115, in _workflow_task_executor_remote
+    return _workflow_task_executor(
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 84, in _workflow_task_executor
+    raise e
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 79, in _workflow_task_executor
+    output = func(*args, **kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 198, in _ray_remote
+    raise e
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
+    return wrapped(*inner_args, **inner_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
+    return self._fn(*unpacked_args, **unpacked_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
+    foo = 1 / 0
+ZeroDivisionError: division by zero

--- a/tests/runtime/ray/ray_logs/data/worker1.out
+++ b/tests/runtime/ray/ray_logs/data/worker1.out
@@ -1,0 +1,1 @@
+:actor_name:WorkflowManagementActor

--- a/tests/runtime/ray/ray_logs/data/worker2.err
+++ b/tests/runtime/ray/ray_logs/data/worker2.err
@@ -1,0 +1,1 @@
+:actor_name:Manager

--- a/tests/runtime/ray/ray_logs/data/worker2.out
+++ b/tests/runtime/ray/ray_logs/data/worker2.out
@@ -1,0 +1,1 @@
+:actor_name:Manager

--- a/tests/runtime/ray/ray_logs/data/worker3.err
+++ b/tests/runtime/ray/ray_logs/data/worker3.err
@@ -1,0 +1,46 @@
+:task_name:create_ray_workflow
+2023-02-01 16:04:57,309	INFO api.py:203 -- Workflow job created. [id="wf.orquestra_basic_demo.e82cbfa"].
+:task_name:_workflow_task_executor_remote
+2023-02-01 16:04:57,685	INFO task_executor.py:78 -- Task status [RUNNING]	[wf.orquestra_basic_demo.e82cbfa@invocation-0-task-generate-data]
+{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf.orquestra_basic_demo.e82cbfa", "task_run_id": "invocation-0-task-generate-data"}
+{"timestamp": "2023-02-01T16:04:59+0100", "level": "ERROR", "filename": "_dag.py:194", "message": "Traceback (most recent call last):\n  File \"/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py\", line 191, in _ray_remote\n    return wrapped(*inner_args, **inner_kwargs)\n  File \"/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py\", line 146, in __call__\n    return self._fn(*unpacked_args, **unpacked_kwargs)\n  File \"/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py\", line 39, in generate_data\n    foo = 1 / 0\nZeroDivisionError: division by zero\n", "wf_run_id": "wf.orquestra_basic_demo.e82cbfa", "task_run_id": "invocation-0-task-generate-data"}
+Traceback (most recent call last):
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
+    return wrapped(*inner_args, **inner_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
+    return self._fn(*unpacked_args, **unpacked_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
+    foo = 1 / 0
+ZeroDivisionError: division by zero
+2023-02-01 16:04:59,460	ERROR worker.py:399 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): [36mray::WorkflowManagementActor.execute_workflow()[39m (pid=74572, ip=127.0.0.1, repr=<ray.workflow.workflow_access.WorkflowManagementActor object at 0x113cf5660>)
+ray.exceptions.RayTaskError(ZeroDivisionError): [36mray::_workflow_task_executor_remote()[39m (pid=74588, ip=127.0.0.1)
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 115, in _workflow_task_executor_remote
+    return _workflow_task_executor(
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 84, in _workflow_task_executor
+    raise e
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 79, in _workflow_task_executor
+    output = func(*args, **kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 198, in _ray_remote
+    raise e
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
+    return wrapped(*inner_args, **inner_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
+    return self._fn(*unpacked_args, **unpacked_kwargs)
+  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
+    foo = 1 / 0
+ZeroDivisionError: division by zero
+
+The above exception was the direct cause of the following exception:
+
+[36mray::WorkflowManagementActor.execute_workflow()[39m (pid=74572, ip=127.0.0.1, repr=<ray.workflow.workflow_access.WorkflowManagementActor object at 0x113cf5660>)
+  File "/Users/alex/.pyenv/versions/3.10.2/lib/python3.10/concurrent/futures/_base.py", line 439, in result
+    return self.__get_result()
+  File "/Users/alex/.pyenv/versions/3.10.2/lib/python3.10/concurrent/futures/_base.py", line 391, in __get_result
+    raise self._exception
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/workflow_access.py", line 209, in execute_workflow
+    await executor.run_until_complete(job_id, context, wf_store)
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/workflow_executor.py", line 109, in run_until_complete
+    await asyncio.gather(
+  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/workflow_executor.py", line 356, in _handle_ready_task
+    raise err
+ray.workflow.exceptions.WorkflowExecutionError: Workflow[id=wf.orquestra_basic_demo.e82cbfa] failed during execution.

--- a/tests/runtime/ray/ray_logs/data/worker3.out
+++ b/tests/runtime/ray/ray_logs/data/worker3.out
@@ -1,0 +1,2 @@
+:task_name:create_ray_workflow
+:task_name:_workflow_task_executor_remote

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -1,0 +1,161 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Unit tests for RayLogs.
+"""
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from orquestra.sdk._ray import _ray_logs
+from orquestra.sdk.schema.workflow_run import WorkflowRunId
+
+DATA_PATH = Path(__file__).parent / "data"
+
+
+TIMEZONE = timezone(timedelta(seconds=3600))
+TIMESTAMP = datetime(2023, 2, 1, 16, 4, 59, tzinfo=TIMEZONE)
+INFO_LOG = _ray_logs.WFLog(
+    timestamp=TIMESTAMP,
+    level="INFO",
+    filename="_log_adapter.py:138",
+    message="hello there!",
+    wf_run_id="wf.orquestra_basic_demo.e82cbfa",
+    task_run_id="invocation-0-task-generate-data",
+)
+ERROR_LOG = _ray_logs.WFLog(
+    timestamp=TIMESTAMP,
+    level="ERROR",
+    filename="_dag.py:194",
+    message='Traceback (most recent call last):\n  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote\n    return wrapped(*inner_args, **inner_kwargs)\n  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__\n    return self._fn(*unpacked_args, **unpacked_kwargs)\n  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data\n    foo = 1 / 0\nZeroDivisionError: division by zero\n',  # noqa: E501
+    wf_run_id="wf.orquestra_basic_demo.e82cbfa",
+    task_run_id="invocation-0-task-generate-data",
+)
+
+
+class TestParseLogLine:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "log_file, expected_parsed",
+        [
+            pytest.param(DATA_PATH / "worker1.err", [], id="wf_manager_stderr"),
+            pytest.param(DATA_PATH / "worker1.out", [], id="wf_manager_stdout"),
+            pytest.param(DATA_PATH / "worker2.err", [], id="idle_worker_stderr"),
+            pytest.param(DATA_PATH / "worker2.err", [], id="idle_worker_stdout"),
+            pytest.param(
+                DATA_PATH / "worker3.err",
+                [INFO_LOG, ERROR_LOG],
+                id="busy_worker_stderr",
+            ),
+            pytest.param(DATA_PATH / "worker3.out", [], id="busy_worker_stdout"),
+        ],
+    )
+    def test_parsing_real_files(log_file: Path, expected_parsed):
+        # Given
+        input_lines = log_file.read_bytes().splitlines(keepends=True)
+        wf_run_id: WorkflowRunId = "wf.orquestra_basic_demo.e82cbfa"
+
+        # When
+        parsed = []
+        for input_line in input_lines:
+            parsed_log = _ray_logs.parse_log_line(input_line, searched_id=wf_run_id)
+            if parsed_log is not None:
+                parsed.append(parsed_log)
+
+        # Then
+        assert parsed == expected_parsed
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            pytest.param("", None, id="empty_line"),
+            pytest.param("{}", None, id="empty_json"),
+            pytest.param("{{}}", None, id="malformed_json"),
+            pytest.param(
+                "2023-01-31 12:44:48,991	INFO workflow_executor.py:86 -- Workflow job [id=wf.orquestra_basic_demo.48c3618] started.",  # noqa: E501
+                None,
+                id="3rd_party_log_with_queried_id",
+            ),
+            pytest.param(
+                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": "wf@inv"}',  # noqa: E501
+                _ray_logs.WFLog(
+                    timestamp=TIMESTAMP,
+                    level="INFO",
+                    filename="_log_adapter.py:138",
+                    message="hello there!",
+                    wf_run_id="wf",
+                    task_run_id="wf@inv",
+                ),
+                id="valid_log_both_ids",
+            ),
+            pytest.param(
+                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": null, "task_run_id": null}',  # noqa: E501
+                _ray_logs.WFLog(
+                    timestamp=TIMESTAMP,
+                    level="INFO",
+                    filename="_log_adapter.py:138",
+                    message="hello there!",
+                    wf_run_id=None,
+                    task_run_id=None,
+                ),
+                id="no_run_ids",
+            ),
+        ],
+    )
+    def test_no_filter(line: str, expected):
+        # Given
+        raw_line = line.encode()
+
+        # When
+        parsed = _ray_logs.parse_log_line(raw_line, searched_id=None)
+
+        # Then
+        assert parsed == expected
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "line,expected",
+        [
+            pytest.param(
+                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": "wf@inv"}',  # noqa: E501
+                _ray_logs.WFLog(
+                    timestamp=TIMESTAMP,
+                    level="INFO",
+                    filename="_log_adapter.py:138",
+                    message="hello there!",
+                    wf_run_id="wf",
+                    task_run_id="wf@inv",
+                ),
+                id="both_ids",
+            ),
+            pytest.param(
+                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": null}',  # noqa: E501
+                _ray_logs.WFLog(
+                    timestamp=TIMESTAMP,
+                    level="INFO",
+                    filename="_log_adapter.py:138",
+                    message="hello there!",
+                    wf_run_id="wf",
+                    task_run_id=None,
+                ),
+                id="only_wf_run_id",
+            ),
+            pytest.param(
+                '{"timestamp": "2023-02-01 12:59:26,568", "level": "INFO", "filename": "_log_adapter.py:131", "message": "hello there!", "wf_run_id": "other", "task_run_id": "wf@inv"}',  # noqa: E501
+                None,
+                id="different_wf_run_id",
+            ),
+        ],
+    )
+    def test_search_by_wf_run_id(line: str, expected):
+        # Given
+        raw_line = line.encode()
+
+        # When
+        parsed = _ray_logs.parse_log_line(raw_line, searched_id="wf")
+
+        # Then
+        assert parsed == expected

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -14,7 +14,6 @@ import pytest
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base._testing import _example_wfs
-from orquestra.sdk._base._testing._connections import make_ray_conn
 from orquestra.sdk._ray import _client, _dag, _ray_logs
 from orquestra.sdk.schema import configs
 from orquestra.sdk.schema.workflow_run import State
@@ -614,6 +613,9 @@ class TestRayRuntimeErrors:
 
 
 @pytest.mark.slow
+# Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+# unraisable exceptions. Last tested with Ray 2.2.0.
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.parametrize("with_run_id", [True, False])
 @pytest.mark.parametrize(
     "wf,tell_tale",

--- a/tests/runtime/test_log_adapter.py
+++ b/tests/runtime/test_log_adapter.py
@@ -1,69 +1,141 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
-import os
-from unittest import mock
+import json
+import subprocess
+import sys
 
 from ray.workflow import workflow_context
 
-from orquestra.sdk import wfprint, workflow_logger
-from orquestra.sdk._base._log_adapter import (
-    get_argo_backend_ids,
-    get_argo_step_name,
-    get_ray_backend_ids,
-    is_argo_backend,
-)
+from orquestra.sdk._base import _log_adapter
+from orquestra.sdk._ray import _ray_logs
 
-LOCAL_UNIFIED_ID = "wf.local_run.0000000@tsk.task_local-0.00000"
 TEST_ARGO_NODE_ID = "hello-orquestra-nk148-r000-4219834842"
 TEST_ARGO_TEMPLATE = """{
     "name": "hello",
     "inputs": "",
     "outputs": ""
 }"""
-TEST_WF_ID = "hello-orquestra-nk148"
-TEST_TASK_ID = "some-task-id-xyz"
+TEST_WF_RUN_ID = "hello-orquestra-nk148"
+TEST_TASK_RUN_ID = "hello-orquestra-nk148@some-task-id-xyz"
 
 
-def test_workflow_logger(caplog):
-    log = workflow_logger()
-    log.info("test test test")
-    assert LOCAL_UNIFIED_ID in caplog.text
+def test_is_argo_backend(monkeypatch):
+    monkeypatch.setenv("ARGO_NODE_ID", TEST_ARGO_NODE_ID)
 
-
-def test_wfprint(caplog):
-    wfprint("hello orquestra")
-    assert LOCAL_UNIFIED_ID in caplog.text
-
-
-@mock.patch.dict(os.environ, {"ARGO_NODE_ID": TEST_ARGO_NODE_ID})
-def test_is_argo_backend():
-    assert is_argo_backend()
+    assert _log_adapter.is_argo_backend()
 
 
 def test_not_argo_backend():
-    assert not is_argo_backend()
+    assert not _log_adapter.is_argo_backend()
 
 
-@mock.patch.dict(os.environ, {"ARGO_NODE_ID": TEST_ARGO_NODE_ID})
-def test_get_argo_backend_ids():
-    workflow_id, task_id = get_argo_backend_ids()
-    assert workflow_id == TEST_WF_ID
+def test_get_argo_backend_ids(monkeypatch):
+    monkeypatch.setenv("ARGO_NODE_ID", TEST_ARGO_NODE_ID)
+
+    workflow_id, task_id = _log_adapter.get_argo_backend_ids()
+    assert workflow_id == TEST_WF_RUN_ID
     assert task_id == TEST_ARGO_NODE_ID
 
 
-@mock.patch.dict(os.environ, {"ARGO_TEMPLATE": TEST_ARGO_TEMPLATE})
-def test_get_argo_step_name():
-    assert get_argo_step_name() == "hello"
+def test_get_argo_step_name(monkeypatch):
+    monkeypatch.setenv("ARGO_TEMPLATE", TEST_ARGO_TEMPLATE)
+    assert _log_adapter.get_argo_step_name() == "hello"
 
 
 def test_get_ray_backend_ids():
     with workflow_context.workflow_task_context(
         context=workflow_context.WorkflowTaskContext(
-            workflow_id=TEST_WF_ID,
-            task_id=TEST_TASK_ID,
+            workflow_id=TEST_WF_RUN_ID,
+            task_id=TEST_TASK_RUN_ID,
         )
     ):
-        workflow_id, task_id = get_ray_backend_ids()
-        assert workflow_id == TEST_WF_ID
-        assert task_id == TEST_TASK_ID
+        workflow_id, task_id = _log_adapter.get_ray_backend_ids()
+        assert workflow_id == TEST_WF_RUN_ID
+        assert task_id == TEST_TASK_RUN_ID
+
+
+class TestMakeLogger:
+    class TestIntegration:
+        """
+        It's very difficult to verify how we arrange loggers and formatters because
+        pytest gets into way. These tests verify the boundary of our system -
+        ``_make_logger()`` in a subprocess.
+
+        The ``_log_adapter`` module produces logs that need to be readable by
+        ``_ray_logs`` module. This is why we use ``_ray_logs`` data structures for
+        assertions.
+
+        System overview::
+
+            _make_logger() -> stdout -> _ray_logs.parse_log_line()
+
+        """
+
+        @staticmethod
+        def _run_script(script: str) -> subprocess.CompletedProcess:
+            # We wanna pass this as a single line to 'python -c my;script;lines'
+            test_script_joined = ";".join(script.splitlines())
+
+            proc = subprocess.run(
+                [sys.executable, "-c", test_script_joined], capture_output=True
+            )
+
+            return proc
+
+        def test_both_ids(self):
+            # Given
+            test_script = """from orquestra.sdk._base import _log_adapter
+logger = _log_adapter._make_logger(wf_run_id="wf.1", task_run_id="task_run_2")
+logger.info("hello!")"""
+
+            # When
+            proc = self._run_script(test_script)
+
+            # Then
+            # Expect logs printed to stderr
+            assert proc.stdout == b""
+            assert proc.stderr != b""
+
+            lines = proc.stderr.splitlines()
+            assert len(lines) == 1
+
+            record = _ray_logs.parse_log_line(lines[0], searched_id=None)
+            assert record is not None
+
+            # Expect timezone-aware dates
+            assert record.timestamp.tzinfo is not None
+
+            assert record.level == "INFO"
+            assert record.message == "hello!"
+            assert record.wf_run_id == "wf.1"
+            assert record.task_run_id == "task_run_2"
+
+        def test_no_ids(self):
+            # Given
+            test_script = """from orquestra.sdk._base import _log_adapter
+                logger = _log_adapter._make_logger(wf_run_id=None, task_run_id=None)
+                logger.info("hello!")"""
+
+            # When
+            proc = self._run_script(test_script)
+
+            # Then
+
+            # Expect logs printed to stderr
+            assert proc.stdout == b""
+            assert proc.stderr != b""
+
+            lines = proc.stderr.splitlines()
+            assert len(lines) == 1
+
+            record = _ray_logs.parse_log_line(lines[0], searched_id=None)
+            assert record is not None
+
+            # Expect timezone-aware dates
+            assert record.timestamp.tzinfo is not None
+
+            assert record.level == "INFO"
+            assert record.message == "hello!"
+            assert record.wf_run_id is None
+            assert record.task_run_id is None


### PR DESCRIPTION
# The problem


Logs read from workflows submitted to Ray resulted in a mix of domains and formats:
```
2023-01-02 09:50:58,793 INFO task_executor.py:78 -- Task status [RUNNING]   [wf.regression_demo.8f92f5f@invocation-1-task-train-model]
{"timestamp": "2023-01-02 09:50:58,809", "level": "ERROR", "filename": "_dag.py:194", "message": {"run_id": "wf.regression_demo.8f92f5f@invocation... 
2023-01-02 09:55:43,523 INFO task_executor.py:78 -- Task status [RUNNING]   [wf.broken_regression_demo.6014772@invocation-1-task-train-model]
```

You can see here both Ray-produced logs in plain-text and user-generated logs in JSONL.

# This PR's solution

* Reading logs now only retrieves user-generated lines.
* To make sure this PR's solution works I've ended up reworking how we generate logs, too.
    * Bonus: we no longer set the global logging config. Fixes https://zapatacomputing.atlassian.net/browse/ORQSDK-740.
    * Bonus: we're using now ISO-8601 date strings with timezones. Fixes https://zapatacomputing.atlassian.net/browse/ORQSDK-563

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
