### PR TITLE
refactor: harden mypy typechecks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ isort:
 # For mypy we additionally need to exclude one of the testing directories.
 # (override)
 mypy:
-	$(PYTHON) -m mypy src tests --exclude tests/sdk/v2/typing
+	$(PYTHON) -m mypy src tests
 
 # (override)
 style: flake8 black isort mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,15 @@ explicit_package_bases = true
 # directory path. If your repo has a different layout you can add the appropriate paths
 # by setting MYPYPATH env variable.
 mypy_path = "src:src/python"
-# Exclude anything in an examples directory, except the docs/examples dir.
-exclude = ['^(?!docs\/examples\/).*examples\/.*$',]
+exclude = [
+    # Exclude anything in an examples directory, except the docs/examples dir.
+    '^(?!docs\/examples\/).*examples\/.*$',
+    # Exclude our test files where we invoce mypy from pytest.
+    "tests/sdk/v2/typing"
+]
+# Without this, mypy would skip typechecking functions that don't have type
+# annotations in the signature.
+check_untyped_defs = true
 
 [tool.coverage.run]
 # main.py should be checked separately in an integration test.

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -742,6 +742,8 @@ class ArtifactFuture:
 
 def _resolve_module_path(fn):
     if (abs_path := inspect.getsourcefile(fn)) is None:
+        # This can happen when the `fn` is defined in a binary module. We need to check
+        # it explicitly to appease mypy. It would be nice to have a test case for it.
         return None
     try:
         relative_path = os.path.relpath(abs_path)

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -741,7 +741,8 @@ class ArtifactFuture:
 
 
 def _resolve_module_path(fn):
-    abs_path = inspect.getsourcefile(fn)
+    if (abs_path := inspect.getsourcefile(fn)) is None:
+        return None
     try:
         relative_path = os.path.relpath(abs_path)
     except ValueError:

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -181,14 +181,15 @@ def _make_python_import_id(imp: _dsl.PythonImports, import_hash: str):
     return f"python-import-{import_hash}"
 
 
+# Hashing inline imports is useless since it gives the same result each time. To ensure
+# uniqueness in the system, use a global counter.
+_global_inline_import_counter: int = 0
+
+
 def _make_inline_import_id():
-    # hashing inline imports is useless since it gives the same result each time.
-    # to ensure uniqueness in the system, use global counter
-    try:
-        _make_inline_import_id.counter += 1
-    except AttributeError:
-        _make_inline_import_id.counter = 0
-    return f"inline-import-{_make_inline_import_id.counter}"
+    global _global_inline_import_counter
+    _global_inline_import_counter += 1
+    return f"inline-import-{_global_inline_import_counter}"
 
 
 def _make_import_model(imp: _dsl.Import):

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -135,16 +135,16 @@ class TupleUnwrapper:
         # because that's the easiest way for us not to rely on
         # `pos_specs`'s element order.
         unpacked_args = list(args)
-        for unpack_spec in self._pos_specs:
-            arg_val = args[unpack_spec.param_index]
-            unpacked_val = arg_val[unpack_spec.unpack_index]
-            unpacked_args[unpack_spec.param_index] = unpacked_val
+        for pos_spec in self._pos_specs:
+            arg_val = args[pos_spec.param_index]
+            unpacked_val = arg_val[pos_spec.unpack_index]
+            unpacked_args[pos_spec.param_index] = unpacked_val
 
         unpacked_kwargs = dict(kwargs)
-        for unpack_spec in self._kw_specs:
-            arg_val = kwargs[unpack_spec.param_name]
-            unpacked_val = arg_val[unpack_spec.unpack_index]
-            unpacked_kwargs[unpack_spec.param_name] = unpacked_val
+        for kw_spec in self._kw_specs:
+            arg_val = kwargs[kw_spec.param_name]
+            unpacked_val = arg_val[kw_spec.unpack_index]
+            unpacked_kwargs[kw_spec.param_name] = unpacked_val
 
         return self._fn(*unpacked_args, **unpacked_kwargs)
 

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -1,6 +1,7 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
+import typing as t
 from unittest.mock import Mock
 
 import pytest
