### PR TITLE
fix: submitting non-package workflows

### DIFF
--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1126,6 +1126,33 @@ class TestWorkflowDefRepoIntegration:
                 # Then
                 assert mod.foo == "abc"
 
+            @staticmethod
+            def test_loads_from_cwd(tmp_path: Path, monkeypatch):
+                """
+                - We have some free-form project files outside of a setuptools-like
+                  distribution
+                - PWD is at the project root
+                - PWD wasn't added to sys.path explicitly
+                """
+                # Given
+                proj_dir = tmp_path / "my_proj"
+                proj_dir.mkdir()
+
+                module_path = proj_dir / "my_pkg" / "my_module.py"
+                module_path.parent.mkdir()
+                module_path.write_text("foo = 'abc'")
+
+                monkeypatch.chdir(proj_dir)
+
+                repo = _repos.WorkflowDefRepo()
+
+                with reloaders.restore_loaded_modules():
+                    # When
+                    mod = repo.get_module_from_spec("my_pkg.my_module")
+
+                    # Then
+                    assert mod.foo == "abc"
+
         class TestNonExistingModules:
             @staticmethod
             def test_invalid_path():


### PR DESCRIPTION
# The problem

`orq wf submit` would raise `ModuleNotFoundError` when used in a project that's not structured as an installable setuptools-like package. This affected both forms:
- `orq submit myproj.wfs`
- `orq submit myproj/wfs.py`

# This PR's solution

Looks like `orq` console script doesn't add current working directory to `sys.path`. This PR adds this manually.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
