### PR TITLE
docs: snippets for new CLI

### DIFF
--- a/docs/examples/tests/test_local_ray.py
+++ b/docs/examples/tests/test_local_ray.py
@@ -34,7 +34,7 @@ class Snippets:
         from workflow_defs import hello_orquestra_wf
 
         # Start the workflow
-        wf_run = hello_orquestra_wf().run("local")
+        wf_run = hello_orquestra_wf().run("ray")
 
         # A workflow can be executed multiple times. Run ID can be used later to
         # identify a single run.

--- a/docs/recipes/vqe.rst
+++ b/docs/recipes/vqe.rst
@@ -63,7 +63,7 @@ Copy the workflow ID that is printed to the terminal and paste it into the follo
 
 .. code-block:: bash
 
-   orq get workflow-run <workflow-id>
+   orq wf view <workflow-id>
 
 .. note::
 

--- a/docs/tutorials/fluentbit.rst
+++ b/docs/tutorials/fluentbit.rst
@@ -65,12 +65,12 @@ Start Services
 Ray-based local runtime requires some services to run in the background: Ray cluster and Fluentbit docker container.
 There's a handy command to start them::
 
-    orq up
+    orq up --all
 
 This only needs to be once until you reboot your computer or
 you stop services manually using the command::
 
-   orq down
+   orq down --all
 
 
 Run Workflows

--- a/docs/tutorials/ray.rst
+++ b/docs/tutorials/ray.rst
@@ -15,22 +15,27 @@ Prerequisites
 Start Ray
 =========
 
-Ray executes workflows in the background.
-Run the following command in your terminal to start the Ray cluster::
+Run the following command in your terminal to start the background services on your machine:
 
-    ray start --head \
-        --temp-dir="$HOME/.orquestra/ray" \
-        --storage="$HOME/.orquestra/ray_storage"
+.. code:: bash
 
-
-.. warning::
-
-    Some features of Orquestra Workflow SDK won't properly if you pass different paths as ``--temp-dir`` and ``--storage`` , e.g. you won't be able to retrieve workflow logs.
+    orq up
 
 
-After you're done, the Ray cluster can be shut down with::
+This ``orq`` commands ensures that the Ray cluster was set up correctly.
 
-    ray stop
+
+.. note::
+
+    There are other ways to start Ray, e.g. via ``ray start``, but some features of Orquestra Workflow SDK might not work properly.
+    In particular, you won't be able to retrieve workflow logs.
+
+
+After you're done, the Ray cluster can be shut down with:
+
+.. code:: bash
+
+    orq down
 
 
 Execute Workflow

--- a/docs/tutorials/remote.rst
+++ b/docs/tutorials/remote.rst
@@ -61,7 +61,7 @@ Token and URI should be stored in local configuration file. To do this, execute 
 
 .. code:: bash
 
-    echo <paste token content> | orq set token -c <your_config_name> -t -
+    orq login -s https://<cluster-name>.orquestra.io -t <paste token content>
 
 .. warning::
 


### PR DESCRIPTION
# The problem

Our docs had some mentions of the old CLI. Commands in dorq are a bit different.

# This PR's solution

* Update Ray tutorial to mention `orq up`
* Update FluentBit tutorial to mention `orq up --all`
* Update QE tutorial to mention `orq login -s ... -t ...`
* Update VQE recipe to mention `orq wf view ...`

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
