### PR TITLE
chore: Expand Git URL model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 
 *Internal*
+* Git URL model changed inside the IR
 
 
 *Docs*

--- a/src/orquestra/sdk/_base/_conversions/_ids.py
+++ b/src/orquestra/sdk/_base/_conversions/_ids.py
@@ -68,11 +68,11 @@ def _id_for_ir_obj(obj) -> str:  # pragma: no cover
 
 @_id_for_ir_obj.register
 def _id_for_GitImport(imp: ir.GitImport):
-    proj_name = imp.repo_url
+    proj_url = imp.repo_url
 
     # Get the repo name
     # "git@github.com:zapatacomputing/orquestra-core.git" -> "orquestra-core.git"
-    proj_name = proj_name.rsplit("/", maxsplit=2)[-1]
+    proj_name = proj_url.path.rsplit("/", maxsplit=2)[-1]
 
     # Remove the trailing '.git'
     # "orquestra-core.git" -> "orquestra-core"

--- a/src/orquestra/sdk/_base/_conversions/_imports.py
+++ b/src/orquestra/sdk/_base/_conversions/_imports.py
@@ -96,7 +96,7 @@ class ImportTranslator:
     def _translate_GitImport(self, imp: ir.GitImport, yaml_name) -> yaml_model.Import:
         git_url = imp.repo_url.copy()
         if imp.repo_url.password is not None:
