### PR TITLE
fix: tag Ray logs with proper task IDs

### DIFF
--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -107,7 +107,9 @@ class ISOFormatter(logging.Formatter):
 
 
 def _make_logger(
-    wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId, task_run_id: TaskRunId
+    wf_run_id: t.Optional[WorkflowRunId],
+    task_inv_id: t.Optional[TaskInvocationId],
+    task_run_id: t.Optional[TaskRunId],
 ):
     # Note: there are two loggers: "nested logger" and "main logger".
     #
@@ -162,12 +164,8 @@ def workflow_logger() -> logging.LoggerAdapter:
         # Workflow is running in the Orquestra QE environment
         wf_run_id, task_inv_id, task_run_id = get_argo_backend_ids()
     else:
-        try:
-            # Workflow may be running in the Ray environment
-            wf_run_id, task_inv_id, task_run_id = get_ray_backend_ids()
-        except (ModuleNotFoundError, AssertionError):
-            # Ray is not installed or not in a running Ray workflow
-            wf_run_id = task_run_id = None
+        # We assume the workflow is running on Ray
+        wf_run_id, task_inv_id, task_run_id = get_ray_backend_ids()
 
     logger = _make_logger(
         wf_run_id=wf_run_id, task_inv_id=task_inv_id, task_run_id=task_run_id

--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -159,7 +159,9 @@ def workflow_logger() -> logging.LoggerAdapter:
     Each call of this function creates a new object. It shouldn't be retained across
     task runs.
     """
-
+    wf_run_id: t.Optional[WorkflowRunId]
+    task_inv_id: t.Optional[TaskInvocationId]
+    task_run_id: t.Optional[TaskRunId]
     if is_argo_backend():
         # Workflow is running in the Orquestra QE environment
         wf_run_id, task_inv_id, task_run_id = get_argo_backend_ids()

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -162,3 +162,9 @@ else:
 
         def cancel(self, workflow_id: str):
             ray.workflow.cancel(workflow_id)
+
+        def get_current_workflow_id(self):
+            return ray.workflow.workflow_context.get_current_workflow_id()
+
+        def get_current_task_id(self):
+            return ray.workflow.workflow_context.get_current_task_id()

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -17,6 +17,8 @@ from datetime import datetime, timedelta, timezone
 from functools import singledispatch
 from pathlib import Path
 
+import pydantic
+
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _exec_ctx, _graphs, dispatch, serde
 from orquestra.sdk._base._db import WorkflowDB
@@ -214,9 +216,12 @@ def _instant_from_timestamp(unix_timestamp: t.Optional[float]) -> t.Optional[dat
     return datetime.fromtimestamp(unix_timestamp, timezone.utc)
 
 
-class InvUserMetadata(t.TypedDict):
+class InvUserMetadata(pydantic.BaseModel):
     """
     Information about a task invocation we store as a Ray metadata dict.
+
+    Pydantic helps us check that the thing we read from Ray is indeed a dictionary we
+    set (i.e. it has proper fields).
     """
 
     # Invocation ID. Scoped to a single workflow def. Allows to distinguish
@@ -229,14 +234,16 @@ class InvUserMetadata(t.TypedDict):
     task_run_id: TaskRunId
 
 
-class WfUserMetadata(t.TypedDict):
+class WfUserMetadata(pydantic.BaseModel):
     """
     Information about a workflow run we store as a Ray metadata dict.
+
+    Pydantic helps us check that the thing we read from Ray is indeed a dictionary we
+    set (i.e. it has proper fields).
     """
 
-    # An orquestra.sdk.schema.ir.WorkflowDef object transformed into a JSON-able
-    # dict. Definition of the workflow that's being run.
-    workflow_def: t.Mapping[str, t.Any]
+    # Full definition of the workflow that's being run.
+    workflow_def: ir.WorkflowDef
 
 
 @singledispatch
@@ -359,20 +366,19 @@ def _make_ray_dag(client: RayClient, wf: ir.WorkflowDef, wf_run_id: str):
         # We want to store both the TaskInvocation.id and TaskRun.id. We use
         # TaskInvocation.id to refer to Ray tasks later. Solution: Ray task
         # name for identification and Ray metadata for anything else.
-        inv_metadata: InvUserMetadata = {
-            "task_run_id": _gen_task_run_id(
-                wf_run_id=wf_run_id, invocation=ir_invocation
-            ),
-            "task_invocation_id": ir_invocation.id,
-        }
+        inv_metadata = InvUserMetadata(
+            task_run_id=_gen_task_run_id(wf_run_id=wf_run_id, invocation=ir_invocation),
+            task_invocation_id=ir_invocation.id,
+        )
 
         pip = _import_pip_env(ir_invocation, wf)
 
         ray_options = {
-            # The task name should probably be the task run ID, not invocation ID. See:
-            # https://zapatacomputing.atlassian.net/browse/ORQSDK-746
+            # We're using task invocation ID as the Ray "task ID" instead of task run ID
+            # because it's easier to query this way. Use the "user_metadata" to get both
+            # identifiers.
             "name": ir_invocation.id,
-            "metadata": inv_metadata,
+            "metadata": _pydatic_to_json_dict(inv_metadata),
             # If there are any python packages to install for step - set runtime env
             "runtime_env": (_client.RuntimeEnv(pip=pip) if len(pip) > 0 else None),
             "catch_exceptions": False,
@@ -711,16 +717,14 @@ class RayRuntime(RuntimeInterface):
             # adding path to the sys_path, so we can de-ref functions in workflow_defs
             dispatch.ensure_sys_paths([str(self._project_dir)])
             dag = _make_ray_dag(self._client, workflow_def, wf_run_id)
-            wf_user_metadata: WfUserMetadata = {
-                "workflow_def": _pydatic_to_json_dict(workflow_def),
-            }
+            wf_user_metadata = WfUserMetadata(workflow_def=workflow_def)
 
             # Unfortunately, Ray doesn't validate uniqueness of workflow IDs. Let's
             # hope we won't get a collision.
             _ = self._client.run_dag_async(
                 dag,
                 workflow_id=wf_run_id,
-                metadata=wf_user_metadata,
+                metadata=_pydatic_to_json_dict(wf_user_metadata),
             )
 
         # .get blocks for the function to be completed. This is required because:
@@ -763,8 +767,8 @@ class RayRuntime(RuntimeInterface):
                 f"Workflow run {workflow_run_id} wasn't found"
             ) from e
 
-        wf_user_meta: WfUserMetadata = wf_meta["user_metadata"]
-        wf_def: ir.WorkflowDef = ir.WorkflowDef.parse_obj(wf_user_meta["workflow_def"])
+        wf_user_metadata = WfUserMetadata.parse_obj(wf_meta["user_metadata"])
+        wf_def = wf_user_metadata.workflow_def
 
         inv_ids = wf_def.task_invocations.keys()
         # We assume that:
@@ -953,3 +957,42 @@ class RayRuntime(RuntimeInterface):
                 -limit:
             ]
         return wf_runs
+
+
+def get_current_ids() -> t.Tuple[
+    t.Optional[WorkflowRunId], t.Optional[TaskInvocationId], t.Optional[TaskRunId]
+]:
+    """
+    Uses Ray context to figure out what are the IDs of the currently running workflow
+    and task.
+
+    The returned TaskInvocationID and TaskRunID are None if we weren't able to get them
+    from current Ray context.
+    """
+    # NOTE: this is tightly coupled with how we create Ray workflow DAG, how we assign
+    # IDs and metadata.
+    client = _client.RayClient()
+
+    try:
+        wf_run_id = client.get_current_workflow_id()
+    except AssertionError:
+        # Ray has an 'assert' about checking the workflow context outside of a workflow
+        return None, None, None
+
+    # We don't need to care what kind of ID it is, we only need it to get the metadata
+    # dict.
+    ray_task_name = client.get_current_task_id()
+    task_meta: dict = client.get_task_metadata(
+        workflow_id=wf_run_id, name=ray_task_name
+    )
+
+    try:
+        user_meta = InvUserMetadata.parse_obj(task_meta.get("user_metadata"))
+    except pydantic.ValidationError:
+        # This ray task wasn't annotated with InvUserMetadata. It happens when
+        # `get_current_ids()` is used from a context that's not a regular Orquestra Task
+        # run. One example is the one-off task that we use to construct Ray DAG inside a
+        # Ray worker process.
+        return wf_run_id, None, None
+
+    return wf_run_id, user_meta.task_invocation_id, user_meta.task_run_id

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pydantic
 
+from orquestra.sdk.schema.ir import TaskInvocationId
 from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRunId
 
 from . import _client
@@ -50,6 +51,8 @@ class WFLog(pydantic.BaseModel):
     message: str
     # ID of the workflow that was run when this line was produced.
     wf_run_id: t.Optional[WorkflowRunId]
+    # ID of the task invocation (node inside the workflow def graph).
+    task_inv_id: t.Optional[TaskInvocationId]
     # ID of the task that was run when this line was produced.
     task_run_id: t.Optional[TaskRunId]
 

--- a/tests/runtime/ray/ray_logs/data/worker1.err
+++ b/tests/runtime/ray/ray_logs/data/worker1.err
@@ -1,35 +1,19 @@
 :actor_name:WorkflowManagementActor
-2023-02-01 16:04:57,663	INFO workflow_executor.py:86 -- Workflow job [id=wf.orquestra_basic_demo.e82cbfa] started.
-2023-02-01 16:04:59,442	ERROR workflow_executor.py:306 -- Task status [FAILED] due to an exception raised by the task.	[wf.orquestra_basic_demo.e82cbfa@invocation-0-task-generate-data]
-2023-02-01 16:04:59,449	ERROR workflow_executor.py:352 -- Workflow 'wf.orquestra_basic_demo.e82cbfa' failed due to [36mray::_workflow_task_executor_remote()[39m (pid=74588, ip=127.0.0.1)
+2023-02-09 12:26:05,407	INFO workflow_executor.py:86 -- Workflow job [id=wf.orquestra_basic_demo.3fcba90] started.
+2023-02-09 12:26:07,104	ERROR workflow_executor.py:306 -- Task status [FAILED] due to an exception raised by the task.	[wf.orquestra_basic_demo.3fcba90@invocation-0-task-generate-data]
+2023-02-09 12:26:07,112	ERROR workflow_executor.py:352 -- Workflow 'wf.orquestra_basic_demo.3fcba90' failed due to [36mray::_workflow_task_executor_remote()[39m (pid=25989, ip=127.0.0.1)
   File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 115, in _workflow_task_executor_remote
     return _workflow_task_executor(
   File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 84, in _workflow_task_executor
     raise e
   File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 79, in _workflow_task_executor
     output = func(*args, **kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 198, in _ray_remote
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 200, in _ray_remote
     raise e
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 193, in _ray_remote
     return wrapped(*inner_args, **inner_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 148, in __call__
     return self._fn(*unpacked_args, **unpacked_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
-    foo = 1 / 0
-ZeroDivisionError: division by zero
-2023-02-01 16:14:24,732	ERROR worker.py:399 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): [36mray::_workflow_task_executor_remote()[39m (pid=74588, ip=127.0.0.1)
-  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 115, in _workflow_task_executor_remote
-    return _workflow_task_executor(
-  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 84, in _workflow_task_executor
-    raise e
-  File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 79, in _workflow_task_executor
-    output = func(*args, **kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 198, in _ray_remote
-    raise e
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
-    return wrapped(*inner_args, **inner_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
-    return self._fn(*unpacked_args, **unpacked_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
+  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 42, in generate_data
     foo = 1 / 0
 ZeroDivisionError: division by zero

--- a/tests/runtime/ray/ray_logs/data/worker3.err
+++ b/tests/runtime/ray/ray_logs/data/worker3.err
@@ -1,38 +1,38 @@
 :task_name:create_ray_workflow
-2023-02-01 16:04:57,309	INFO api.py:203 -- Workflow job created. [id="wf.orquestra_basic_demo.e82cbfa"].
+2023-02-09 12:26:05,035	INFO api.py:203 -- Workflow job created. [id="wf.orquestra_basic_demo.3fcba90"].
 :task_name:_workflow_task_executor_remote
-2023-02-01 16:04:57,685	INFO task_executor.py:78 -- Task status [RUNNING]	[wf.orquestra_basic_demo.e82cbfa@invocation-0-task-generate-data]
-{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf.orquestra_basic_demo.e82cbfa", "task_run_id": "invocation-0-task-generate-data"}
-{"timestamp": "2023-02-01T16:04:59+0100", "level": "ERROR", "filename": "_dag.py:194", "message": "Traceback (most recent call last):\n  File \"/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py\", line 191, in _ray_remote\n    return wrapped(*inner_args, **inner_kwargs)\n  File \"/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py\", line 146, in __call__\n    return self._fn(*unpacked_args, **unpacked_kwargs)\n  File \"/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py\", line 39, in generate_data\n    foo = 1 / 0\nZeroDivisionError: division by zero\n", "wf_run_id": "wf.orquestra_basic_demo.e82cbfa", "task_run_id": "invocation-0-task-generate-data"}
+2023-02-09 12:26:05,424	INFO task_executor.py:78 -- Task status [RUNNING]	[wf.orquestra_basic_demo.3fcba90@invocation-0-task-generate-data]
+{"timestamp": "2023-02-09T11:26:07.098413+00:00", "level": "INFO", "filename": "_log_adapter.py:184", "message": "hello there!", "wf_run_id": "wf.orquestra_basic_demo.3fcba90", "task_inv_id": "invocation-0-task-generate-data", "task_run_id": "wf.orquestra_basic_demo.3fcba90@invocation-0-task-generate-data.d0751"}
+{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "ERROR", "filename": "_dag.py:196", "message": "Traceback (most recent call last):\n  File \"/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py\", line 193, in _ray_remote\n    return wrapped(*inner_args, **inner_kwargs)\n  File \"/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py\", line 148, in __call__\n    return self._fn(*unpacked_args, **unpacked_kwargs)\n  File \"/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py\", line 42, in generate_data\n    foo = 1 / 0\nZeroDivisionError: division by zero\n", "wf_run_id": "wf.orquestra_basic_demo.3fcba90", "task_inv_id": "invocation-0-task-generate-data", "task_run_id": "wf.orquestra_basic_demo.3fcba90@invocation-0-task-generate-data.d0751"}
 Traceback (most recent call last):
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 193, in _ray_remote
     return wrapped(*inner_args, **inner_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 148, in __call__
     return self._fn(*unpacked_args, **unpacked_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
+  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 42, in generate_data
     foo = 1 / 0
 ZeroDivisionError: division by zero
-2023-02-01 16:04:59,460	ERROR worker.py:399 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): [36mray::WorkflowManagementActor.execute_workflow()[39m (pid=74572, ip=127.0.0.1, repr=<ray.workflow.workflow_access.WorkflowManagementActor object at 0x113cf5660>)
-ray.exceptions.RayTaskError(ZeroDivisionError): [36mray::_workflow_task_executor_remote()[39m (pid=74588, ip=127.0.0.1)
+2023-02-09 12:26:07,118	ERROR worker.py:399 -- Unhandled error (suppress with 'RAY_IGNORE_UNHANDLED_ERRORS=1'): [36mray::WorkflowManagementActor.execute_workflow()[39m (pid=25907, ip=127.0.0.1, repr=<ray.workflow.workflow_access.WorkflowManagementActor object at 0x11bbff580>)
+ray.exceptions.RayTaskError(ZeroDivisionError): [36mray::_workflow_task_executor_remote()[39m (pid=25989, ip=127.0.0.1)
   File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 115, in _workflow_task_executor_remote
     return _workflow_task_executor(
   File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 84, in _workflow_task_executor
     raise e
   File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/task_executor.py", line 79, in _workflow_task_executor
     output = func(*args, **kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 198, in _ray_remote
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 200, in _ray_remote
     raise e
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 193, in _ray_remote
     return wrapped(*inner_args, **inner_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__
+  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 148, in __call__
     return self._fn(*unpacked_args, **unpacked_kwargs)
-  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data
+  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 42, in generate_data
     foo = 1 / 0
 ZeroDivisionError: division by zero
 
 The above exception was the direct cause of the following exception:
 
-[36mray::WorkflowManagementActor.execute_workflow()[39m (pid=74572, ip=127.0.0.1, repr=<ray.workflow.workflow_access.WorkflowManagementActor object at 0x113cf5660>)
+[36mray::WorkflowManagementActor.execute_workflow()[39m (pid=25907, ip=127.0.0.1, repr=<ray.workflow.workflow_access.WorkflowManagementActor object at 0x11bbff580>)
   File "/Users/alex/.pyenv/versions/3.10.2/lib/python3.10/concurrent/futures/_base.py", line 439, in result
     return self.__get_result()
   File "/Users/alex/.pyenv/versions/3.10.2/lib/python3.10/concurrent/futures/_base.py", line 391, in __get_result
@@ -43,4 +43,4 @@ The above exception was the direct cause of the following exception:
     await asyncio.gather(
   File "/Users/alex/Code/zapata/evangelism-workflows/venv/lib/python3.10/site-packages/ray/workflow/workflow_executor.py", line 356, in _handle_ready_task
     raise err
-ray.workflow.exceptions.WorkflowExecutionError: Workflow[id=wf.orquestra_basic_demo.e82cbfa] failed during execution.
+ray.workflow.exceptions.WorkflowExecutionError: Workflow[id=wf.orquestra_basic_demo.3fcba90] failed during execution.

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -15,23 +15,25 @@ from orquestra.sdk.schema.workflow_run import WorkflowRunId
 DATA_PATH = Path(__file__).parent / "data"
 
 
-TIMEZONE = timezone(timedelta(seconds=3600))
-TIMESTAMP = datetime(2023, 2, 1, 16, 4, 59, tzinfo=TIMEZONE)
 INFO_LOG = _ray_logs.WFLog(
-    timestamp=TIMESTAMP,
+    timestamp=datetime(2023, 2, 9, 11, 26, 7, 98413, tzinfo=timezone.utc),
     level="INFO",
-    filename="_log_adapter.py:138",
+    filename="_log_adapter.py:184",
     message="hello there!",
-    wf_run_id="wf.orquestra_basic_demo.e82cbfa",
-    task_run_id="invocation-0-task-generate-data",
+    wf_run_id="wf.orquestra_basic_demo.3fcba90",
+    task_inv_id="invocation-0-task-generate-data",
+    task_run_id="wf.orquestra_basic_demo.3fcba90@invocation-0-task-generate-data.d0751",
 )
+
+SAMPLE_TIMESTAMP = datetime(2023, 2, 9, 11, 26, 7, 99382, tzinfo=timezone.utc)
 ERROR_LOG = _ray_logs.WFLog(
-    timestamp=TIMESTAMP,
+    timestamp=SAMPLE_TIMESTAMP,
     level="ERROR",
-    filename="_dag.py:194",
-    message='Traceback (most recent call last):\n  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 191, in _ray_remote\n    return wrapped(*inner_args, **inner_kwargs)\n  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 146, in __call__\n    return self._fn(*unpacked_args, **unpacked_kwargs)\n  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 39, in generate_data\n    foo = 1 / 0\nZeroDivisionError: division by zero\n',  # noqa: E501
-    wf_run_id="wf.orquestra_basic_demo.e82cbfa",
-    task_run_id="invocation-0-task-generate-data",
+    filename="_dag.py:196",
+    message='Traceback (most recent call last):\n  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 193, in _ray_remote\n    return wrapped(*inner_args, **inner_kwargs)\n  File "/Users/alex/Code/zapata/evangelism-workflows/vendor/orquestra-workflow-sdk/src/orquestra/sdk/_ray/_dag.py", line 148, in __call__\n    return self._fn(*unpacked_args, **unpacked_kwargs)\n  File "/Users/alex/Code/zapata/evangelism-workflows/demos/basic/tasks.py", line 42, in generate_data\n    foo = 1 / 0\nZeroDivisionError: division by zero\n',  # noqa: E501
+    wf_run_id="wf.orquestra_basic_demo.3fcba90",
+    task_inv_id="invocation-0-task-generate-data",
+    task_run_id="wf.orquestra_basic_demo.3fcba90@invocation-0-task-generate-data.d0751",
 )
 
 
@@ -55,7 +57,7 @@ class TestParseLogLine:
     def test_parsing_real_files(log_file: Path, expected_parsed):
         # Given
         input_lines = log_file.read_bytes().splitlines(keepends=True)
-        wf_run_id: WorkflowRunId = "wf.orquestra_basic_demo.e82cbfa"
+        wf_run_id: WorkflowRunId = "wf.orquestra_basic_demo.3fcba90"
 
         # When
         parsed = []
@@ -80,9 +82,9 @@ class TestParseLogLine:
                 id="3rd_party_log_with_queried_id",
             ),
             pytest.param(
-                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": "wf@inv"}',  # noqa: E501
+                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": "wf@inv"}',  # noqa: E501
                 _ray_logs.WFLog(
-                    timestamp=TIMESTAMP,
+                    timestamp=SAMPLE_TIMESTAMP,
                     level="INFO",
                     filename="_log_adapter.py:138",
                     message="hello there!",
@@ -92,9 +94,9 @@ class TestParseLogLine:
                 id="valid_log_both_ids",
             ),
             pytest.param(
-                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": null, "task_run_id": null}',  # noqa: E501
+                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": null, "task_run_id": null}',  # noqa: E501
                 _ray_logs.WFLog(
-                    timestamp=TIMESTAMP,
+                    timestamp=SAMPLE_TIMESTAMP,
                     level="INFO",
                     filename="_log_adapter.py:138",
                     message="hello there!",
@@ -120,9 +122,9 @@ class TestParseLogLine:
         "line,expected",
         [
             pytest.param(
-                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": "wf@inv"}',  # noqa: E501
+                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": "wf@inv"}',  # noqa: E501
                 _ray_logs.WFLog(
-                    timestamp=TIMESTAMP,
+                    timestamp=SAMPLE_TIMESTAMP,
                     level="INFO",
                     filename="_log_adapter.py:138",
                     message="hello there!",
@@ -132,19 +134,20 @@ class TestParseLogLine:
                 id="both_ids",
             ),
             pytest.param(
-                '{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_run_id": null}',  # noqa: E501
+                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf", "task_inv_id": null, "task_run_id": null}',  # noqa: E501
                 _ray_logs.WFLog(
-                    timestamp=TIMESTAMP,
+                    timestamp=SAMPLE_TIMESTAMP,
                     level="INFO",
                     filename="_log_adapter.py:138",
                     message="hello there!",
                     wf_run_id="wf",
+                    task_inv_id=None,
                     task_run_id=None,
                 ),
                 id="only_wf_run_id",
             ),
             pytest.param(
-                '{"timestamp": "2023-02-01 12:59:26,568", "level": "INFO", "filename": "_log_adapter.py:131", "message": "hello there!", "wf_run_id": "other", "task_run_id": "wf@inv"}',  # noqa: E501
+                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:131", "message": "hello there!", "wf_run_id": "other", "task_inv_id": "inv", "task_run_id": "wf@inv"}',  # noqa: E501
                 None,
                 id="different_wf_run_id",
             ),


### PR DESCRIPTION
# The problem

`sdk.wfprint()` produces structured logs. We tag these logs with identifiers related to the workflow and the task run. Our log query machinery depends on filtering by `TaskRunID`. Meanwhile, our logs had `TaskInvocationID` set as `task_run_id` inside log entries.

Example:
```
{"timestamp": "2023-02-01T16:04:59+0100", "level": "INFO", "filename": "_log_adapter.py:138",
 "message": "hello there!", "wf_run_id": "wf.orquestra_basic_demo.e82cbfa", 
 "task_run_id": "invocation-0-task-generate-data"}
```

# This PR's solution

* Tags log entries with all three IDs: `WorkflowRunID`, `TaskInvocationID`, `TaskRunID`.
* Infers `task_*_id` in much more careful way on Ray.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
