### PR TITLE
feat: Allow secrets in workflow functions and IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 
 🔥 *Features*
+* Secrets can now be used inside workflow functions
 
 
 👩‍🔬 *Experimental*

--- a/docs/examples/tests/test_workflow_syntax.py
+++ b/docs/examples/tests/test_workflow_syntax.py
@@ -423,9 +423,9 @@ class TestSnippets:
         # Exactly 2 constants
         assert len(model.constant_nodes) == 2
         assert (
-            model.constant_nodes["constant-0"].serialization_format == "ENCODED_PICKLE"
+            model.constant_nodes["constant-1"].serialization_format == "ENCODED_PICKLE"
         )
-        assert model.constant_nodes["constant-1"].serialization_format == "JSON"
+        assert model.constant_nodes["constant-0"].serialization_format == "JSON"
 
     @staticmethod
     def test_calling_regular_function():

--- a/src/orquestra/sdk/__init__.py
+++ b/src/orquestra/sdk/__init__.py
@@ -21,6 +21,7 @@ from ._base._dsl import (
     LocalImport,
     PythonImports,
     Resources,
+    Secret,
     TaskDef,
     task,
 )
@@ -39,6 +40,7 @@ __all__ = [
     "PythonImports",
     "Resources",
     "RuntimeConfig",
+    "Secret",
     "TaskDef",
     "TaskRun",
     "WorkflowDef",

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -73,7 +73,12 @@ class UnknownPlaceholderInCustomNameWarning(Warning):
 # ----- data structures -----
 
 Constant = Any
-Argument = Union[Constant, "ArtifactFuture"]
+Argument = Union[Constant, "ArtifactFuture", "Secret"]
+
+
+class Secret(NamedTuple):
+    name: str
+    config_name: Optional[str] = None
 
 
 class GitImport(NamedTuple):

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -78,6 +78,10 @@ Argument = Union[Constant, "ArtifactFuture", "Secret"]
 
 class Secret(NamedTuple):
     name: str
+    # Config name is only used for the local runtimes where we can't infer the location
+    # where we get a secret's value from.
+    # This matches the behaviour of `sdk.secrets.get` where the config name is used to
+    # get a secret when running locally.
     config_name: Optional[str] = None
 
 

--- a/src/orquestra/sdk/_base/_exec_ctx.py
+++ b/src/orquestra/sdk/_base/_exec_ctx.py
@@ -21,6 +21,7 @@ from enum import Enum
 
 
 class ExecContext(Enum):
+    WORKFLOW_BUILD = "WORKFLOW_BUILD"
     LOCAL_DIRECT = "LOCAL_DIRECT"
     LOCAL_RAY = "LOCAL_RAY"
     PLATFORM_QE = "PLATFORM_QE"
@@ -42,6 +43,15 @@ def _set_context(ctx: ExecContext):
         yield
     finally:
         global_context = prev_val
+
+
+@contextmanager
+def workflow_build():
+    """
+    Helper. Sets the context for workflow traversal
+    """
+    with _set_context(ExecContext.WORKFLOW_BUILD):
+        yield
 
 
 @contextmanager

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -90,32 +90,32 @@ class GraphTraversal:
         We iterate over the futures returned from the workflow find the artifacts,
         constants, and secrets.
         """
-        node_counts: t.Dict[str, int] = defaultdict(int)
+        artifact_counter = 0
+        secret_counter = 0
+        constant_counter = 0
         for n in _iter_nodes(root_futures):
-            node_type: str
             if isinstance(n, _dsl.ArtifactFuture):
-                node_type = "artifact"
                 self._artifacts[_make_key(n)] = _make_artifact_node(
-                    node_counts[node_type], n
+                    artifact_counter, n
                 )
+                artifact_counter += 1
                 # Map the invocation to the future.
                 # Note: Each unique future has one invocation, but each invocation
                 #       can have many Futures.
                 #       We're mapping `invocation: set(futures from invocation)`
                 self._invocations.setdefault(n.invocation, set()).add(n)
             elif isinstance(n, _dsl.Secret):
-                node_type = "secret"
                 self._secrets[_make_key(n)] = model.SecretNode(
-                    id=f"secret-{node_counts[node_type]}",
+                    id=f"secret-{secret_counter}",
                     secret_name=n.name,
                     secret_config=n.config_name,
                 )
+                secret_counter += 1
             else:
-                node_type = "constant"
                 self._constants[_make_key(n)] = _make_constant_node(
-                    node_counts[node_type], n
+                    constant_counter, n
                 )
-            node_counts[node_type] += 1
+                constant_counter += 1
 
     @property
     def artifacts(self):

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -10,7 +10,7 @@ import collections.abc
 import hashlib
 import re
 import typing as t
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 from pip_api import Requirement
 
@@ -73,26 +73,86 @@ def _make_artifact_id(source_task: model.TaskDef, future_index: int):
     )
 
 
-def _iter_futures(root_future) -> t.Iterator[_dsl.ArtifactFuture]:
-    traversal_list = [root_future]
-    traversed_nodes = set()
-    while traversal_list:
-        current_node = traversal_list.pop()
-        # using ID as all nodes are within lifetime in this function
-        # and this allows us to quickly remove duplicate iterations
-        traversed_nodes.add(id(current_node))
-        invocation = current_node.invocation
-        for arg in [*invocation.args, *[arg for _, arg in invocation.kwargs]]:
-            if isinstance(arg, _dsl.ArtifactFuture) and id(arg) not in traversed_nodes:
-                traversal_list.append(arg)
+GraphNode = t.Union[_dsl.ArtifactFuture, _dsl.Constant, _dsl.Secret]
+
+
+class GraphTraversal:
+    def __init__(self):
+        self._artifacts = {}
+        self._invocations = {}
+        self._secrets = {}
+        self._constants = {}
+
+    def traverse(self, root_futures: t.Sequence[GraphNode]):
+        """
+        Traverse the workflow graph.
+
+        We iterate over the futures returned from the workflow find the artifacts,
+        constants, and secrets.
+        """
+        node_counts: t.Dict[str, int] = defaultdict(int)
+        for n in _iter_nodes(root_futures):
+            node_type: str
+            if isinstance(n, _dsl.ArtifactFuture):
+                node_type = "artifact"
+                self._artifacts[_make_key(n)] = _make_artifact_node(
+                    node_counts[node_type], n
+                )
+                # Map the invocation to the future.
+                # Note: Each unique future has one invocation, but each invocation
+                #       can have many Futures.
+                #       We're mapping `invocation: set(futures from invocation)`
+                self._invocations.setdefault(n.invocation, set()).add(n)
+            elif isinstance(n, _dsl.Secret):
+                node_type = "secret"
+                self._secrets[_make_key(n)] = model.SecretNode(
+                    id=f"secret-{node_counts[node_type]}",
+                    secret_name=n.name,
+                    secret_config=n.config_name,
+                )
             else:
-                # this must be a constant
-                pass
-        yield current_node
+                node_type = "constant"
+                self._constants[_make_key(n)] = _make_constant_node(
+                    node_counts[node_type], n
+                )
+            node_counts[node_type] += 1
+
+    @property
+    def artifacts(self):
+        return self._artifacts
+
+    @property
+    def constants(self):
+        return self._constants
+
+    @property
+    def invocations(self):
+        return self._invocations
+
+    @property
+    def secrets(self):
+        return self._secrets
+
+    def get_argument_id(self, node: GraphNode):
+        return self[node].id
+
+    def __getitem__(self, node: GraphNode):
+        key = _make_key(node)
+        if key in self._artifacts:
+            return self._artifacts[key]
+        elif key in self._secrets:
+            return self._secrets[key]
+        elif key in self._constants:
+            return self._constants[key]
+        else:
+            # In normal circumstances, this should never happen
+            raise KeyError(node)  # pragma: no cover
 
 
-def _iter_constants(root_future) -> t.Iterator[_dsl.Constant]:
-    traversal_list = [root_future]
+def _iter_nodes(
+    root_futures: t.Sequence[GraphNode],
+) -> t.Iterator[t.Union[_dsl.ArtifactFuture, _dsl.Constant]]:
+    traversal_list = [*root_futures]
     traversed_nodes = set()
     while traversal_list:
         current_node = traversal_list.pop()
@@ -103,20 +163,7 @@ def _iter_constants(root_future) -> t.Iterator[_dsl.Constant]:
             for arg in [*invocation.args, *[arg for _, arg in invocation.kwargs]]:
                 if _make_key(arg) not in traversed_nodes:
                     traversal_list.append(arg)
-        else:
-            # this must be a constant
-            yield current_node
-
-
-def _invert_dict(a_dict: t.Mapping):
-    """Given a dict of {k: v} returns another dict of {v: {k}}.
-    Note that multiple keys might point to the same value in the input dict. That's why
-    the values in the output are sets.
-    """
-    target_dict: t.Dict = {}
-    for k, v in a_dict.items():
-        target_dict.setdefault(v, set()).add(k)
-    return target_dict
+        yield current_node
 
 
 def _make_local_import_id(imp: _dsl.LocalImport, import_hash: str):
@@ -477,28 +524,16 @@ def _make_invocation_model(
     invocation: _dsl.TaskInvocation,
     invocation_index: int,
     task_models_dict: t.Dict[_dsl.TaskDef, model.TaskDef],
-    constant_node_dict: t.Dict[_dsl.Constant, model.ConstantNode],
-    future_node_dict: t.Dict[_dsl.ArtifactFuture, model.ArtifactNode],
-    invocation_outputs: t.Dict[_dsl.TaskInvocation, t.Set[_dsl.ArtifactFuture]],
+    graph: GraphTraversal,
 ):
-    args_ids = [
-        future_node_dict[arg].id if isinstance(arg, _dsl.ArtifactFuture)
-        # We use `_make_key()` because the keys need to be hashable
-        else constant_node_dict[_make_key(arg)].id
-        for i, arg in enumerate(invocation.args)
-    ]
+    args_ids = [graph.get_argument_id(arg) for arg in invocation.args]
 
     kwargs_ids = {
-        arg_name: (
-            future_node_dict[arg_val].id
-            if isinstance(arg_val, _dsl.ArtifactFuture)
-            # We use `_make_key()` because the keys need to be hashable
-            else constant_node_dict[_make_key(arg_val)].id
-        )
+        arg_name: graph.get_argument_id(arg_val)
         for arg_name, arg_val in invocation.kwargs
     }
 
-    sorted_outputs = sorted(invocation_outputs[invocation], key=_sort_artifact_futures)
+    sorted_outputs = sorted(graph.invocations[invocation], key=_sort_artifact_futures)
 
     return model.TaskInvocation(
         id=_make_invocation_id(
@@ -509,9 +544,7 @@ def _make_invocation_model(
         task_id=task_models_dict[invocation.task].id,
         args_ids=args_ids,
         kwargs_ids=kwargs_ids,
-        output_ids=[
-            future_node_dict[output_future].id for output_future in sorted_outputs
-        ],
+        output_ids=[graph[output_future].id for output_future in sorted_outputs],
         resources=_make_resources_model(invocation.resources),
         custom_image=invocation.custom_image,
     )
@@ -560,35 +593,8 @@ def flatten_graph(
     """
     root_futures = futures
 
-    future_node_dict: t.Dict[_dsl.ArtifactFuture, model.ArtifactNode] = {
-        future: _make_artifact_node(future_i, future)
-        for future_i, future in enumerate(
-            [
-                future
-                for root_future in root_futures
-                if isinstance(root_future, _dsl.ArtifactFuture)
-                for future in _iter_futures(root_future)
-            ]
-        )
-    }
-    constant_node_dict: t.Dict[_dsl.Constant, model.ConstantNode] = {
-        # We use `_make_key()` because the keys need to be hashable
-        _make_key(constant): _make_constant_node(constant_i, constant)
-        for constant_i, constant in enumerate(
-            [
-                constant
-                for root_feature in root_futures
-                for constant in _iter_constants(root_feature)
-            ]
-        )
-    }
-
-    output_invocations: t.Dict[_dsl.ArtifactFuture, _dsl.TaskInvocation] = {
-        future: future.invocation for future in future_node_dict.keys()
-    }
-    invocation_outputs: t.Dict[
-        _dsl.TaskInvocation, t.Set[_dsl.ArtifactFuture]
-    ] = _invert_dict(output_invocations)
+    graph = GraphTraversal()
+    graph.traverse(root_futures)
 
     import_models_dict: t.Dict[_dsl.Import, model.Import] = {}
 
@@ -596,7 +602,7 @@ def flatten_graph(
     # As deferred git imports are fetching repos inside model creation, this is used
     # to avoid git fetch spam for the same repos over and over.
     cached_git_import_dict: t.Dict[t.Tuple, model.Import] = {}
-    for invocation in invocation_outputs.keys():
+    for invocation in graph.invocations.keys():
         for imp in [
             invocation.task.source_import,
             *(invocation.task.dependency_imports or []),
@@ -615,29 +621,24 @@ def flatten_graph(
 
     task_models_dict: t.Dict[_dsl.TaskDef, model.TaskDef] = {
         invocation.task: _make_task_model(invocation.task, import_models_dict)
-        for invocation in invocation_outputs.keys()
+        for invocation in graph.invocations.keys()
     }
 
-    dsl_invocations = list(invocation_outputs.keys())
+    dsl_invocations = list(graph.invocations.keys())
 
     invocation_models_dict: t.Dict[_dsl.TaskInvocation, model.TaskInvocation] = {
         dsl_invocation: _make_invocation_model(
             invocation=dsl_invocation,
             invocation_index=dsl_invocation_i,
             task_models_dict=task_models_dict,
-            constant_node_dict=constant_node_dict,
-            future_node_dict=future_node_dict,
-            invocation_outputs=invocation_outputs,
+            graph=graph,
         )
         for dsl_invocation_i, dsl_invocation in enumerate(dsl_invocations)
     }
 
     output_ids: t.List[t.Union[model.ConstantNodeId, model.ArtifactNodeId]] = []
     for output_future in futures:
-        if isinstance(output_future, _dsl.ArtifactFuture):
-            output_id = future_node_dict[output_future].id
-        else:
-            output_id = constant_node_dict[_make_key(output_future)].id
+        output_id = graph.get_argument_id(output_future)
         output_ids.append(output_id)
     return model.WorkflowDef(
         # At the moment 'orq submit workflow-def <name>' assumes that the <name> is
@@ -652,11 +653,14 @@ def flatten_graph(
         tasks={task_model.id: task_model for task_model in task_models_dict.values()},
         artifact_nodes={
             artifact_node.id: artifact_node
-            for artifact_node in future_node_dict.values()
+            for artifact_node in graph.artifacts.values()
+        },
+        secret_nodes={
+            secret_node.id: secret_node for secret_node in graph.secrets.values()
         },
         constant_nodes={
             constant_node.id: constant_node
-            for constant_node in constant_node_dict.values()
+            for constant_node in graph.constants.values()
         },
         task_invocations={
             invocation.id: invocation for invocation in invocation_models_dict.values()

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -95,9 +95,7 @@ class GraphTraversal:
         constant_counter = 0
         for n in _iter_nodes(root_futures):
             if isinstance(n, _dsl.ArtifactFuture):
-                self._artifacts[_make_key(n)] = _make_artifact_node(
-                    artifact_counter, n
-                )
+                self._artifacts[_make_key(n)] = _make_artifact_node(artifact_counter, n)
                 artifact_counter += 1
                 # Map the invocation to the future.
                 # Note: Each unique future has one invocation, but each invocation
@@ -112,9 +110,7 @@ class GraphTraversal:
                 )
                 secret_counter += 1
             else:
-                self._constants[_make_key(n)] = _make_constant_node(
-                    constant_counter, n
-                )
+                self._constants[_make_key(n)] = _make_constant_node(constant_counter, n)
                 constant_counter += 1
 
     @property

--- a/src/orquestra/sdk/schema/ir.py
+++ b/src/orquestra/sdk/schema/ir.py
@@ -195,6 +195,7 @@ TaskInvocationId = str
 TaskNodeId = str
 ArtifactNodeId = str
 ConstantNodeId = str
+SecretNodeId = str
 
 
 class ArtifactNode(BaseModel):
@@ -269,7 +270,22 @@ class ConstantNodePickle(BaseModel):
 ConstantNode = t.Union[ConstantNodeJSON, ConstantNodePickle]
 
 
-ArgumentId = t.Union[ArtifactNodeId, ConstantNodeId]
+class SecretNode(BaseModel):
+    """
+    A reference to a secret stored in an external secret/config service.
+    """
+
+    # Workflow-scope unique ID used to refer from task invocations
+    id: SecretNodeId
+
+    # Serialized value
+    secret_name: str
+
+    # Secret config
+    secret_config: t.Optional[str] = None
+
+
+ArgumentId = t.Union[ArtifactNodeId, ConstantNodeId, SecretNodeId]
 
 
 class TaskInvocation(BaseModel):
@@ -313,6 +329,7 @@ class WorkflowDef(BaseModel):
     tasks: t.Dict[TaskDefId, TaskDef]
     artifact_nodes: t.Dict[ArtifactNodeId, ArtifactNode]
     constant_nodes: t.Dict[ConstantNodeId, ConstantNode]
+    secret_nodes: t.Dict[SecretNodeId, SecretNode] = {}
 
     # The actual graph in form node clusters ("invocations"). Each task invocation is a
     # small subgraph with TaskNode in the center and connections to data nodes

--- a/src/orquestra/sdk/schema/ir.py
+++ b/src/orquestra/sdk/schema/ir.py
@@ -282,6 +282,8 @@ class SecretNode(BaseModel):
     secret_name: str
 
     # Secret config
+    # This is only used locally, and we expect this to be None (or ignored) on remote
+    # runtimes.
     secret_config: t.Optional[str] = None
 
 

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -28,7 +28,7 @@ def get(
     name: str,
     *,
     config_name: t.Optional[str] = None,
-) -> t.Union[str, _dsl.Secret]:
+) -> str:
     """
     Retrieves secret value from the remote vault.
 
@@ -47,7 +47,7 @@ def get(
             remote vault failed.
     """
     if _exec_ctx.global_context == _exec_ctx.ExecContext.WORKFLOW_BUILD:
-        return _dsl.Secret(name=name, config_name=config_name)
+        return t.cast(str, _dsl.Secret(name=name, config_name=config_name))
     provider = _infer_secrets_provider()
     client = provider.make_client(
         config_name=config_name,

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -45,6 +45,13 @@ def get(
             was found.
         orquestra.sdk.exceptions.UnauthorizedError: when the authorization with the
             remote vault failed.
+
+    Returns:
+        Either:
+        - the value of the secret
+        - if used inside a workflow function (a function decorated with @sdk.workflow),
+            this function will return a "future" which will be used to retrieve the
+            secret at execution time.
     """
     if _exec_ctx.global_context == _exec_ctx.ExecContext.WORKFLOW_BUILD:
         return t.cast(str, _dsl.Secret(name=name, config_name=config_name))

--- a/src/orquestra/sdk/secrets/_providers.py
+++ b/src/orquestra/sdk/secrets/_providers.py
@@ -13,7 +13,7 @@ from .._base import _config
 from ._client import SecretsClient
 
 
-class SecretsProvider(t.Protocol):
+class SecretsAuthProvider(t.Protocol):
     """
     Builds a ``SecretsClient`` object with a proper authorization.
     Implementations of this protocol decide where to get the auth from.
@@ -34,7 +34,7 @@ class ConfigProvider:
     """
     Gets auth creds from a local config file.
 
-    Implements SecretsProvider.
+    Implements SecretsAuthProvider.
     """
 
     def make_client(
@@ -53,7 +53,7 @@ class PassportProvider:
       by ORQUESTRA_PASSPORT_FILE env var.
     * The URI is hardcoded to a self-reference.
 
-    Implements SecretsProvider. Ignores the ``config_name`` and ``config_save_path``
+    Implements SecretsAuthProvider. Ignores the ``config_name`` and ``config_save_path``
     arguments.
     """
 

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -494,22 +494,22 @@ class TestRayRuntimeMethods:
             _example_wfs.multioutput_wf,
             ("Emiliano Zapata", "Zapata computing"),
             {
-                "invocation-0-task-concat": ("Emiliano Zapata",),
-                "invocation-1-task-capitalize": ("Zapata",),
-                "invocation-2-task-capitalize": ("Zapata computing",),
-                "invocation-3-task-make-company-name": ("zapata computing",),
+                "invocation-0-task-capitalize": ("Zapata computing",),
+                "invocation-1-task-make-company-name": ("zapata computing",),
+                "invocation-2-task-concat": ("Emiliano Zapata",),
+                "invocation-3-task-capitalize": ("Zapata",),
             },
         ),
         (
             _example_wfs.multioutput_task_wf,
             ("Zapata", "Computing", "Computing", ("Zapata", "Computing")),
             {
-                "invocation-0-task-multioutput-task": ("Zapata", "Computing"),
                 # The outputs for invocation 1 and 2 should be just a single tuple, not
                 # tuple-in-tuple. TODO: change it when working on
                 # https://zapatacomputing.atlassian.net/browse/ORQSDK-695.
+                "invocation-0-task-multioutput-task": (("Zapata", "Computing"),),
                 "invocation-1-task-multioutput-task": (("Zapata", "Computing"),),
-                "invocation-2-task-multioutput-task": (("Zapata", "Computing"),),
+                "invocation-2-task-multioutput-task": ("Zapata", "Computing"),
             },
         ),
         (
@@ -525,10 +525,10 @@ class TestRayRuntimeMethods:
             _example_wfs.wf_using_inline_imports,
             ("Emiliano Zapata", "Zapata computing"),
             {
-                "invocation-0-task-concat": ("Emiliano Zapata",),
-                "invocation-1-task-capitalize-inline": ("Zapata",),
-                "invocation-2-task-capitalize-inline": ("Zapata computing",),
-                "invocation-3-task-make-company-name": ("zapata computing",),
+                "invocation-0-task-capitalize-inline": ("Zapata computing",),
+                "invocation-1-task-make-company-name": ("zapata computing",),
+                "invocation-2-task-concat": ("Emiliano Zapata",),
+                "invocation-3-task-capitalize-inline": ("Zapata",),
             },
         ),
     ],

--- a/tests/sdk/v2/secrets/test_api.py
+++ b/tests/sdk/v2/secrets/test_api.py
@@ -77,6 +77,18 @@ class TestSelectsAppropriateProvider:
 
     class TestGet:
         @staticmethod
+        def test_returns_future_in_workflow_ctx(dummy_config_name, secret_name):
+            """
+            A special context for workflow builds. This does not use the underlying
+            config auth provider.
+            """
+            with _exec_ctx.workflow_build():
+                secret = sdk.secrets.get(secret_name, config_name=dummy_config_name)
+            assert isinstance(secret, sdk.Secret)
+            assert secret.name == secret_name
+            assert secret.config_name == dummy_config_name
+
+        @staticmethod
         def test_default_ctx(
             ConfigProvider,
             PassportProvider,

--- a/tests/sdk/v2/test_artifact_future_methods.py
+++ b/tests/sdk/v2/test_artifact_future_methods.py
@@ -285,14 +285,14 @@ class TestArifactFutureMethodsCalls:
             )
             == 1
         )
-        assert [*wf_model.task_invocations.values()][0].resources is None
+        assert [*wf_model.task_invocations.values()][1].resources is None
         assert [*wf_model.task_invocations.values()][
-            1
+            0
         ].resources.dict() == resources_no_default
 
-        assert [*wf_model.task_invocations.values()][0].custom_image is DEFAULT_IMAGE
+        assert [*wf_model.task_invocations.values()][1].custom_image is DEFAULT_IMAGE
         assert [*wf_model.task_invocations.values()][
-            1
+            0
         ].custom_image == custom_image_no_default["custom_image"]
 
     @staticmethod
@@ -314,14 +314,14 @@ class TestArifactFutureMethodsCalls:
             )
             == 1
         )
-        assert [*wf_model.task_invocations.values()][0].resources is None
+        assert [*wf_model.task_invocations.values()][1].resources is None
         assert [*wf_model.task_invocations.values()][
-            1
+            0
         ].resources.dict() == resources_no_default
 
-        assert [*wf_model.task_invocations.values()][0].custom_image == [
+        assert [*wf_model.task_invocations.values()][1].custom_image == [
             *wf_model.task_invocations.values()
-        ][1].custom_image
+        ][0].custom_image
 
     @staticmethod
     def test_artifact_with_custom_image_workflow_model():
@@ -342,13 +342,13 @@ class TestArifactFutureMethodsCalls:
             )
             == 1
         )
-        assert [*wf_model.task_invocations.values()][0].resources == [
+        assert [*wf_model.task_invocations.values()][1].resources == [
             *wf_model.task_invocations.values()
-        ][1].resources
+        ][0].resources
 
-        assert [*wf_model.task_invocations.values()][0].custom_image == DEFAULT_IMAGE
+        assert [*wf_model.task_invocations.values()][1].custom_image == DEFAULT_IMAGE
         assert [*wf_model.task_invocations.values()][
-            1
+            0
         ].custom_image == custom_image_no_default["custom_image"]
 
     @staticmethod
@@ -370,12 +370,13 @@ class TestArifactFutureMethodsCalls:
             )
             == 1
         )
-        assert [*wf_model.task_invocations.values()][0].resources is None
+        print([*wf_model.task_invocations.values()])
+        assert [*wf_model.task_invocations.values()][1].resources is None
         assert [*wf_model.task_invocations.values()][
-            1
+            0
         ].resources.dict() == resources_no_default
 
-        assert [*wf_model.task_invocations.values()][0].custom_image is DEFAULT_IMAGE
+        assert [*wf_model.task_invocations.values()][1].custom_image is DEFAULT_IMAGE
         assert [*wf_model.task_invocations.values()][
-            1
+            0
         ].custom_image == custom_image_no_default["custom_image"]

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -15,7 +15,7 @@ import git
 import pytest
 
 import orquestra.sdk.schema.ir as model
-from orquestra.sdk import exceptions
+from orquestra.sdk import exceptions, secrets
 from orquestra.sdk._base import _dsl, _traversal, _workflow, serde
 
 from .data.complex_serialization.workflow_defs import (
@@ -353,6 +353,12 @@ def wf_with_inline():
 @_workflow.workflow
 def dupe_import_wf():
     return duplicate_deps()
+
+
+@_workflow.workflow
+def workflow_with_secret():
+    secret = secrets.get("my_secret")
+    return simple_task(secret)
 
 
 def _id_from_wf(param):
@@ -1154,3 +1160,10 @@ def test_find_obj_in_nested_fields(root, needle_type, expected):
         return isinstance(o, needle_type)
 
     assert _traversal._find_nested_objs_in_fields(root, _predicate) == expected
+
+
+def test_workflow_with_secret():
+    wf = workflow_with_secret().model
+    assert len(wf.secret_nodes) == 1
+    assert len(wf.constant_nodes) == 0
+    assert wf.secret_nodes["secret-0"].secret_name == "my_secret"

--- a/tests/sdk/v2/test_viz.py
+++ b/tests/sdk/v2/test_viz.py
@@ -19,45 +19,45 @@ class TestWfDefGraph:
 
         assert graph.nodes1 == [
             _viz.Node(
-                id="invocation-0-task-add",
-                caption=["tests.sdk.v2.sample_wfs.add():12", "invocation-0-task-add"],
+                id="invocation-0-task-inc",
+                caption=["tests.sdk.v2.sample_wfs.inc():17", "invocation-0-task-inc"],
             ),
             _viz.Node(
-                id="invocation-1-task-integer-division",
+                id="invocation-1-task-inc-2",
+                caption=["[inlined].inc_2()", "invocation-1-task-inc-2"],
+            ),
+            _viz.Node(
+                id="invocation-2-task-integer-division",
                 caption=[
                     "tests.sdk.v2.sample_wfs.integer_division():27",
-                    "invocation-1-task-integer-division",
+                    "invocation-2-task-integer-division",
                 ],
             ),
             _viz.Node(
-                id="invocation-2-task-inc",
-                caption=["tests.sdk.v2.sample_wfs.inc():17", "invocation-2-task-inc"],
-            ),
-            _viz.Node(
-                id="invocation-3-task-inc-2",
-                caption=["[inlined].inc_2()", "invocation-3-task-inc-2"],
+                id="invocation-3-task-add",
+                caption=["tests.sdk.v2.sample_wfs.add():12", "invocation-3-task-add"],
             ),
         ]
         assert graph.nodes2 == [
-            _viz.Node(id="artifact-0-add", caption=[]),
-            _viz.Node(id="artifact-1-integer-division", caption=[]),
+            _viz.Node(id="artifact-0-inc", caption=[]),
+            _viz.Node(id="artifact-1-inc-2", caption=[]),
             _viz.Node(id="artifact-4-integer-division", caption=[]),
-            _viz.Node(id="artifact-2-inc", caption=[]),
-            _viz.Node(id="artifact-3-inc-2", caption=[]),
-            _viz.Node(id="constant-0", caption=["6"]),
-            _viz.Node(id="constant-3", caption=["3"]),
-            _viz.Node(id="constant-4", caption=["123"]),
+            _viz.Node(id="artifact-2-integer-division", caption=[]),
+            _viz.Node(id="artifact-3-add", caption=[]),
+            _viz.Node(id="constant-0", caption=["3"]),
+            _viz.Node(id="constant-1", caption=["123"]),
+            _viz.Node(id="constant-2", caption=["6"]),
         ]
         assert graph.edges == [
-            ("artifact-1-integer-division", "invocation-0-task-add"),
-            ("constant-0", "invocation-0-task-add"),
-            ("invocation-0-task-add", "artifact-0-add"),
-            ("constant-4", "invocation-1-task-integer-division"),
-            ("constant-3", "invocation-1-task-integer-division"),
-            ("invocation-1-task-integer-division", "artifact-1-integer-division"),
-            ("invocation-1-task-integer-division", "artifact-4-integer-division"),
-            ("artifact-3-inc-2", "invocation-2-task-inc"),
-            ("invocation-2-task-inc", "artifact-2-inc"),
-            ("artifact-4-integer-division", "invocation-3-task-inc-2"),
-            ("invocation-3-task-inc-2", "artifact-3-inc-2"),
+            ("artifact-1-inc-2", "invocation-0-task-inc"),
+            ("invocation-0-task-inc", "artifact-0-inc"),
+            ("artifact-2-integer-division", "invocation-1-task-inc-2"),
+            ("invocation-1-task-inc-2", "artifact-1-inc-2"),
+            ("constant-1", "invocation-2-task-integer-division"),
+            ("constant-0", "invocation-2-task-integer-division"),
+            ("invocation-2-task-integer-division", "artifact-4-integer-division"),
+            ("invocation-2-task-integer-division", "artifact-2-integer-division"),
+            ("artifact-4-integer-division", "invocation-3-task-add"),
+            ("constant-2", "invocation-3-task-add"),
+            ("invocation-3-task-add", "artifact-3-add"),
         ]


### PR DESCRIPTION
# The problem

Currently, if someone wanted to use a secret inside their workflow, they may accidentally expose the secret value as a constant inside the workflow graph.

# This PR's solution

- Adds a new exec context for workflow building
- Returns a "Secret" future for any call to `sdk.secrets.get` inside this new context
- Adds a new node to the IR for secrets
- Updates the traversal code to accept this new node

Note: the traversal code has changed, meaning the ordering of invocations, constants, and artifacts may have changed.
This does not impact any previously generated workflows.

Following PRs will add this functionality to:
- Ray
- QE
- In-process

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