@@ -115,7 +116,7 @@ class TestConfigResolver:
             choose from available configs.
             """
             # Given
-            config = []
+            config: t.List = []
 
             config_repo = Mock()
             local_config_names = ["cfg1", "cfg2"]
@@ -965,7 +966,7 @@ class TestWFRunFilterResolver:
         @staticmethod
         def test_passing_no_state_default():
             # Given
-            states = []
+            states: t.List[str] = []
             return_states = ["WAITING"]
             prompter = Mock()
             resolver = _arg_resolvers.WFRunFilterResolver(prompter=prompter)
@@ -981,7 +982,7 @@ class TestWFRunFilterResolver:
         @staticmethod
         def test_passing_no_state_interactive():
             # Given
-            states = []
+            states: t.List[str] = []
             return_states = ["WAITING"]
             prompter = Mock()
             resolver = _arg_resolvers.WFRunFilterResolver(prompter=prompter)

--- a/tests/cli/dorq/workflow/test_list.py
+++ b/tests/cli/dorq/workflow/test_list.py
@@ -5,6 +5,7 @@
 Unit tests for 'orq wf list' glue code.
 """
 
+import typing as t
 from unittest.mock import Mock
 
 import pytest
@@ -29,9 +30,9 @@ class TestAction:
         # Given
         # CLI inputs
         config = ["<config sentinel>"]
-        limit = "<limit sentinel>"
+        limit: t.Any = "<limit sentinel>"
         max_age = "<max_age sentinel>"
-        state = "<state sentinel>"
+        state: t.Any = "<state sentinel>"
 
         # Resolved values
         resolved_configs = ["<resolved config 1>", "<resolved config 2>"]

--- a/tests/runtime/corq/test_cli_with_qe.py
+++ b/tests/runtime/corq/test_cli_with_qe.py
@@ -65,14 +65,6 @@ def _write_new_config(
     config_file_path.write_text(config_file.json())
 
 
-def _read_config_file(dirpath: Path) -> RuntimeConfigurationFile:
-    """
-    Reads the contents of the user config file at 'dirpath'.
-    """
-    config_file_path = dirpath / _config.CONFIG_FILE_NAME
-    return RuntimeConfigurationFile.parse_file(config_file_path)
-
-
 class TestCLIWithQEMock:
     """Tests CLI actions while using a mock instead the real QERuntime."""
 
@@ -81,7 +73,7 @@ class TestCLIWithQEMock:
 
         # Set up runtime object mock
         inv_id_1 = "inv-id-1"
-        log_lines1 = []
+        log_lines1: t.List[str] = []
         inv_id_2 = "inv-id-2"
         log_lines2 = ["foo 2", "foo bar 2"]
         mock_runtime = create_autospec(RuntimeInterface)

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -449,7 +449,7 @@ class TestGeneral:
             runtime_options={},
         )
         with pytest.raises(exceptions.RuntimeConfigError):
-            _qe_runtime.QERuntime(config, "shouldnt_matter")
+            _qe_runtime.QERuntime(config, Path("shouldnt_matter"))
 
 
 class TestCreateWorkflowRun:
@@ -770,7 +770,7 @@ class TestGetWorkflowRunStatus:
             runtime_options={"uri": "http://localhost", "token": "blah"},
         )
         # Return a runtime object
-        runtime = _qe_runtime.QERuntime(config, "Nothing")
+        runtime = _qe_runtime.QERuntime(config, Path("Nothing"))
 
         stub_runID = "hello-there-abc123-r000"
         with pytest.raises(exceptions.WorkflowNotFoundError) as exc_info:
@@ -961,7 +961,7 @@ class TestGetWorkflowRunOutputsNonBlocking:
             runtime_options={"uri": "http://localhost", "token": "blah"},
         )
         # Return a runtime object
-        runtime = _qe_runtime.QERuntime(config, "Nothing")
+        runtime = _qe_runtime.QERuntime(config, Path("Nothing"))
 
         stub_runID = "hello-there-abc123-r000"
         with pytest.raises(exceptions.WorkflowNotFoundError) as exc_info:
@@ -1429,7 +1429,7 @@ class TestHTTPErrors:
             runtime.create_workflow_run(TEST_WORKFLOW)
         for telltale in telltales:
             assert telltale in str(exc_info)
