### PR TITLE
imp: print when polling when awaiting wf completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 💅 *Improvements*
 * `orq wf view` now shows `TaskInvocationID`s instead of `TaskRunID`s. This improves usage of `orq wf view` with other CLI commands that require passing invocation ID, like `orq task {logs,results}`.
+* `sdk.WorkflowRun.wait_until_finished()` will now print workflow status every now and then.
 
 
 *Internal*

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -394,19 +394,52 @@ class TestWorkflowRun:
                 "method."
             ) in str(exc_info)
 
-        @staticmethod
-        def test_waits_until_finished(monkeypatch, run, mock_runtime):
-            # Given
-            monkeypatch.setattr(time, "sleep", MagicMock())
-            # When
-            run.start()
-            run.wait_until_finished()
-            # Then
-            # We expect wait_until_finished to keep calling get_workflow_run_status from
-            # the runtime until the status is in a completed state.
-            # The mock runtime will return RUNNING twice before SUCCEEDED.
-            # We expect 3 total calls to get_workflow_run_status
-            assert mock_runtime.get_workflow_run_status.call_count == 3
+        class TestHappyPath:
+            @staticmethod
+            def test_verbose(monkeypatch, run, mock_runtime, capsys):
+                # Given
+                monkeypatch.setattr(time, "sleep", MagicMock())
+
+                # When
+                run.start()
+                run.wait_until_finished()
+
+                # Then
+                # We expect wait_until_finished to keep calling get_workflow_run_status from
+                # the runtime until the status is in a completed state.
+                # The mock runtime will return RUNNING twice before SUCCEEDED.
+                # We expect 3 total calls to get_workflow_run_status
+                assert mock_runtime.get_workflow_run_status.call_count == 3
+
+                # We expect x prints to stderr.
+                captured = capsys.readouterr()
+                assert captured.out == ""
+                assert captured.err == (
+                    "wf_pass_tuple-1 is RUNNING. Sleeping for 4.0s...\n"
+                    "wf_pass_tuple-1 is RUNNING. Sleeping for 4.0s...\n"
+                    "wf_pass_tuple-1 is SUCCEEDED\n"
+                )
+
+            @staticmethod
+            def test_quiet(monkeypatch, run, mock_runtime, capsys):
+                # Given
+                monkeypatch.setattr(time, "sleep", MagicMock())
+
+                # When
+                run.start()
+                run.wait_until_finished(verbose=False)
+
+                # Then
+                # We expect wait_until_finished to keep calling get_workflow_run_status from
+                # the runtime until the status is in a completed state.
+                # The mock runtime will return RUNNING twice before SUCCEEDED.
+                # We expect 3 total calls to get_workflow_run_status
+                assert mock_runtime.get_workflow_run_status.call_count == 3
+
+                # We expect no prints to stderr.
+                captured = capsys.readouterr()
+                assert captured.out == ""
+                assert captured.err == ""
 
     class TestGetResults:
         @staticmethod

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -405,8 +405,8 @@ class TestWorkflowRun:
                 run.wait_until_finished()
 
                 # Then
-                # We expect wait_until_finished to keep calling get_workflow_run_status from
-                # the runtime until the status is in a completed state.
+                # We expect wait_until_finished to keep calling get_workflow_run_status
+                # from the runtime until the status is in a completed state.
                 # The mock runtime will return RUNNING twice before SUCCEEDED.
                 # We expect 3 total calls to get_workflow_run_status
                 assert mock_runtime.get_workflow_run_status.call_count == 3
@@ -430,8 +430,8 @@ class TestWorkflowRun:
                 run.wait_until_finished(verbose=False)
 
                 # Then
-                # We expect wait_until_finished to keep calling get_workflow_run_status from
-                # the runtime until the status is in a completed state.
+                # We expect wait_until_finished to keep calling get_workflow_run_status
+                # from the runtime until the status is in a completed state.
                 # The mock runtime will return RUNNING twice before SUCCEEDED.
                 # We expect 3 total calls to get_workflow_run_status
                 assert mock_runtime.get_workflow_run_status.call_count == 3


### PR DESCRIPTION
# The problem

I've been writing some scripts
In every script for submitting and awaiting workflows I need to await the workflow completion. We have `sdk.WorkflowRun.wait_until_finished()` but when the workflow is big, or it's running on the remote runtime, it can take long with no information for the user. 

# This PR's solution

I've added a `verbose=True` flag to `.wait_until_finished()`. It prints to stderr in every iteration of the polling loop.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
