### PR TITLE
internal: remove obsolete iter_logs

### DIFF
--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -306,12 +306,3 @@ class CERuntime(RuntimeInterface):
         See LogReader.get_full_logs.
         """
         raise NotImplementedError()
-
-    def iter_logs(
-        self,
-        workflow_or_task_run_id: Optional[Union[WorkflowRunId, TaskRunId]] = None,
-    ) -> Iterator[Sequence[str]]:
-        """
-        See LogReader.iter_logs.
-        """
-        raise NotImplementedError()

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -268,8 +268,3 @@ class InProcessRuntime(abc.RuntimeInterface):
         raise NotImplementedError(
             "This functionality isn't available for 'in_process' runtime"
         )
-
-    def iter_logs(self, *args, **kwargs):
-        raise NotImplementedError(
-            "This functionality isn't available for 'in_process' runtime"
-        )

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -791,10 +791,6 @@ class QERuntime(RuntimeInterface):
             for task_run in workflow_run.task_runs
         }
 
-    def iter_logs(self, _: Optional[Union[WorkflowRunId, TaskRunId]] = None):
-        """Raises NotImplementedError as QE cannot stream logs in this manner"""
-        raise NotImplementedError("Unable to stream logs from Quantum Engine")
-
     def stop_workflow_run(self, run_id: WorkflowRunId) -> None:
         """Terminates a workflow run.
 

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -62,21 +62,6 @@ class LogReader(t.Protocol):
         """
         raise NotImplementedError()
 
-    def iter_logs(
-        self,
-        workflow_or_task_run_id: t.Optional[t.Union[WorkflowRunId, TaskRunId]] = None,
-    ) -> t.Iterator[t.Sequence[str]]:
-        """Returns an iterator for the logs from the runtime. Each yield is a batch of
-        log lines.
-
-        If the target ID is missing, this method will return all logs available from
-        the runtime.
-
-        Arguments:
-            workflow_or_task_run_id: target workflow/task run
-        """
-        ...
-
 
 # A typealias that hints where we expect raw artifact values.
 ArtifactValue = t.Any
@@ -186,16 +171,6 @@ class RuntimeInterface(ABC):
     ) -> t.Dict[TaskInvocationId, t.List[str]]:
         """
         See LogReader.get_full_logs.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def iter_logs(
-        self,
-        workflow_or_task_run_id: t.Optional[t.Union[WorkflowRunId, TaskRunId]] = None,
-    ) -> t.Iterator[t.Sequence[str]]:
-        """
-        See LogReader.iter_logs.
         """
         raise NotImplementedError()
 

