### PR TITLE
feat: IR Secrets in runtimes

### DIFF
--- a/src/orquestra/sdk/_base/_conversions/_invocations.py
+++ b/src/orquestra/sdk/_base/_conversions/_invocations.py
@@ -10,6 +10,7 @@ from orquestra.sdk.schema import ir, responses, yaml_model
 # TODO: it would be nice to have a single document where the user could look up a "type"
 # from the workflow yaml and see what it's about.
 RESULT_DICT_TYPE_NAME = "workflow-result-dict"
+SECRET_DICT_TYPE_NAME = "workflow-secret-dict"
 SDK_METADATA_TYPE_NAME = "sdk-metadata"
 
 
@@ -51,6 +52,7 @@ class InvocationTranslator:
         self._task_defs_dict = wf.tasks
         self._constants_dict = wf.constant_nodes
         self._artifacts_dict = wf.artifact_nodes
+        self._secrets_dict = wf.secret_nodes
         self._ir_imports = wf.imports
         # Tells what invocation is required to produce a given artifact.
         self._artifact_producer_dict: t.Mapping[
@@ -71,6 +73,10 @@ class InvocationTranslator:
     @property
     def result_dict_type_name(self):
         return RESULT_DICT_TYPE_NAME
+
+    @property
+    def secret_dict_type_name(self):
+        return SECRET_DICT_TYPE_NAME
 
     @property
     def sdk_metadata_type_name(self):
@@ -182,6 +188,20 @@ class InvocationTranslator:
 
         return [fn_dict, output_dict, sys_path_dict]
 
+    def _make_input(
+        self, arg_id: ir.ArgumentId, name: t.Optional[ir.ParameterName] = None
+    ):
+        if arg_id in self._constants_dict:
+            constant = self._constants_dict[arg_id]
+            return _make_constant_input(name or arg_id, constant)
+        elif arg_id in self._secrets_dict:
+            secret = self._secrets_dict[arg_id]
+            return _make_secret_input(name or arg_id, secret)
+        else:
+            artifact = self._artifacts_dict[arg_id]
+            producing_invocation = self._artifact_producer_dict[arg_id]
+            return _make_artifact_input(name or arg_id, artifact, producing_invocation)
+
     def _make_args_inputs(self, args_ids: t.Sequence[ir.ArgumentId]):
         args_inputs = [
             {
@@ -190,15 +210,7 @@ class InvocationTranslator:
             }
         ]
         for arg_id in args_ids:
-            try:
-                constant = self._constants_dict[arg_id]
-                args_inputs.append(_make_constant_input(arg_id, constant))
-            except KeyError:
-                artifact = self._artifacts_dict[arg_id]
-                producing_invocation = self._artifact_producer_dict[arg_id]
-                args_inputs.append(
-                    _make_artifact_input(arg_id, artifact, producing_invocation)
-                )
+            args_inputs.append(self._make_input(arg_id))
         return args_inputs
 
     def _make_kwargs_inputs(
@@ -206,16 +218,7 @@ class InvocationTranslator:
     ):
         inputs = []
         for arg_name, arg_id in (kwargs_ids or {}).items():
-            try:
-                constant = self._constants_dict[arg_id]
-                inputs.append(_make_constant_input(arg_name, constant))
-            except KeyError:
-                artifact = self._artifacts_dict[arg_id]
-                producing_invocation = self._artifact_producer_dict[arg_id]
-                inputs.append(
-                    _make_artifact_input(arg_name, artifact, producing_invocation)
-                )
-
+            inputs.append(self._make_input(arg_id, arg_name))
         return inputs
 
     def _make_outputs(self, output_ids: t.Iterable[ir.ArtifactNodeId]):
@@ -308,6 +311,14 @@ def _make_constant_input(
     return {
         arg_name: json_dict,
         "type": RESULT_DICT_TYPE_NAME,
+    }
+
+
+def _make_secret_input(arg_name: str, secret: ir.SecretNode) -> yaml_model.StepInput:
+    json_dict = json.loads(secret.json())
+    return {
+        arg_name: json_dict,
+        "type": SECRET_DICT_TYPE_NAME,
     }
 
 

--- a/src/orquestra/sdk/_base/_conversions/_invocations.py
+++ b/src/orquestra/sdk/_base/_conversions/_invocations.py
@@ -14,6 +14,10 @@ SECRET_DICT_TYPE_NAME = "workflow-secret-dict"
 SDK_METADATA_TYPE_NAME = "sdk-metadata"
 
 
+def _json_dict_from_pydantic(model):
+    return json.loads(model.json())
+
+
 class InvocationTranslator:
     """
     Translates task invocations from the IR (`orquestra.sdk.schema.ir`) to YAML
@@ -306,7 +310,7 @@ def _make_constant_input(
             f"are supported. ({type(constant.serialization_format)}) is not."
         )
 
-    json_dict = json.loads(result.json())
+    json_dict = _json_dict_from_pydantic(result)
 
     return {
         arg_name: json_dict,
@@ -315,7 +319,7 @@ def _make_constant_input(
 
 
 def _make_secret_input(arg_name: str, secret: ir.SecretNode) -> yaml_model.StepInput:
-    json_dict = json.loads(secret.json())
+    json_dict = _json_dict_from_pydantic(secret)
     return {
         arg_name: json_dict,
         "type": SECRET_DICT_TYPE_NAME,

--- a/src/orquestra/sdk/_base/_conversions/_yaml_exporter.py
+++ b/src/orquestra/sdk/_base/_conversions/_yaml_exporter.py
@@ -86,6 +86,7 @@ def workflow_to_yaml(
         types=[
             inv_translator.sdk_metadata_type_name,
             inv_translator.result_dict_type_name,
+            inv_translator.secret_dict_type_name,
         ],
         dataAggregation=data_aggregation,
     )

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -15,6 +15,7 @@ from orquestra.sdk.schema.workflow_run import (
     WorkflowRunId,
 )
 
+from .. import secrets
 from ..exceptions import WorkflowRunNotFoundError
 from ._graphs import iter_invocations_topologically
 from .dispatch import locate_fn_ref
@@ -95,6 +96,10 @@ class InProcessRuntime(abc.RuntimeInterface):
             id: deserialize_constant(node)
             for id, node in workflow_def.constant_nodes.items()
         }
+        for id, secret in workflow_def.secret_nodes.items():
+            consts[id] = secrets.get(
+                secret.secret_name, config_name=secret.secret_config
+            )
         # We'll store artifacts for this run here.
         self._artifact_store[run_id] = {}
 

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -290,3 +290,9 @@ def wf_with_exec_ctx():
 @sdk.workflow
 def parametrized_wf(a: int):
     return add(a, 5)
+
+
+@sdk.workflow
+def wf_with_secrets():
+    secret = sdk.secrets.get("some-secret", config_name="test_config_default")
+    return capitalize_inline(secret)

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1200,6 +1200,7 @@ class TestWorkflowDefRepoIntegration:
                 "wf_with_log",
                 "wf_with_exec_ctx",
                 "parametrized_wf",
+                "wf_with_secrets",
             ]
 
         @staticmethod

--- a/tests/sdk/v2/conversions/data/additional-metrics.yml
+++ b/tests/sdk/v2/conversions/data/additional-metrics.yml
@@ -94,3 +94,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/basics.yml
+++ b/tests/sdk/v2/conversions/data/basics.yml
@@ -56,3 +56,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/basics_file_ref.yml
+++ b/tests/sdk/v2/conversions/data/basics_file_ref.yml
@@ -55,3 +55,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/basics_with_data_aggregation.yml
+++ b/tests/sdk/v2/conversions/data/basics_with_data_aggregation.yml
@@ -65,3 +65,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/basics_with_gpu.yml
+++ b/tests/sdk/v2/conversions/data/basics_with_gpu.yml
@@ -57,3 +57,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/custom_json.yml
+++ b/tests/sdk/v2/conversions/data/custom_json.yml
@@ -55,3 +55,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/exportable_wf.yml
+++ b/tests/sdk/v2/conversions/data/exportable_wf.yml
@@ -89,3 +89,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/inline_function.yml
+++ b/tests/sdk/v2/conversions/data/inline_function.yml
@@ -80,3 +80,4 @@ RlJxR3NzhnFIYi4=\n"]
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/main_test.yml
+++ b/tests/sdk/v2/conversions/data/main_test.yml
@@ -47,3 +47,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/multi_task_outputs.yml
+++ b/tests/sdk/v2/conversions/data/multi_task_outputs.yml
@@ -82,3 +82,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/multi_task_outputs_as_inputs.yml
+++ b/tests/sdk/v2/conversions/data/multi_task_outputs_as_inputs.yml
@@ -86,3 +86,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/positional.yml
+++ b/tests/sdk/v2/conversions/data/positional.yml
@@ -55,3 +55,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/positional_artifact.yml
+++ b/tests/sdk/v2/conversions/data/positional_artifact.yml
@@ -92,3 +92,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/conversions/data/python_import.yml
+++ b/tests/sdk/v2/conversions/data/python_import.yml
@@ -61,3 +61,4 @@ steps:
 types:
 - sdk-metadata
 - workflow-result-dict
+- workflow-secret-dict

--- a/tests/sdk/v2/test_in_process_runtime.py
+++ b/tests/sdk/v2/test_in_process_runtime.py
@@ -9,14 +9,17 @@ We need this file because test_api.py might be too coarse for some scenarios.
 When adding new tests, please consider that suite first.
 """
 from datetime import datetime, timedelta, timezone
+from unittest.mock import create_autospec
 
 import pytest
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
 from orquestra.sdk._base._in_process_runtime import InProcessRuntime
+from orquestra.sdk._base._testing._example_wfs import wf_with_secrets
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.workflow_run import State, WorkflowRunId
+from orquestra.sdk.secrets import _client, _models
 
 from .data.complex_serialization.workflow_defs import (
     wf_pass_callables_from_task,
@@ -59,6 +62,20 @@ def wf_def_unused_outputs() -> ir.WorkflowDef:
 @pytest.fixture
 def wf_def_all_used() -> ir.WorkflowDef:
     return wf_all_used().model
+
+
+def test_secret_inside_ir(
+    tmp_default_config_json, monkeypatch: pytest.MonkeyPatch, runtime: InProcessRuntime
+):
+    mocked_secret = _models.SecretDefinition(name="a-secret", value="mocked")
+    get_secret = create_autospec(_client.SecretsClient.get_secret)
+    get_secret.return_value = mocked_secret
+    monkeypatch.setattr(_client.SecretsClient, "get_secret", get_secret)
+
+    run_id = runtime.create_workflow_run(wf_with_secrets().model)
+    result = runtime.get_workflow_run_outputs(run_id)
+
+    assert result == "Mocked"
 
 
 class TestQueriesAfterRunning:


### PR DESCRIPTION
# The problem

Secrets are in the IR (#52) and now we need to implement runtime support

# This PR's solution

- Update Ray, QE, and in-process runtimes to get the secrets from the secrets API

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