-        assert _save_workflow_run.assert_not_called
+        _save_workflow_run.assert_not_called()
 
     def test_get_workflow_run_status(
         self,

--- a/tests/runtime/test_v2_runtimes_integration.py
+++ b/tests/runtime/test_v2_runtimes_integration.py
@@ -114,7 +114,7 @@ def test_studio_like_flow():
         print(f"Submitted wf run {wf_run_id} to {config_name}")
 
         config = _config.read_config(config_name)
-        rt = QERuntime(config=config, project_dir=project_dir)
+        rt = QERuntime(config=config, project_dir=Path(project_dir))
 
         # We need to wait between submitting workflow and getting its status.
         # Otherwise, QE responds with status code 500.

--- a/tests/sdk/v2/data/complex_serialization/workflow_defs.py
+++ b/tests/sdk/v2/data/complex_serialization/workflow_defs.py
@@ -211,7 +211,7 @@ def wf_non_picklable_constant_should_fail():
     """
     Rare case where an object can't be serialized using pickle.
     """
-    const = NonPicklable()
+    const: t.Any = NonPicklable()
     return [capitalize(const)]
 
 

--- a/tests/sdk/v2/data/configs.py
+++ b/tests/sdk/v2/data/configs.py
@@ -1,40 +1,43 @@
 ################################################################################
 # © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
+import typing as t
+
 from orquestra.sdk.schema.configs import CONFIG_FILE_CURRENT_VERSION
 
-TEST_CONFIG_JSON = {
-    "version": CONFIG_FILE_CURRENT_VERSION,
-    "configs": {
-        "test_config_default": {
-            "config_name": "test_config_default",
-            "runtime_name": "QE_REMOTE",
-            "runtime_options": {
-                "uri": "test_config_default_uri",
-                "token": "test_config_default_token",
-            },
-        },
-        "test_config_no_runtime_options": {
-            "config_name": "test_config_no_runtime_options",
-            "runtime_name": "QE_REMOTE",
-            "runtime_options": {},
-        },
-        "test_config_qe": {
-            "config_name": "test_config_qe",
-            "runtime_name": "QE_REMOTE",
-            "runtime_options": {
-                "uri": "test_uri",
-                "token": "test_token",
-            },
-        },
-        "actual_name": {
-            "config_name": "actual_name",
-            "runtime_name": "QE_REMOTE",
-            "runtime_options": {
-                "uri": "http://actual_name.domain",
-                "token": "this_token_best_token",
-            },
+TEST_CONFIGS_DICT: t.Mapping[str, t.Mapping[str, t.Any]] = {
+    "test_config_default": {
+        "config_name": "test_config_default",
+        "runtime_name": "QE_REMOTE",
+        "runtime_options": {
+            "uri": "test_config_default_uri",
+            "token": "test_config_default_token",
         },
     },
+    "test_config_no_runtime_options": {
+        "config_name": "test_config_no_runtime_options",
+        "runtime_name": "QE_REMOTE",
+        "runtime_options": {},
+    },
+    "test_config_qe": {
+        "config_name": "test_config_qe",
+        "runtime_name": "QE_REMOTE",
+        "runtime_options": {
+            "uri": "test_uri",
+            "token": "test_token",
+        },
+    },
+    "actual_name": {
+        "config_name": "actual_name",
+        "runtime_name": "QE_REMOTE",
+        "runtime_options": {
+            "uri": "http://actual_name.domain",
+            "token": "this_token_best_token",
+        },
+    },
+}
+TEST_CONFIG_JSON: t.Mapping[str, t.Any] = {
+    "version": CONFIG_FILE_CURRENT_VERSION,
+    "configs": TEST_CONFIGS_DICT,
     "default_config_name": "test_config_default",
 }

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -15,7 +15,7 @@ from orquestra.sdk.schema.workflow_run import State, WorkflowRunId
 
 
 @pytest.fixture
-def runtime(tmp_path, mock_workflow_db_location):
+def runtime(mock_workflow_db_location):
     # Fake CE configuration
     config = RuntimeConfiguration(
         config_name="hello",
@@ -61,8 +61,8 @@ class TestInitialization:
         )
 
         # then
-        assert rt._config == rt2._config
-        assert rt._verbose == rt2._verbose
+        assert rt._config == rt2._config  # type: ignore
+        assert rt._verbose == rt2._verbose  # type: ignore
 
     def test_invalid_config(self):
         config = RuntimeConfiguration(

--- a/tests/sdk/v2/test_ast.py
+++ b/tests/sdk/v2/test_ast.py
@@ -3,6 +3,7 @@
 ################################################################################
 import ast
 import inspect
+import typing as t
 from types import FunctionType
 
 import numpy as np
@@ -35,6 +36,7 @@ def test_normalize_indents():
     assert inspect.getsource(fn1) == _ast.normalize_indents(inspect.getsource(fn2))
 
 
+@t.no_type_check
 def function_with_calls():
     np.arange(2)
     simple_obj = ObjWithTask(0)
@@ -54,7 +56,7 @@ function_calls = [
             _ast.NodeReference(name="np", node_type=_ast.NodeReferenceType.NAME),
             _ast.NodeReference(name="arange", node_type=_ast.NodeReferenceType.CALL),
         ],
-        line_no=2,
+        line_no=3,
     ),
     _ast._Call(
         callable_name="ObjWithTask",
@@ -63,7 +65,7 @@ function_calls = [
                 name="ObjWithTask", node_type=_ast.NodeReferenceType.CALL
             )
         ],
-        line_no=3,
+        line_no=4,
     ),
     _ast._Call(
         callable_name="get_id",
@@ -73,7 +75,7 @@ function_calls = [
             ),
             _ast.NodeReference(name="get_id", node_type=_ast.NodeReferenceType.CALL),
         ],
-        line_no=4,
+        line_no=5,
     ),
     _ast._Call(
         callable_name="_task_without_resources",
@@ -82,14 +84,14 @@ function_calls = [
                 name="_task_without_resources", node_type=_ast.NodeReferenceType.CALL
             )
         ],
-        line_no=5,
+        line_no=6,
     ),
     _ast._Call(
         callable_name="print",
         call_statement=[
             _ast.NodeReference(name="print", node_type=_ast.NodeReferenceType.CALL)
         ],
-        line_no=6,
+        line_no=7,
     ),
     _ast._Call(
         callable_name="with_resources",
@@ -99,14 +101,14 @@ function_calls = [
                 name="with_resources", node_type=_ast.NodeReferenceType.CALL
             ),
         ],
-        line_no=7,
+        line_no=8,
     ),
     _ast._Call(
         callable_name="range",
         call_statement=[
             _ast.NodeReference(name="range", node_type=_ast.NodeReferenceType.CALL)
         ],
-        line_no=8,
+        line_no=9,
     ),
     _ast._Call(
         callable_name="with_resources",
@@ -116,7 +118,7 @@ function_calls = [
                 name="with_resources", node_type=_ast.NodeReferenceType.CALL
             ),
         ],