-            logging.debug(
+            logging.getLogger(__name__).debug(
                 f"Refusing to dereference secret for url `{imp.repo_url.original_url}`"
             )
             git_url.password = None

--- a/src/orquestra/sdk/_base/_git_url_utils.py
+++ b/src/orquestra/sdk/_base/_git_url_utils.py
@@ -1,0 +1,113 @@
+import re
+from typing import Optional
+
+from urllib3.exceptions import LocationParseError
+from urllib3.util import parse_url
+
+from .. import secrets
+from ..schema.ir import GitURL
+
+
+def _split_auth(auth_value: Optional[str]):
+    if auth_value is None:
+        return None, None
+
+    split_auth = auth_value.split(":")
+
+    if len(split_auth) == 1:
+        return split_auth[0], None
+    else:
+        return split_auth[0], ":".join(split_auth[1:])
+
+
+def build_git_url(url: GitURL, protocol_override: Optional[str] = None):
+    """
+    Returns a usable string from a GitURL
+    This will get the password from the secrets API, if required.
+
+    Args:
+        url: the GitURL to build the URL string from
+        protocol_override: Ignore the protocol defined in the URL and build the URL
+            using a different protocol.
+    """
+    protocol = protocol_override or url.protocol
+    user = url.user or "git"
+    port = f":{url.port}" if url.port is not None else ""
+
+    # Dereference secret used as password
+    if url.password is not None:
+        secret = secrets.get(
+            url.password.secret_name, config_name=url.password.secret_config
+        )
+        password = f":{secret}"
+    else:
+        password = ""
+
+    if protocol == "ssh":
+        if url.port is None:
+            return f"{user}@{url.host}:{url.path}"
+        else:
+            return f"ssh://{user}{password}@{url.host}{port}/{url.path}"
+    elif protocol in ("git+ssh", "ssh+git", "ftp", "ftps"):
+        return f"{protocol}://{user}{password}@{url.host}{port}/{url.path}"
+    elif protocol in ("http", "https", "git+https", "git+http"):
+        if url.user is None and url.password is None:
+            return f"{protocol}://{url.host}{port}/{url.path}"
+        else:
+            return f"{protocol}://{user}{password}@{url.host}{port}/{url.path}"
+    else:
+        if protocol == url.protocol:
+            return url.original_url
+        else:
+            raise ValueError(f"Unknown protocol: `{protocol}`")
+
+
+def parse_git_url(url: str) -> GitURL:
+    """
+    Parse a git URL from a string
+    Accepted formats:
+        <protocol>://[<user>@]<host>[:<port>]/<path>[?<query>]
+        <user>@<host>:<path>
+        ssh://<user>@<host>:<repo>
+    """
+    try:
+        parsed = parse_url(url)
+        protocol = parsed.scheme
+        user, password = _split_auth(parsed.auth)
+        host = parsed.host
+        port = parsed.port
+        query = parsed.query
+        if parsed.path is not None:
+            path = parsed.path.lstrip("/")
+        else:
+            path = ""
+    except LocationParseError as e:
+        _url = url.strip("ssh://")
+        m = re.match(
+            r"(?P<user>.+)@(?P<domain>[^/]+?):(?P<repo>.+)", _url, re.IGNORECASE
+        )
+        if m is None:
+            raise ValueError(f"Invalid URL format: `{url}`") from e
+        protocol = "ssh"
+        user, password = _split_auth(m.group("user"))
+        host = m.group("domain")
+        port = None
+        path = m.group("repo")
+        query = None
+
+    if host is None:
+        raise ValueError(f"Could not parse the host for URL `{url}`")
+
+    if password is not None:
+        raise ValueError("Passwords should not be stored in the URL directly")
+
+    return GitURL(
+        original_url=url,
+        protocol=protocol or "https",
+        user=user,
+        password=None,
+        host=host,
+        port=port,
+        path=path,
+        query=query,
+    )

--- a/src/orquestra/sdk/_base/_git_url_utils.py
+++ b/src/orquestra/sdk/_base/_git_url_utils.py
@@ -20,7 +20,7 @@ def _split_auth(auth_value: Optional[str]):
         return split_auth[0], ":".join(split_auth[1:])
 
 
-def build_git_url(url: GitURL, protocol_override: Optional[str] = None):
+def build_git_url(url: GitURL, protocol_override: Optional[str] = None) -> str:
     """
     Returns a usable string from a GitURL
     This will get the password from the secrets API, if required.

--- a/tests/sdk/v2/conversions/test_imports.py
+++ b/tests/sdk/v2/conversions/test_imports.py
@@ -73,6 +73,7 @@ def test_disallowed_package_versions(
 
 
 def test_skip_password_dereference_yaml(caplog: pytest.LogCaptureFixture):
+    caplog.set_level("DEBUG")
     ir_imports = {
         "sdk": GitImport(
             id="sdk",
@@ -107,4 +108,10 @@ def test_skip_password_dereference_yaml(caplog: pytest.LogCaptureFixture):
     }
     _ = _imports.ImportTranslator(ir_imports=ir_imports, orq_sdk_git_ref=None)
     logs = caplog.records
-    assert logs == []
+    assert len(logs) == 1
+    assert logs[0].name == "orquestra.sdk._base._conversions._imports"
+    assert logs[0].levelname == "DEBUG"
+    assert (
+        logs[0].msg
+        == "Refusing to dereference secret for url `https://example.com/some/path.git`"
+    )

--- a/tests/sdk/v2/test_git_url_utils.py
+++ b/tests/sdk/v2/test_git_url_utils.py
@@ -1,0 +1,185 @@
+from unittest.mock import create_autospec
+
+import pytest
+
+import orquestra.sdk.secrets
+from orquestra.sdk._base import _git_url_utils
+from orquestra.sdk.schema.ir import GitURL, SecretNode
+
+
+@pytest.fixture
+def git_url() -> GitURL:
+    return GitURL(
+        original_url="https://github.com/zapatacomputing/orquestra-workflow-sdk",
+        protocol="https",
+        user=None,
+        password=None,
+        host="github.com",
+        port=None,
+        path="zapatacomputing/orquestra-workflow-sdk",
+        query=None,
+    )
+
+
+class TestBuildGitURL:
+    @pytest.mark.parametrize(
+        "protocol,expected_url",
+        [
+            (
+                "git+ssh",
+                "git+ssh://git@github.com/zapatacomputing/orquestra-workflow-sdk",
+            ),
+            (
+                "ssh+git",
+                "ssh+git://git@github.com/zapatacomputing/orquestra-workflow-sdk",
+            ),
+            ("ftp", "ftp://git@github.com/zapatacomputing/orquestra-workflow-sdk"),
+            ("ftps", "ftps://git@github.com/zapatacomputing/orquestra-workflow-sdk"),
+            ("http", "http://github.com/zapatacomputing/orquestra-workflow-sdk"),
+            ("https", "https://github.com/zapatacomputing/orquestra-workflow-sdk"),
+            (
+                "git+http",
+                "git+http://github.com/zapatacomputing/orquestra-workflow-sdk",
+            ),
+            (
+                "git+https",
+                "git+https://github.com/zapatacomputing/orquestra-workflow-sdk",
+            ),
+        ],
+    )
+    def test_different_protocols(
+        self, git_url: GitURL, protocol: str, expected_url: str
+    ):
+        url = _git_url_utils.build_git_url(git_url, protocol)
+        assert url == expected_url
+
+    def test_ssh_with_port(self, git_url: GitURL):
+        git_url.port = 22
+        url = _git_url_utils.build_git_url(git_url, "ssh")
+        assert url == "ssh://git@github.com:22/zapatacomputing/orquestra-workflow-sdk"
+
+    @pytest.mark.parametrize(
+        "protocol",
+        ["http", "https", "git+http", "git+https"],
+    )
+    def test_http_with_user(self, git_url: GitURL, protocol: str):
+        git_url.user = "amelio_robles_avila"
+        url = _git_url_utils.build_git_url(git_url, protocol)
+        assert url == (
+            f"{protocol}://amelio_robles_avila@github.com"
+            "/zapatacomputing/orquestra-workflow-sdk"
+        )
+
+    def test_uses_default_protocol(self, git_url: GitURL):
+        url = _git_url_utils.build_git_url(git_url)
+        assert url == "https://github.com/zapatacomputing/orquestra-workflow-sdk"
+
+    def test_with_password(self, monkeypatch: pytest.MonkeyPatch, git_url: GitURL):
+        secrets_get = create_autospec(orquestra.sdk.secrets.get)
+        secrets_get.return_value = "<mocked secret>"
+        monkeypatch.setattr(orquestra.sdk.secrets, "get", secrets_get)
+
+        secret_name = "my_secret"
+        secret_config = "secret config"
+        git_url.password = SecretNode(
+            id="mocked secret", secret_name=secret_name, secret_config=secret_config
+        )
+
+        url = _git_url_utils.build_git_url(git_url)
+        assert url == (
+            "https://git:<mocked secret>@github.com"
+            "/zapatacomputing/orquestra-workflow-sdk"
+        )
+        secrets_get.assert_called_once_with(secret_name, config_name=secret_config)
+
+    def test_unknown_protocol_in_original(self, git_url: GitURL):
+        git_url.original_url = "custom_protocol://<blah>"
+        git_url.protocol = "custom_protocol"
+        url = _git_url_utils.build_git_url(git_url)
+        assert url == git_url.original_url
+
+    def test_unknown_protocol_override(self, git_url: GitURL):
+        with pytest.raises(ValueError) as exc_info:
+            _ = _git_url_utils.build_git_url(git_url, "custom_protocol")
+        exc_info.match("Unknown protocol: `custom_protocol`")
+
+
+class TestParseGitURL:
+    @pytest.mark.parametrize(
+        "url,expected",
+        [
+            (
+                "https://user@example.com:3000/some/path.git?q=1",
+                GitURL(
+                    original_url="https://user@example.com:3000/some/path.git?q=1",
+                    protocol="https",
+                    user="user",
+                    password=None,
+                    host="example.com",
+                    port=3000,
+                    path="some/path.git",
+                    query="q=1",
+                ),
+            ),
+            (
+                "git+ssh://user@example.com/some/path.git",
+                GitURL(
+                    original_url="git+ssh://user@example.com/some/path.git",
+                    protocol="git+ssh",
+                    user="user",
+                    password=None,
+                    host="example.com",
+                    port=None,
+                    path="some/path.git",
+                    query=None,
+                ),
+            ),
+            (
+                "http://example.com",
+                GitURL(
+                    original_url="http://example.com",
+                    protocol="http",
+                    user=None,
+                    password=None,
+                    host="example.com",
+                    port=None,
+                    path="",
+                    query=None,
+                ),
+            ),
+            (
+                "git@example.com:some/path.git",
+                GitURL(
+                    original_url="git@example.com:some/path.git",
+                    protocol="ssh",
+                    user="git",
+                    password=None,
+                    host="example.com",
+                    port=None,
+                    path="some/path.git",
+                    query=None,
+                ),
+            ),
+        ],
+    )
+    def test_parsing(self, url: str, expected: GitURL):
+        parsed = _git_url_utils.parse_git_url(url)
+        assert parsed == expected
+
+    def test_with_password(self):
+        url = "https://user:password@example.com/some/path.git"
+        with pytest.raises(ValueError) as exc_info:
+            _ = _git_url_utils.parse_git_url(url)
+        exc_info.match("Passwords should not be stored in the URL directly")
+
+    def test_missing_host(self):
+        url = "https:///some/path.git"
+        with pytest.raises(ValueError) as exc_info:
+            _ = _git_url_utils.parse_git_url(url)
+        exc_info.match("Could not parse the host for URL")
+
+    def test_invalid_url(self):
+        url = "::"
+        with pytest.raises(ValueError) as exc_info:
+            _ = _git_url_utils.parse_git_url(url)
+        exc_info.match("Invalid URL format")

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -864,7 +864,18 @@ GENERATE_GRAPH_IMPORTS = [
 CAPITALIZE_IMPORTS_INFER = [
     model.GitImport(
         id=AnyMatchingStr(r"git-\w{10}_github_com_zapatacomputing_orquestra.*sdk"),
-        repo_url=AnyMatchingStr(r"git@github.com:zapatacomputing/orquestra.*sdk.*"),
+        repo_url=model.GitURL(
+            original_url=AnyMatchingStr(
+                r"git@github.com:zapatacomputing/orquestra.*sdk.*"
+            ),
+            protocol="ssh",
+            user="git",
+            password=None,
+            host="github.com",
+            port=None,
+            path=AnyMatchingStr(r"zapatacomputing/orquestra.*sdk.*"),
+            query=None,
+        ),
         git_ref="main",
     ),
 ]
@@ -932,9 +943,10 @@ def test_get_model_imports_from_task_def(monkeypatch, task_def, expected_imports
 
     monkeypatch.setattr(git.remote.Remote, "fetch", fake_fetch)
     monkeypatch.setattr(git.Repo, "is_dirty", fake_is_dirty)
-    assert [
+    imports = [
         imp.dict() for imp in _traversal.get_model_imports_from_task_def(task_def)
-    ] == [imp.dict() for imp in expected_imports]
+    ]
+    assert imports == [imp.dict() for imp in expected_imports]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# The problem

We currently store the URL for a Git repo as a string inside the IR/schema. We are adding features which require making changes to parts of the URL.

# This PR's solution

* Adds a new model for Git repo URLs in the IR
* Adds parsing code for strings to the new model
* Adds a function to get the URL string for a Git URL model, based on a chosen protocol
* Switches Ray/QE's handling of Git imports to use the new model

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
