### PR TITLE
fix: getting results via CLI

### DIFF
--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_results.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_results.py
@@ -21,7 +21,8 @@ class Action:
 
     def __init__(
         self,
-        presenter=_presenters.WrappedCorqOutputPresenter(),
+        artifact_presenter=_presenters.ArtifactPresenter(),
+        error_presenter=_presenters.WrappedCorqOutputPresenter(),
         dumper=_dumpers.WFOutputDumper(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
@@ -39,7 +40,8 @@ class Action:
         )
 
         # output
-        self._presenter = presenter
+        self._artifact_presenter = artifact_presenter
+        self._error_presenter = error_presenter
         self._dumper = dumper
 
     def on_cmd_call(
@@ -55,7 +57,7 @@ class Action:
                 config=config,
             )
         except Exception as e:
-            self._presenter.show_error(e)
+            self._error_presenter.show_error(e)
 
     def _on_cmd_call_with_exceptions(
         self,
@@ -81,6 +83,8 @@ class Action:
                     output_index=output_i,
                     dir_path=download_dir,
                 )
-                self._presenter.show_dumped_wf_result(dump_details)
+                self._artifact_presenter.show_dumped_artifact(dump_details)
         else:
-            self._presenter.show_workflow_outputs(output_values, resolved_wf_run_id)
+            self._artifact_presenter.show_workflow_outputs(
+                output_values, resolved_wf_run_id
+            )

--- a/tests/cli/dorq/workflow/test_logs.py
+++ b/tests/cli/dorq/workflow/test_logs.py
@@ -6,7 +6,7 @@ Unit tests for 'orq wf results' glue code.
 """
 
 from pathlib import Path
-from unittest.mock import Mock, create_autospec
+from unittest.mock import create_autospec
 
 from orquestra.sdk._base.cli._dorq._arg_resolvers import WFConfigResolver, WFRunResolver
 from orquestra.sdk._base.cli._dorq._dumpers import LogsDumper

--- a/tests/cli/dorq/workflow/test_results.py
+++ b/tests/cli/dorq/workflow/test_results.py
@@ -6,9 +6,11 @@ Unit tests for 'orq wf results' glue code.
 """
 
 from pathlib import Path
-from unittest.mock import Mock
+from unittest.mock import create_autospec
 
 from orquestra.sdk._base.cli._dorq._workflow import _results
+from orquestra.sdk._base.cli._dorq._ui import _presenters
+from orquestra.sdk._base.cli._dorq import _dumpers, _repos, _arg_resolvers
 
 
 class TestAction:
@@ -38,20 +40,22 @@ class TestAction:
             resolved_config = "<resolved config>"
 
             # Mocks
-            presenter = Mock()
-            dumper = Mock()
-            wf_run_repo = Mock()
+            artifact_presenter = create_autospec(_presenters.ArtifactPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            dumper = create_autospec(_dumpers.WFOutputDumper)
+            wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
             fake_outputs = [object(), "hello", None]
             wf_run_repo.get_wf_outputs.return_value = fake_outputs
 
-            config_resolver = Mock()
+            config_resolver = create_autospec(_arg_resolvers.WFConfigResolver)
             config_resolver.resolve.return_value = resolved_config
 
-            wf_run_resolver = Mock()
+            wf_run_resolver = create_autospec(_arg_resolvers.WFRunResolver)
             wf_run_resolver.resolve_id.return_value = resolved_id
 
             action = _results.Action(
-                presenter=presenter,
+                artifact_presenter=artifact_presenter,
+                error_presenter=error_presenter,
                 dumper=dumper,
                 wf_run_repo=wf_run_repo,
                 config_resolver=config_resolver,
@@ -76,7 +80,7 @@ class TestAction:
             )
 
             # We expect printing the workflow run returned from the repo.
-            presenter.show_workflow_outputs.assert_called_with(
+            artifact_presenter.show_workflow_outputs.assert_called_with(
                 fake_outputs, resolved_id
             )
 
@@ -96,20 +100,23 @@ class TestAction:
             resolved_config = "<resolved config>"
 
             # Mocks
-            presenter = Mock()
-            dumper = Mock()
-            wf_run_repo = Mock()
+            artifact_presenter = create_autospec(_presenters.ArtifactPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            dumper = create_autospec(_dumpers.WFOutputDumper)
+
+            wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
             fake_outputs = [object(), "hello", None]
             wf_run_repo.get_wf_outputs.return_value = fake_outputs
 
-            config_resolver = Mock()
+            config_resolver = create_autospec(_arg_resolvers.WFConfigResolver)
             config_resolver.resolve.return_value = resolved_config
 
-            wf_run_resolver = Mock()
+            wf_run_resolver = create_autospec(_arg_resolvers.WFRunResolver)
             wf_run_resolver.resolve_id.return_value = resolved_id
 
             action = _results.Action(
-                presenter=presenter,
+                artifact_presenter=artifact_presenter,
+                error_presenter=error_presenter,
                 dumper=dumper,
                 wf_run_repo=wf_run_repo,
                 config_resolver=config_resolver,
@@ -134,7 +141,7 @@ class TestAction:
             )
 
             # We expect a summary printed for each output
-            assert len(presenter.mock_calls) == len(fake_outputs)
+            assert len(artifact_presenter.mock_calls) == len(fake_outputs)
 
             # We expect a dump for each output
             assert len(dumper.mock_calls) == len(fake_outputs)

--- a/tests/cli/dorq/workflow/test_results.py
+++ b/tests/cli/dorq/workflow/test_results.py
@@ -8,9 +8,9 @@ Unit tests for 'orq wf results' glue code.
 from pathlib import Path
 from unittest.mock import create_autospec
 
-from orquestra.sdk._base.cli._dorq._workflow import _results
+from orquestra.sdk._base.cli._dorq import _arg_resolvers, _dumpers, _repos
 from orquestra.sdk._base.cli._dorq._ui import _presenters
-from orquestra.sdk._base.cli._dorq import _dumpers, _repos, _arg_resolvers
+from orquestra.sdk._base.cli._dorq._workflow import _results
 
 
 class TestAction:

--- a/tests/cli/dorq/workflow/test_results.py
+++ b/tests/cli/dorq/workflow/test_results.py
@@ -145,3 +145,23 @@ class TestAction:
 
             # We expect a dump for each output
             assert len(dumper.mock_calls) == len(fake_outputs)
+
+    @staticmethod
+    def test_presents_errors():
+        # Given
+        error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+        config_resolver = create_autospec(_arg_resolvers.WFConfigResolver)
+
+        err = RuntimeError()
+        config_resolver.resolve.side_effect = err
+
+        action = _results.Action(
+            error_presenter=error_presenter,
+            config_resolver=config_resolver,
+        )
+
+        # When
+        action.on_cmd_call(wf_run_id=None, config=None, download_dir=None)
+
+        # Then
+        error_presenter.show_error.assert_called_with(err)


### PR DESCRIPTION
# The problem

`orq wf result` would fail with an `AttributeError`. We didn't update this piece after one refactor we had made.

# This PR's solution

* Updates class & method names for CLI presenters
* Makes the tests more robust by changing `Mock()` -> `create_autospec()`

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
