### PR TITLE
chore: Pin dill to a release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     # Schema definition 
     pydantic<2
     # Pickling library
-    dill
+    dill==0.3.6
     # Enhances wrapping of user's functions
     wrapt
     # Configuration file locking


### PR DESCRIPTION
# The problem

An internal user ran into issues when pickling some data. It turned out they were using `dill==0.3.4` on one machine and `dill==0.3.6` on another.

# This PR's solution

Pin `dill` to a specific version to stop any pickling differences between versions.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
