### PR TITLE
feat: Private Github repo support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 🔥 *Features*
 * Secrets can now be used inside workflow functions
 * `sdk.secrets.get("name")` will now use passport-based authorization if `ORQUESTRA_PASSPORT_FILE` environment variable is set. Otherwise, passing a valid `config_name="..."` is required.
+* `GithubImport` can be used with a username and a secret referring to a "personal access token" to enable private GitHub repositories on Compute Engine. Server side support coming soon!
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -85,6 +85,19 @@ class Secret(NamedTuple):
     config_name: Optional[str] = None
 
 
+class GitImportWithAuth(NamedTuple):
+    """
+    A task import that uses a private Git repo
+
+    Please use a helper method, such as GithubImport, instead of this class
+    """
+
+    repo_url: str
+    git_ref: str
+    username: Optional[str]
+    auth_secret: Optional[Secret]
+
+
 class GitImport(NamedTuple):
     """A task import that uses a Git repository"""
 
@@ -109,9 +122,19 @@ class GitImport(NamedTuple):
         return DeferredGitImport(local_repo_path, git_ref)
 
 
-def GithubImport(repo: str, git_ref: str = "main"):
+def GithubImport(
+    repo: str,
+    git_ref: str = "main",
+    username: Optional[str] = None,
+    personal_access_token: Optional[Secret] = None,
+):
     """Helper to create GitImports from Github repos"""
-    return GitImport(repo_url=f"git@github.com:{repo}.git", git_ref=git_ref)
+    return GitImportWithAuth(
+        repo_url=f"https://github.com/{repo}.git",
+        git_ref=git_ref,
+        username=username,
+        auth_secret=personal_access_token,
+    )
 
 
 class DeferredGitImport:
@@ -229,7 +252,14 @@ class InlineImport(NamedTuple):
     pass
 
 
-Import = Union[GitImport, LocalImport, DeferredGitImport, PythonImports, InlineImport]
+Import = Union[
+    LocalImport,
+    GitImport,
+    GitImportWithAuth,
+    DeferredGitImport,
+    PythonImports,
+    InlineImport,
+]
 """Type that includes all possible task imports"""
 
 

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -475,10 +475,25 @@ def test_deferred_git_import_resolved(my_fake_repo_setup):
     assert resolved.git_ref == my_fake_repo.active_branch.name
 
 
-def test_github_import_is_git_import():
-    imp = _dsl.GithubImport("zapatacomputing/orquestra-workflow-sdk", "main")
-    assert imp == _dsl.GitImport(
-        "git@github.com:zapatacomputing/orquestra-workflow-sdk.git", "main"
+@pytest.mark.parametrize(
+    "username,personal_access_token",
+    [
+        (None, None),
+        ("emiliano_zapata", _dsl.Secret("my_secret")),
+    ],
+)
+def test_github_import_is_git_import_with_auth(username, personal_access_token):
+    imp = _dsl.GithubImport(
+        "zapatacomputing/orquestra-workflow-sdk",
+        "main",
+        username=username,
+        personal_access_token=personal_access_token,
+    )
+    assert imp == _dsl.GitImportWithAuth(
+        repo_url="https://github.com/zapatacomputing/orquestra-workflow-sdk.git",
+        git_ref="main",
+        username=username,
+        auth_secret=personal_access_token,
     )
 
 


### PR DESCRIPTION
# The problem

Users should be able to pass credentials for private Git repos rather than these being configured on the cluster.

# This PR's solution

* Uses the secrets API to manage personal access tokens for Github imports

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
