### PR TITLE
chore: add missing changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 
 🐛 *Bug Fixes*
+* Getting full logs produced by Ray workflows. Previously, the dictionary returned by `logs_dict = wf_run.get_logs()` had just a single entry: `{"logs": ["task 1 log", "task 1 log", "task 2 log", "task 2 log"]}`. Now, the dictionary has a correct shape: `{"task_invocation_id1": ["task 1 log", "task 1 log"], "task_invocation_id2": ["task 2 log", "task 2 log"]}`.
+* Getting single task logs. Previously `orq task logs` would raise an unhandled exception. Now, it prints the log lines.
 
 
 *Internal*


### PR DESCRIPTION
# The problem

I forgot to edit the changelog when working on https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/51.

# This PR's solution

Adds missing changelog content.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