-        line_no=9,
+        line_no=10,
     ),
 ]
 
@@ -129,7 +131,7 @@ wf_function_calls = [
                 name="ObjWithTask", node_type=_ast.NodeReferenceType.CALL
             )
         ],
-        line_no=3,
+        line_no=4,
     ),
     _ast._Call(
         callable_name="get_id",
@@ -139,7 +141,7 @@ wf_function_calls = [
             ),
             _ast.NodeReference(name="get_id", node_type=_ast.NodeReferenceType.CALL),
         ],
-        line_no=4,
+        line_no=5,
     ),
     _ast._Call(
         callable_name="with_invocation_meta",
@@ -151,7 +153,7 @@ wf_function_calls = [
                 name="with_invocation_meta", node_type=_ast.NodeReferenceType.CALL
             ),
         ],
-        line_no=5,
+        line_no=6,
     ),
 ]
 

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -18,8 +18,7 @@ the user. It's a lot easier to figure out appropriate behavior this way.
 """
 import datetime
 import json
-import os
-import tempfile
+import typing as t
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -55,7 +54,7 @@ class TestSavePartialConfig:
 class TestResolveRuntimeOptionsForWriting:
     @staticmethod
     def test_returns_builtins_if_name_is_builtin():
-        new_runtime_options = {}
+        new_runtime_options: t.Dict = {}
         config_name = _config.BUILT_IN_CONFIG_NAME
         stub_prev_config = RuntimeConfiguration(
             config_name="test_config", runtime_name="RAY_LOCAL", runtime_options={}
@@ -139,7 +138,7 @@ class TestGenerateConfigName:
     @staticmethod
     def test_raises_exception_if_qe_but_no_uri():
         with pytest.raises(AttributeError) as exc_info:
-            _config.generate_config_name(RuntimeName.QE_REMOTE, {})
+            _config.generate_config_name(RuntimeName.QE_REMOTE, None)
         assert "QE and CE runtime configurations must have a 'URI' value set." in str(
             exc_info
         )

--- a/tests/sdk/v2/test_dispatch_integration.py
+++ b/tests/sdk/v2/test_dispatch_integration.py
@@ -15,7 +15,7 @@ import pytest
 import yaml
 
 import orquestra.sdk as sdk
-from orquestra.sdk._base import dispatch, loader
+from orquestra.sdk._base import _dsl, dispatch, loader
 from orquestra.sdk._base._conversions import _yaml_exporter as yaml_converter
 from orquestra.sdk._base._testing._example_wfs import wf_with_secrets
 from orquestra.sdk.schema import ir
@@ -112,7 +112,7 @@ def test_execution(monkeypatch, tmp_path, wf, expected_out):
 
     with ch_temp_dir() as temp_dir:
         # 4. Execute!
-        dispatch.exec_task_fn(**kwarg_inputs)
+        dispatch.exec_task_fn(**kwarg_inputs)  # type: ignore
 
         # 5. Validate outputs
         json_files = [
@@ -178,6 +178,7 @@ class TestModuleCaching:
                 function_name="capitalize_task",
             )
         )
+        assert isinstance(fn, _dsl.TaskDef)
         # If this doesn't raise, we're good. It would raise a RuntimeError if
         # the module with fakes was cached.
         assert fn._TaskDef__sdk_task_body("hello") == "Hello"

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -394,6 +394,8 @@ class TestFlattenGraph:
         invocation = _first(wf.task_invocations.values())
         task = wf.tasks[invocation.task_id]
         source_import = wf.imports[task.source_import_id]
+
+        assert task.dependency_import_ids is not None
         assert len(task.dependency_import_ids) == 1
         dep_import = wf.imports[task.dependency_import_ids[0]]
 
@@ -437,7 +439,12 @@ class TestFlattenGraph:
 
     def test_equal_constants_different_types(self):
         wf = constant_collisions.model
-        serialised_constants = [con.value for con in wf.constant_nodes.values()]
+        constant_nodes = []
+        for constant_node in wf.constant_nodes.values():
+            assert isinstance(constant_node, model.ConstantNodeJSON)
+            constant_nodes.append(constant_node)
+
+        serialised_constants = [con.value for con in constant_nodes]
         assert len(wf.constant_nodes) == 3
         assert "true" in serialised_constants
         assert "1" in serialised_constants

--- a/tests/sdk/v2/test_workflow.py
+++ b/tests/sdk/v2/test_workflow.py
@@ -1,6 +1,7 @@
 ################################################################################
 # © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
+import typing as t
 from pathlib import Path
 
 import pytest
@@ -93,10 +94,13 @@ class TestDataAggregationResources:
         with pytest.warns(Warning) as warns:
             wf = self._workflow_gpu_set_for_data_aggregation()
             assert len(warns.list) == 1
+            assert wf.model.data_aggregation is not None
+            assert wf.model.data_aggregation.resources is not None
             assert wf.model.data_aggregation.resources.gpu == "0"
 
     def test_workflow_data_aggregation_false(self):
         wf = self._workflow_data_aggregation_false()
+        assert wf.model.data_aggregation is not None
         assert wf.model.data_aggregation.run is False
 
     def test_workflow_data_aggregation_true(self):
@@ -226,12 +230,13 @@ def test_artifact_node_custom_names():
 class TestWorkflowTemplate:
     @staticmethod
     def test_wraps_fn():
-        assert _simple_workflow.__name__ == _simple_workflow._fn.__name__
+        wf: t.Any = _simple_workflow
+        assert wf.__name__ == wf._fn.__name__
 
     @staticmethod
     def test_parametrized_wf_with_no_args():
         with pytest.raises(WorkflowSyntaxError):
-            _parametrized_workflow()
+            _parametrized_workflow()  # type: ignore
 
 
 class TestGraph:


### PR DESCRIPTION
# The problem

Our linter produced `mypy` warnings like:
```
src/orquestra/sdk/_base/_qe/_client.py:195: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
```
([example run](https://github.com/zapatacomputing/orquestra-workflow-sdk/actions/runs/4230645095/jobs/7348207337#step:5:32)).

Turns out there's a `mypy` setting we didn't use.

# This PR's solution

* Turns on checking "untyped defs" ([docs](https://mypy.readthedocs.io/en/stable/config_file.html#confval-check_untyped_defs)). It allows typechecking functions even if the signature doesn't include type annotations.
* Moves the "ignore" flag from the makefile to the config file.
* Fixes or works around existing typing issues.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
