### PR TITLE
chore: Update ctrl-c handling in orq login

### DIFF
--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -61,7 +61,7 @@ class Action:
     def _prompt_for_login(self, url: str, ce: bool):
         try:
             asyncio.run(self._get_token_from_server(url, ce, 60))
-        except web.GracefulExit:
+        except (web.GracefulExit, KeyboardInterrupt):
             pass
         if self._login_server.token is None:
             # We didn't get a token, this means the collector timed out or otherwise

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -217,7 +217,9 @@ class LoginPresenter:
         click.echo(f"Configuration name for {url} is {config_name}")
 
     def print_login_help(self):
-        click.echo("Continue the login process in your web browser.")
+        click.echo(
+            "Continue the login process in your web browser. Press [ctrl-c] to cancel."
+        )
 
     def open_url_in_browser(self, url) -> bool:
         return webbrowser.open(url)


### PR DESCRIPTION
# The problem

If a user cannot complete the login process, it's difficult to tell how to proceed.

# This PR's solution

- Updates the login prompt to tell the user to use ctrl-c to cancel the automatic login process
- Catch KeyboardInterrupt to print out the manual login process message

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
