### PR TITLE
fix: Ray: Set workflow run ID from environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 🐛 *Bug Fixes*
 * Getting full logs produced by Ray workflows. Previously, the dictionary returned by `logs_dict = wf_run.get_logs()` had just a single entry: `{"logs": ["task 1 log", "task 1 log", "task 2 log", "task 2 log"]}`. Now, the dictionary has a correct shape: `{"task_invocation_id1": ["task 1 log", "task 1 log"], "task_invocation_id2": ["task 2 log", "task 2 log"]}`.
 * Getting single task logs. Previously `orq task logs` would raise an unhandled exception. Now, it prints the log lines.
+* Workflow run IDs inside logs on CE now match the expected run ID.
 
 
 💅 *Improvements*

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -44,3 +44,8 @@ PASSPORT_FILE_ENV = "ORQUESTRA_PASSPORT_FILE"
 """
 Consumed by the Workflow SDK to set auth in remote contexts
 """
+
+RAY_GLOBAL_WF_RUN_ID_ENV = "GLOBAL_WF_RUN_ID"
+"""
+Used to set the workflow run ID in a Ray workflow
+"""

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -31,7 +31,7 @@ from .._base import (
     serde,
 )
 from .._base._db import WorkflowDB
-from .._base._env import RAY_DOWNLOAD_GIT_IMPORTS_ENV
+from .._base._env import RAY_DOWNLOAD_GIT_IMPORTS_ENV, RAY_GLOBAL_WF_RUN_ID_ENV
 from .._base.abc import ArtifactValue, LogReader, RuntimeInterface
 from ..schema import ir
 from ..schema.configs import RuntimeConfiguration
@@ -715,7 +715,8 @@ class RayRuntime(RuntimeInterface):
         client.shutdown()
 
     def create_workflow_run(self, workflow_def: ir.WorkflowDef) -> WorkflowRunId:
-        wf_run_id = _generate_wf_run_id(workflow_def)
+        global_run_id = os.getenv(RAY_GLOBAL_WF_RUN_ID_ENV)
+        wf_run_id = global_run_id or _generate_wf_run_id(workflow_def)
 
         # This is huge workaround for the issue:
         # https://github.com/ray-project/ray/issues/29253

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -100,6 +100,19 @@ class TestRayRuntimeMethods:
             outputs = runtime.get_workflow_run_outputs(run_id)
             assert outputs == ("RAY",)
 
+        def test_sets_run_id_from_env(
+            self, monkeypatch: pytest.MonkeyPatch, runtime: _dag.RayRuntime
+        ):
+            wf_def = _example_wfs.multioutput_wf.model
+            # Appending the normal run ID to prevent collisions
+            global_wf_run_id = "run_id_from_env" + _dag._generate_wf_run_id(wf_def)
+            monkeypatch.setenv("GLOBAL_WF_RUN_ID", global_wf_run_id)
+
+            run_id = runtime.create_workflow_run(wf_def)
+
+            runtime.stop_workflow_run(run_id)
+            assert run_id == global_wf_run_id
+
     class TestGetWorkflowRunStatus:
         """
         Tests that validate .get_workflow_run_status().


### PR DESCRIPTION
# The problem

CE generates workflow run IDs, `RayRuntime` also generated workflow run IDs.

This IDs don't match and this meant IDs inside logs from CE were wrong.

# This PR's solution

* Modifies `RayRuntime` to grab the workflow run ID from the environment, if available.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