--- a/src/orquestra/sdk/_base/cli/_corq/action/_get_logs.py
+++ b/src/orquestra/sdk/_base/cli/_corq/action/_get_logs.py
@@ -45,19 +45,7 @@ def orq_get_logs(
     runtime = _factory.build_runtime_from_config(project_dir=project_dir, config=config)
 
     if args.follow:
-        # Special case: instead of returning a full response we await new log line
-        # batches and print as they arrive. This never exists unless the user sends
-        # an interrupt.
-        log_batch_iterator = runtime.iter_logs(args.workflow_or_task_run_id)
-
-        print("Listening to logs. Press Ctrl-C to quit.", file=sys.stderr)
-
-        for log_batch in log_batch_iterator:
-            for log_line in log_batch:
-                print(log_line)
-
-        # This will never be executed, but we need it to appease mypy
-        return None
+        raise NotImplementedError("Log streaming isn't implemented")
     else:
         # no follow/eager mode
         log_dict = runtime.get_full_logs(args.workflow_or_task_run_id)

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -899,14 +899,6 @@ class RayRuntime(RuntimeInterface):
         else:
             return self._ray_reader.get_full_logs(run_id)
 
-    def iter_logs(
-        self, run_id: t.Optional[t.Union[WorkflowRunId, TaskRunId]] = None
-    ) -> t.Iterator[t.Sequence[str]]:
-        if self._service_manager.is_fluentbit_running():
-            yield from self._fluentbit_reader.iter_logs(run_id)
-        else:
-            yield from self._ray_reader.iter_logs(run_id)
-
     def list_workflow_runs(
         self,
         *,

--- a/src/orquestra/sdk/_ray/_query_service.py
+++ b/src/orquestra/sdk/_ray/_query_service.py
@@ -111,6 +111,3 @@ class FluentbitReader:
 
         service = LogQueryService(run_id=run_id, logs_dir=self._logs_dir)
         return service.get_full_logs()
-
-    def iter_logs(self, run_id: t.Optional[str] = None) -> t.Iterator[t.Sequence[str]]:
-        raise NotImplementedError()

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -144,12 +144,6 @@ class _RayLogs:
 
         return logs
 
-    def iter_logs(self):
-        while True:
-            parsed_logs = self._read_log_files()
-            yield [log.json() for log in parsed_logs]
-            time.sleep(2)
-
     def get_full_logs(self):
         parsed_logs = self._read_log_files()
         formatted = [log.json() for log in parsed_logs]
@@ -173,7 +167,3 @@ class DirectRayReader:
     def get_full_logs(self, run_id: t.Optional[str] = None) -> t.Dict[str, t.List[str]]:
         wrapped = _RayLogs(ray_temp=self._ray_temp, workflow_or_task_run_id=run_id)
         return wrapped.get_full_logs()
-
-    def iter_logs(self, run_id: t.Optional[str] = None) -> t.Iterator[t.Sequence[str]]:
-        wrapped = _RayLogs(ray_temp=self._ray_temp, workflow_or_task_run_id=run_id)
-        yield from wrapped.iter_logs()

--- a/tests/runtime/corq/test_cli_with_ray.py
+++ b/tests/runtime/corq/test_cli_with_ray.py
@@ -959,52 +959,6 @@ class TestCLIAgainstRuntimeMock:
             )
 
         @pytest.mark.parametrize("query_by_run_id", [True, False])
-        def test_follow(
-            self,
-            tmp_path,
-            monkeypatch,
-            capsys,
-            mocked_nonsense_config,
-            query_by_run_id: bool,
-        ):
-            """
-            Validates that when RayRuntime.iter_logs() yields something, it gets
-            printed to stdout.
-            """
-            # Given
-            wf_run_id = "hello_there_1234"
-            tell_tale = "general kenobi!"
-
-            runtime_mock = Mock()
-
-            def _mock_iter_logs(run_id):
-                if run_id in {None, wf_run_id}:
-                    return [[tell_tale]]
-                else:
-                    return []
-
-            runtime_mock.iter_logs = _mock_iter_logs
-
-            _setup_runtime_mock(monkeypatch, runtime_mock)
-
-            # When
-            query_id = wf_run_id if query_by_run_id else None
-            action.orq_get_logs(
-                argparse.Namespace(
-                    workflow_or_task_run_id=query_id,
-                    follow=True,
-                    output_format=ResponseFormat.PLAIN_TEXT,
-                    directory=tmp_path,
-                    config=TEST_CONFIG_NAME,
-                )
-            )
-
-            # Then
-            captured = capsys.readouterr()
-            assert tell_tale in captured.out
-            assert "Ctrl-C" in captured.err
-
-        @pytest.mark.parametrize("query_by_run_id", [True, False])
         def test_historical(
             self,
             tmp_path,

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -1235,16 +1235,6 @@ class TestGetFullLogs:
             _ = runtime.get_full_logs(task_run_id)
 
 
-class TestIterLogs:
-    def test_no_args(self, runtime):
-        with pytest.raises(NotImplementedError):
-            runtime.iter_logs()
-
-    def test_arg(self, runtime):
-        with pytest.raises(NotImplementedError):
-            runtime.iter_logs("workflow-run-id")
-
-
 class TestStopWorkflowRun:
     def test_invalid_run_id(self, monkeypatch, runtime, mocked_responses):
         with pytest.raises(exceptions.WorkflowRunCanNotBeTerminated):

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -240,47 +240,6 @@ class TestRayRuntime:
             assert result_dict == logs_dict
             reader_mock.get_full_logs.assert_called_with(run_id)
 
-        @staticmethod
-        @pytest.mark.parametrize(
-            "runtime_attr_to_mock,fluentbit_running",
-            [
-                ("_ray_reader", False),
-                ("_fluentbit_reader", True),
-            ],
-        )
-        def test_iter_logs(
-            runtime_attr_to_mock: str,
-            fluentbit_running: bool,
-            tmp_path: Path,
-            runtime_config: RuntimeConfiguration,
-        ):
-            """
-            Makes a spare ``RayRuntime`` object, mocks its attributes, and verifies
-            passing data between the reader and ``RayRuntime``.
-            """
-            # Given
-            rt = _dag.RayRuntime(
-                client=Mock(),
-                config=runtime_config,
-                project_dir=tmp_path,
-            )
-            rt._service_manager = Mock()
-            rt._service_manager.is_fluentbit_running.return_value = fluentbit_running
-
-            reader_mock = Mock()
-            logs_batch = ["Hello, there!", "General Kenobi!"]
-            reader_mock.iter_logs.return_value = [logs_batch]
-            setattr(rt, runtime_attr_to_mock, reader_mock)
-
-            run_id = "wf_or_task_run_id"
-
-            # When
-            result_batch = next(rt.iter_logs(run_id=run_id))
-
-            # Then
-            assert result_batch == logs_batch
-            reader_mock.iter_logs.assert_called_with(run_id)
-
     class TestListWorkflowRuns:
         def test_happy_path(self, client, runtime_config, monkeypatch, tmp_path):
             # Given

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -661,31 +661,6 @@ class TestDirectRayReader:
 
         assert tell_tale in log_lines_joined
 
-    def test_iter_logs(
-        self, shared_ray_conn, runtime, with_run_id: bool, wf, tell_tale: str
-    ):
-        """
-        Submit a workflow, wait for it to finish, get one batch of logs, look for
-        the test message.
-        """
-        # Given
-        ray_params = shared_ray_conn
-        reader = _ray_logs.DirectRayReader(Path(ray_params._temp_dir))
-
-        run_id = runtime.create_workflow_run(wf)
-        _wait_to_finish_wf(run_id, runtime)
-
-        query_run_id = run_id if with_run_id else None
-
-        # When
-        iterator = reader.iter_logs(run_id=query_run_id)
-        logs_batch = next(iterator)
-
-        # Then
-        log_lines_joined = "".join(log_line for log_line in logs_batch)
-
-        assert tell_tale in log_lines_joined
-
 
 @pytest.mark.slow
 # Ray mishandles log file handlers and we get "_io.FileIO [closed]"

--- a/tests/sdk/v2/test_in_process_runtime.py
+++ b/tests/sdk/v2/test_in_process_runtime.py
@@ -225,7 +225,6 @@ class TestUnsupportedMethods:
             InProcessRuntime.from_runtime_configuration,
             InProcessRuntime.get_all_workflow_runs_status,
             InProcessRuntime.get_full_logs,
-            InProcessRuntime.iter_logs,
         ],
     )
     def test_raises(runtime, method):


### PR DESCRIPTION
# The problem

* `RuntimeInterface` had method `.iter_logs()`. We don't expose this functionality to the user anymore.
* Maintenance of log streaming started to be increasingly painful, esp. given the refactors I'm working on atm.

# This PR's solution

* Removes `iter_logs()` from the `RuntimeInterface` ABC.
* Removes `iter_logs()` all known implementations.
* Removes the related tests.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
