### PR TITLE
fix: Make Ray dirs before starting Ray

### DIFF
--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -84,6 +84,13 @@ class RayManager:
             subprocess.CalledProcessError: if calling the `ray` CLI failed. This
                 shouldn't happen in regular conditions.
         """
+        ray_temp = ray_temp_path()
+        ray_storage = ray_storage_path()
+        ray_plasma = ray_plasma_path()
+
+        for path in (ray_temp, ray_storage, ray_plasma):
+            path.mkdir(exist_ok=True, parents=True)
+
         # 'ray start' fails if the cluster can't be started, or another problem
         # occurred. I don't know a good way to differentiate between these
         # scenarios, so the strategy is:
@@ -95,9 +102,9 @@ class RayManager:
                 "ray",
                 "start",
                 "--head",
-                f"--temp-dir={ray_temp_path()}",
-                f"--storage={ray_storage_path()}",
-                f"--plasma-directory={ray_plasma_path()}",
+                f"--temp-dir={ray_temp}",
+                f"--storage={ray_storage}",
+                f"--plasma-directory={ray_plasma}",
             ],
             check=False,
             timeout=IPC_TIMEOUT,

--- a/tests/runtime/test_services_integration.py
+++ b/tests/runtime/test_services_integration.py
@@ -1,0 +1,22 @@
+################################################################################
+# © Copyright 2022-2023 Zapata Computing Inc.
+################################################################################
+import pytest
+
+from orquestra.sdk._base._services import RayManager
+from orquestra.sdk._base._testing._connections import ray_suitable_temp_dir
+
+
+@pytest.mark.slow
+@pytest.mark.skip("PATH issues on CI: ORQSDK-771")
+def test_ray_roundtrip(monkeypatch: pytest.MonkeyPatch):
+    with ray_suitable_temp_dir() as tmp_path:
+        orq_dir = tmp_path / ".orquestra"
+        monkeypatch.setenv("ORQ_RAY_TEMP_PATH", str(orq_dir / "ray"))
+        monkeypatch.setenv("ORQ_RAY_STORAGE_PATH", str(orq_dir / "ray_storage"))
+        monkeypatch.setenv("ORQ_RAY_PLASMA_PATH", str(orq_dir / "ray_plasma"))
+        ray = RayManager()
+        ray.up()
+        assert ray.is_running()
+        ray.down()
+        assert not ray.is_running()


### PR DESCRIPTION
# The problem

Ray was failing to start after #66 because the directory it set may not exist

# This PR's solution

Ensures all Ray dirs are made before starting Ray

There's an issue with the test on CI, see ORQSDK-771.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
