### PR TITLE
chore: Replace config_save_file with an environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ for task in wf_run.get_tasks():
 ```
 * `sdk.WorkflowRun.get_artifacts()` doesn't accept any arguments any more. Now, it returns all the artifacts produced by the tasks in the workflow.
 * `sdk.TaskRun.get_logs()` returns a list of log lines produced by this task. Previously, it returned a dictionary with one entry.
-* Executing a workflow on Ray with Git imports will now install them. A known limition is that this will only work for Git repositories that are Python packages and will fail for Git repositories that are not Python packages.
+* Executing a workflow on Ray with Git imports will now install them. A known limitation is that this will only work for Git repositories that are Python packages and will fail for Git repositories that are not Python packages.
+* The API will no longer accept `config_save_file` as optional parameters, from now on if you want to use a different config file use the `ORQ_CONFIG_PATH` environment variable.
 
 
 🔥 *Features*

--- a/docs/examples/tests/test_remote.py
+++ b/docs/examples/tests/test_remote.py
@@ -133,9 +133,14 @@ class TestSnippets:
 
     @staticmethod
     @pytest.fixture
-    def define_test_config(httpserver: pytest_httpserver.HTTPServer):
+    def define_test_config(
+        httpserver: pytest_httpserver.HTTPServer,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         from orquestra import sdk
 
+        monkeypatch.setenv("ORQ_CONFIG_PATH", str(tmp_path / "config.json"))
         sdk.RuntimeConfig.qe(uri=f"http://127.0.0.1:{httpserver.port}", token="nice")
 
     @staticmethod
@@ -173,6 +178,7 @@ class TestSnippets:
         change_test_dir,
         httpserver: pytest_httpserver.HTTPServer,
         change_db_location,
+        define_test_config,
     ):
         # Given
         httpserver.expect_request("/v1/workflow").respond_with_json(QE_STATUS_RESPONSE)

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -28,7 +28,6 @@ def get(
     name: str,
     *,
     config_name: t.Optional[str] = None,
-    config_file_path: t.Optional[Path] = None,
 ) -> str:
     """
     Retrieves secret value from the remote vault.
@@ -50,7 +49,6 @@ def get(
     provider = _infer_secrets_provider()
     client = provider.make_client(
         config_name=config_name,
-        config_save_path=config_file_path,
     )
     try:
         return client.get_secret(name).value
@@ -64,7 +62,6 @@ def get(
 def list(
     *,
     config_name: t.Optional[str] = None,
-    config_file_path: t.Optional[Path] = None,
 ) -> t.Sequence[str]:
     """
     Lists all secret names.
@@ -85,7 +82,6 @@ def list(
     provider = _infer_secrets_provider()
     client = provider.make_client(
         config_name=config_name,
-        config_save_path=config_file_path,
     )
     try:
         return [obj.name for obj in client.list_secrets()]
@@ -99,7 +95,6 @@ def set(
     value: str,
     *,
     config_name: t.Optional[str] = None,
-    config_file_path: t.Optional[Path] = None,
 ):
     """
     Sets secret value at the remote vault. Overwrites already existing secrets.
@@ -120,7 +115,6 @@ def set(
     provider = _infer_secrets_provider()
     client = provider.make_client(
         config_name=config_name,
-        config_save_path=config_file_path,
     )
     try:
         try:
@@ -136,7 +130,6 @@ def delete(
     name: str,
     *,
     config_name: t.Optional[str] = None,
-    config_file_path: t.Optional[Path] = None,
 ):
     """
     Deletes secret from the remote vault.
@@ -159,7 +152,6 @@ def delete(
     provider = _infer_secrets_provider()
     client = provider.make_client(
         config_name=config_name,
-        config_save_path=config_file_path,
     )
     try:
         client.delete_secret(name)

--- a/src/orquestra/sdk/secrets/_providers.py
+++ b/src/orquestra/sdk/secrets/_providers.py
@@ -22,15 +22,12 @@ class SecretsProvider(t.Protocol):
     def make_client(
         self,
         config_name: t.Optional[str],
-        config_save_path: t.Optional[Path],
     ) -> SecretsClient:
         ...
 
 
-def _read_config_opts(config_name, config_path):
-    return _config.read_config(
-        config_name=config_name, config_file_path=config_path
-    ).runtime_options
+def _read_config_opts(config_name):
+    return _config.read_config(config_name=config_name).runtime_options
 
 
 class ConfigProvider:
@@ -43,9 +40,8 @@ class ConfigProvider:
     def make_client(
         self,
         config_name: t.Optional[str],
-        config_save_path: t.Optional[Path],
     ):
-        opts = _read_config_opts(config_name, config_save_path)
+        opts = _read_config_opts(config_name)
         return SecretsClient.from_token(base_uri=opts["uri"], token=opts["token"])
 
 
@@ -68,7 +64,6 @@ class PassportProvider:
     def make_client(
         self,
         config_name: t.Optional[str],
-        config_save_path: t.Optional[Path],
     ) -> SecretsClient:
         """
         Ignores the arguments and reads passport and cluster URI from env vars.

--- a/tests/runtime/api/test_api_with_qe.py
+++ b/tests/runtime/api/test_api_with_qe.py
@@ -278,7 +278,6 @@ class TestGetWorkflowRunStatus:
 
         run_reconnect = sdk.WorkflowRun.by_id(
             id,
-            config_save_file=tmp_path / "config.json",
         )
 
         # THEN

--- a/tests/runtime/api/test_api_with_ray.py
+++ b/tests/runtime/api/test_api_with_ray.py
@@ -102,6 +102,7 @@ class TestRunningLocalInBackground:
         ):
             # GIVEN
             monkeypatch.setattr(Path, "cwd", Mock(return_value=tmp_path))
+            monkeypatch.setenv("ORQ_CONFIG_PATH", str(tmp_path / "config.json"))
 
             run = wf_pass_tuple().run(sdk.RuntimeConfig.ray())
             run.wait_until_finished()
@@ -112,7 +113,6 @@ class TestRunningLocalInBackground:
             # WHEN
             run_reconnect = sdk.WorkflowRun.by_id(
                 id,
-                config_save_file=tmp_path / "config.json",
             )
             results = run_reconnect.get_results()
 

--- a/tests/runtime/corq/test_cli_with_ray.py
+++ b/tests/runtime/corq/test_cli_with_ray.py
@@ -175,7 +175,7 @@ class TestCLIWithRay:
             submited_workflow,
             setup_ray,
         ):
-            def _mock_get_config_dir(_):
+            def _mock_get_config_dir():
                 return tmp_path
 
             monkeypatch.setattr(
@@ -291,7 +291,7 @@ class TestCLIWithRay:
     def test_get_workflow_v2_results_for_jsonable_outputs_no_config(
         self, tmp_path, monkeypatch, setup_ray
     ):
-        def _mock_get_config_dir(_):
+        def _mock_get_config_dir():
             return tmp_path
 
         monkeypatch.setattr(v2_config, "_get_config_directory", _mock_get_config_dir)
@@ -384,7 +384,7 @@ class TestCLIWithRay:
         raises,
         setup_ray,
     ):
-        def _mock_get_config_dir(_):
+        def _mock_get_config_dir():
             return tmp_path
 
         monkeypatch.setattr(v2_config, "_get_config_directory", _mock_get_config_dir)
@@ -443,7 +443,7 @@ class TestCLIWithRay:
             action.orq_stop_workflow_run(args)
 
     def test_orq_stop_workflow_run_no_config(self, tmp_path, monkeypatch, setup_ray):
-        def _mock_get_config_dir(_):
+        def _mock_get_config_dir():
             return tmp_path
 
         monkeypatch.setattr(v2_config, "_get_config_directory", _mock_get_config_dir)

--- a/tests/sdk/v2/conftest.py
+++ b/tests/sdk/v2/conftest.py
@@ -19,10 +19,8 @@ def patch_config_location(tmp_path, monkeypatch):
     Makes the functions in orquestra.sdk._base._config read/write file from a
     temporary directory.
     """
-    config_location = Mock(return_value=tmp_path / "config.json")
-    monkeypatch.setattr(
-        orquestra.sdk._base._config, "_get_config_file_path", config_location
-    )
+    config_location = tmp_path / "config.json"
+    monkeypatch.setenv("ORQ_CONFIG_PATH", str(config_location))
     return tmp_path
 
 

--- a/tests/sdk/v2/secrets/test_api.py
+++ b/tests/sdk/v2/secrets/test_api.py
@@ -70,8 +70,10 @@ class TestSelectsAppropriateProvider:
 
     @staticmethod
     @pytest.fixture
-    def fake_config_path(tmp_path):
-        return tmp_path / "config.json"
+    def fake_config_path(tmp_path, monkeypatch):
+        config_path = tmp_path / "config.json"
+        monkeypatch.setenv("ORQ_CONFIG_PATH", str(config_path))
+        return config_path
 
     class TestGet:
         @staticmethod
@@ -90,7 +92,6 @@ class TestSelectsAppropriateProvider:
             sdk.secrets.get(
                 secret_name,
                 config_name=dummy_config_name,
-                config_file_path=fake_config_path,
             )
 
             # Then
@@ -114,7 +115,6 @@ class TestSelectsAppropriateProvider:
                 sdk.secrets.get(
                     secret_name,
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then
@@ -138,7 +138,6 @@ class TestSelectsAppropriateProvider:
                 sdk.secrets.get(
                     secret_name,
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then
@@ -162,7 +161,6 @@ class TestSelectsAppropriateProvider:
             sdk.secrets.delete(
                 secret_name,
                 config_name=dummy_config_name,
-                config_file_path=fake_config_path,
             )
 
             # Then
@@ -186,7 +184,6 @@ class TestSelectsAppropriateProvider:
                 sdk.secrets.delete(
                     secret_name,
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then
@@ -210,7 +207,6 @@ class TestSelectsAppropriateProvider:
                 sdk.secrets.delete(
                     secret_name,
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then
@@ -232,7 +228,6 @@ class TestSelectsAppropriateProvider:
             # When
             sdk.secrets.list(
                 config_name=dummy_config_name,
-                config_file_path=fake_config_path,
             )
 
             # Then
@@ -254,7 +249,6 @@ class TestSelectsAppropriateProvider:
             with _exec_ctx.local_ray():
                 sdk.secrets.list(
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then
@@ -276,7 +270,6 @@ class TestSelectsAppropriateProvider:
             with _exec_ctx.platform_qe():
                 sdk.secrets.list(
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then
@@ -302,7 +295,6 @@ class TestSelectsAppropriateProvider:
                 secret_name,
                 secret_value,
                 config_name=dummy_config_name,
-                config_file_path=fake_config_path,
             )
 
             # Then
@@ -328,7 +320,6 @@ class TestSelectsAppropriateProvider:
                     secret_name,
                     secret_value,
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then
@@ -354,7 +345,6 @@ class TestSelectsAppropriateProvider:
                     secret_name,
                     secret_value,
                     config_name=dummy_config_name,
-                    config_file_path=fake_config_path,
                 )
 
             # Then

--- a/tests/sdk/v2/secrets/test_providers.py
+++ b/tests/sdk/v2/secrets/test_providers.py
@@ -60,13 +60,19 @@ class TestConfigProvider:
             config_path.unlink()
 
     @staticmethod
-    def test_reads_creds(config_name: str, config_file: Path, uri: str, token: str):
+    def test_reads_creds(
+        config_name: str,
+        config_file: Path,
+        uri: str,
+        token: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("ORQ_CONFIG_PATH", str(config_file))
         provider = _providers.ConfigProvider()
 
         # When
         client = provider.make_client(
             config_name=config_name,
-            config_save_path=config_file,
         )
 
         # Then
@@ -74,17 +80,19 @@ class TestConfigProvider:
         assert client._session.headers["Authorization"] == f"Bearer {token}"
 
     @staticmethod
-    def test_uses_default_config(config_file: Path, uri: str, token: str):
+    def test_uses_default_config(
+        config_file: Path, uri: str, token: str, monkeypatch: pytest.MonkeyPatch
+    ):
         """
         Likely to happen when the user doesn't pass config name to Secrets(), and it's
         inside a local script, or a task on a local Ray.
         """
+        monkeypatch.setenv("ORQ_CONFIG_PATH", str(config_file))
         provider = _providers.ConfigProvider()
 
         # When
         client = provider.make_client(
             config_name=None,
-            config_save_path=config_file,
         )
 
         # Then
@@ -117,7 +125,6 @@ class TestPassportProvider:
         # When
         client = provider.make_client(
             config_name=None,
-            config_save_path=None,
         )
 
         # Then

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -18,6 +18,9 @@ the user. It's a lot easier to figure out appropriate behavior this way.
 """
 import datetime
 import json
+import os
+import tempfile
+from pathlib import Path
 from unittest.mock import Mock
 
 import filelock
@@ -28,6 +31,13 @@ from orquestra.sdk._base import _config
 from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
 
 from .data.configs import TEST_CONFIG_JSON
+
+# @pytest.fixture(scope="module", autouse=True)
+# def mock_config_path():
+#     with tempfile.TemporaryDirectory() as dir_path:
+#         with pytest.MonkeyPatch.context() as mp:
+#             mp.setenv("ORQ_CONFIG_PATH", os.path.join(dir_path, "config.json"))
+#             yield mp
 
 
 class TestSavePartialConfig:
@@ -97,13 +107,11 @@ class TestResolveConfigFileForReading:
         assert _config._resolve_config_file_for_reading() is None
 
     @staticmethod
-    def test_returns_none_for_nonexistant_file_custom_location(tmp_path):
-        assert (
-            _config._resolve_config_file_for_reading(
-                config_file_path=tmp_path / "test.file"
-            )
-            is None
-        )
+    def test_returns_none_for_nonexistant_file_custom_location(
+        tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        monkeypatch.setenv("ORQ_CONFIG_PATH", str(tmp_path / "test.file"))
+        assert _config._resolve_config_file_for_reading() is None
 
 
 class TestResolveConfigName:

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -32,13 +32,6 @@ from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
 
 from .data.configs import TEST_CONFIG_JSON
 
-# @pytest.fixture(scope="module", autouse=True)
-# def mock_config_path():
-#     with tempfile.TemporaryDirectory() as dir_path:
-#         with pytest.MonkeyPatch.context() as mp:
-#             mp.setenv("ORQ_CONFIG_PATH", os.path.join(dir_path, "config.json"))
-#             yield mp
-
 
 class TestSavePartialConfig:
     """


### PR DESCRIPTION
# The problem

It was difficult to maintain the code and tests with passing around the config path around.

# This PR's solution

Removes the `config_save_file` option and replaces with an env variable.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
