### PR TITLE
Chore: remove skipping service integration tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
+      # Used to create OS-agnostic python virtual env used for other steps.
       - uses: syphar/restore-virtualenv@v1
         id: cache-virtualenv
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,21 +32,12 @@ jobs:
         with:
           # Fetch depth 0 required to compare against `main`
           fetch-depth: 0
-
-      # Load a specific version of Python
-      - name: Setup python
-        uses: actions/setup-python@v4
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-
-      - name: Run Python commands
-        shell: bash
-        run: |
-          pip install --upgrade pip
-          python -m venv env
-          source env/bin/activate
-          echo "VIRTUAL ENV:" $VIRTUAL_ENV
+      - uses: syphar/restore-virtualenv@v1
+        id: cache-virtualenv
 
       - name: Install deps
         shell: bash
@@ -54,9 +45,7 @@ jobs:
 
       - name: Run tests and gather coverage stats
         shell: bash
-        run: |
-          echo "VIRTUAL ENV:" $VIRTUAL_ENV
-          make coverage
+        run: make coverage
 
       - name: Comment with code coverage
         uses: zapatacomputing/command-pr-comment@baca4fb9246eaaee3e47f35f296764acc394fae7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,13 +40,23 @@ jobs:
           python-version: ${{ matrix.python }}
           architecture: x64
 
+      - name: Run Python commands
+        shell: bash
+        run: |
+          pip install --upgrade pip
+          python3.8 -m venv env
+          source env/bin/activate
+          echo "VIRTUAL ENV:" $VIRTUAL_ENV
+
       - name: Install deps
         shell: bash
         run: make github_actions
 
       - name: Run tests and gather coverage stats
         shell: bash
-        run: make coverage
+        run: |
+          echo "VIRTUAL ENV:" $VIRTUAL_ENV
+          make coverage
 
       - name: Comment with code coverage
         uses: zapatacomputing/command-pr-comment@baca4fb9246eaaee3e47f35f296764acc394fae7

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           pip install --upgrade pip
-          python3.8 -m venv env
+          python -m venv env
           source env/bin/activate
           echo "VIRTUAL ENV:" $VIRTUAL_ENV
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -19,8 +19,10 @@ jobs:
   TestPerformance:
     runs-on: ubuntu-latest
     steps:
-      - name: Git Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - uses: syphar/restore-virtualenv@v1
+        id: cache-virtualenv
 
       - name: Run performance test
         shell: bash

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
+      # Used to create OS-agnostic python virtual env used for other steps.
       - uses: syphar/restore-virtualenv@v1
         id: cache-virtualenv
 

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -18,13 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # Needed to get access to publish-release action definition
-      - name: Check out the released repo
-        uses: actions/checkout@v3
-        with:
-          # Fetch whole repo to get access to tags to read current package
-          # version.
-          fetch-depth: 0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+      - uses: syphar/restore-virtualenv@v1
 
       - name: Get next version
         id: get-next-version

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -19,7 +19,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Fetch depth 0 required to compare against `main`
+          fetch-depth: 0
       - uses: actions/setup-python@v4
+      # Used to create OS-agnostic python virtual env used for other steps.
       - uses: syphar/restore-virtualenv@v1
 
       - name: Get next version

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ github-actions-coverage-report:
 
 # We need to set PATH here because performance test calls the `orq` CLI in a subprocess.
 performance:
-	PATH="${VENV_NAME}/bin:${PATH}" $(PYTHON) -m pytest --durations=0 tests/runtime/performance
+	$(PYTHON) -m pytest --durations=0 tests/runtime/performance
 
 
 # This is NOT mypy checking, it is ensuring the Workflow SDK has correct type hints for our users
@@ -64,8 +64,8 @@ user-typing:
 
 # (override)
 github_actions:
-	${PYTHON_EXE} -m pip install --upgrade pip
-	${PYTHON_EXE} -m pip install -e '.[dev]'
+	${PYTHON} -m pip install --upgrade pip
+	${PYTHON} -m pip install -e '.[dev]'
 
 # Install deps required to build wheel. Used for release automation. See also:
 # https://github.com/zapatacomputing/cicd-actions/blob/67dd6765157e0baefee0dc874e0f46ccd2075657/.github/workflows/py-wheel-build-and-push.yml#L26

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,17 @@ test:
 #
 # (override)
 coverage:
-	PATH="${PATH};${VENV_NAME}/${VENV_BINDIR}" PYTHONPATH="." $(PYTHON) -m pytest -s\
+	PYTHONPATH="." $(PYTHON) -m pytest \
 		-m "not needs_separate_project" \
 		--cov=src \
+		--cov-fail-under=$(MIN_COVERAGE) \
 		--cov-report xml \
 		--no-cov-on-fail \
 		--ignore=tests/runtime/performance \
 		--ignore=tests/sdk/v2/typing \
 		--durations=10 \
-		tests/runtime/test_services_integration.py \
+		docs/examples/tests \
+		tests \
 		&& echo Code coverage Passed the $(MIN_COVERAGE)% mark!
 
 # Reads the code coverage stats from '.coverage' file and prints a textual,

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 #
 # (override)
 coverage:
-	PATH="${VENV_NAME}/${VENV_BINDIR}:${PATH}" PYTHONPATH="." $(PYTHON) -m pytest \
+	PATH="${VENV_NAME}/${VENV_BINDIR}:${PATH}" PYTHONPATH="." $(PYTHON) -m pytest -s\
 		-m "not needs_separate_project" \
 		--cov=src \
 		--cov-report xml \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 #
 # (override)
 coverage:
-	PATH=${PATH};${VENV_NAME}/${VENV_BINDIR} PYTHONPATH="." $(PYTHON) -m pytest -s\
+	PATH="${PATH};${VENV_NAME}/${VENV_BINDIR}" PYTHONPATH="." $(PYTHON) -m pytest -s\
 		-m "not needs_separate_project" \
 		--cov=src \
 		--cov-report xml \

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,8 @@ user-typing:
 
 # (override)
 github_actions:
-	${PYTHON_EXE} -m venv ${VENV_NAME}
-	${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE} -m pip install --upgrade pip
-	${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE} -m pip install -e '.[dev]'
+	${PYTHON_EXE} -m pip install --upgrade pip
+	${PYTHON_EXE} -m pip install -e '.[dev]'
 
 # Install deps required to build wheel. Used for release automation. See also:
 # https://github.com/zapatacomputing/cicd-actions/blob/67dd6765157e0baefee0dc874e0f46ccd2075657/.github/workflows/py-wheel-build-and-push.yml#L26

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ user-typing:
 
 # (override)
 github_actions:
-	${PYTHON} -m pip install --upgrade pip
-	${PYTHON} -m pip install -e '.[dev]'
+	$(PYTHON) -m pip install --upgrade pip
+	$(PYTHON) -m pip install -e '.[dev]'
 
 # Install deps required to build wheel. Used for release automation. See also:
 # https://github.com/zapatacomputing/cicd-actions/blob/67dd6765157e0baefee0dc874e0f46ccd2075657/.github/workflows/py-wheel-build-and-push.yml#L26

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 #
 # (override)
 coverage:
-	PATH="${VENV_NAME}/${VENV_BINDIR}:${PATH}" PYTHONPATH="." $(PYTHON) -m pytest -s\
+	PATH="${VENV_NAME}/${VENV_BINDIR};${PATH}" PYTHONPATH="." $(PYTHON) -m pytest -s\
 		-m "not needs_separate_project" \
 		--cov=src \
 		--cov-report xml \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 #
 # (override)
 coverage:
-	PATH="${VENV_NAME}/bin:${PATH}" PYTHONPATH="." $(PYTHON) -m pytest \
+	PATH="${VENV_NAME}/${VENV_BINDIR}:${PATH}" PYTHONPATH="." $(PYTHON) -m pytest \
 		-m "not needs_separate_project" \
 		--cov=src \
 		--cov-report xml \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 #
 # (override)
 coverage:
-	PATH="${VENV_NAME}/${VENV_BINDIR};${PATH}" PYTHONPATH="." $(PYTHON) -m pytest -s\
+	PYTHONPATH="." $(PYTHON) -m pytest -s\
 		-m "not needs_separate_project" \
 		--cov=src \
 		--cov-report xml \

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test:
 #
 # (override)
 coverage:
-	PYTHONPATH="." $(PYTHON) -m pytest -s\
+	PATH=${PATH};${VENV_NAME}/${VENV_BINDIR} PYTHONPATH="." $(PYTHON) -m pytest -s\
 		-m "not needs_separate_project" \
 		--cov=src \
 		--cov-report xml \

--- a/Makefile
+++ b/Makefile
@@ -27,17 +27,15 @@ test:
 #
 # (override)
 coverage:
-	PYTHONPATH="." $(PYTHON) -m pytest \
+	PATH="${VENV_NAME}/bin:${PATH}" PYTHONPATH="." $(PYTHON) -m pytest \
 		-m "not needs_separate_project" \
 		--cov=src \
-		--cov-fail-under=$(MIN_COVERAGE) \
 		--cov-report xml \
 		--no-cov-on-fail \
 		--ignore=tests/runtime/performance \
 		--ignore=tests/sdk/v2/typing \
 		--durations=10 \
-		docs/examples/tests \
-		tests \
+		tests/runtime/test_services_integration.py \
 		&& echo Code coverage Passed the $(MIN_COVERAGE)% mark!
 
 # Reads the code coverage stats from '.coverage' file and prints a textual,

--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -99,7 +99,7 @@ class RayManager:
         #    started, or it had been already running prior to this command.
         import os
         print(os.getenv('PATH'))
-        os.environ["PATH"] += os.pathsep + "C:\Windows\System32\Wbem"
+        os.environ["PATH"] += os.pathsep + "C:\\Windows\\System32\\Wbem"
         print(os.getenv('PATH'))
         x = subprocess.run(
             [

--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -112,6 +112,8 @@ class RayManager:
             stderr=subprocess.PIPE,
         )
         print(x)
+        import os
+        print(os.environ["PATH"])
         if not self.is_running():
             raise RuntimeError("Couldn't start Ray cluster")
 

--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -97,7 +97,7 @@ class RayManager:
         # 1. Attempt to start the Ray cluster. Ignore errors.
         # 2. Check if the cluster is running to confirm that either the cluster was
         #    started, or it had been already running prior to this command.
-        _ = subprocess.run(
+        x = subprocess.run(
             [
                 "ray",
                 "start",
@@ -108,9 +108,10 @@ class RayManager:
             ],
             check=False,
             timeout=IPC_TIMEOUT,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
+        print(x)
         if not self.is_running():
             raise RuntimeError("Couldn't start Ray cluster")
 

--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -113,7 +113,7 @@ class RayManager:
         )
         print(x)
         import os
-        print(os.environ["PATH"])
+        print(os.getenv('PATH'))
         if not self.is_running():
             raise RuntimeError("Couldn't start Ray cluster")
 

--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -97,11 +97,7 @@ class RayManager:
         # 1. Attempt to start the Ray cluster. Ignore errors.
         # 2. Check if the cluster is running to confirm that either the cluster was
         #    started, or it had been already running prior to this command.
-        import os
-        print(os.getenv('PATH'))
-        os.environ["PATH"] += os.pathsep + "C:\\Windows\\System32\\Wbem"
-        print(os.getenv('PATH'))
-        x = subprocess.run(
+        _ = subprocess.run(
             [
                 "ray",
                 "start",
@@ -112,11 +108,9 @@ class RayManager:
             ],
             check=False,
             timeout=IPC_TIMEOUT,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
         )
-        print(x)
-
         if not self.is_running():
             raise RuntimeError("Couldn't start Ray cluster")
 

--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -97,6 +97,10 @@ class RayManager:
         # 1. Attempt to start the Ray cluster. Ignore errors.
         # 2. Check if the cluster is running to confirm that either the cluster was
         #    started, or it had been already running prior to this command.
+        import os
+        print(os.getenv('PATH'))
+        os.environ["PATH"] += os.pathsep + "C:\Windows\System32\Wbem"
+        print(os.getenv('PATH'))
         x = subprocess.run(
             [
                 "ray",
@@ -112,8 +116,7 @@ class RayManager:
             stderr=subprocess.PIPE,
         )
         print(x)
-        import os
-        print(os.getenv('PATH'))
+
         if not self.is_running():
             raise RuntimeError("Couldn't start Ray cluster")
 

--- a/subtrees/z_quantum_actions/Makefile
+++ b/subtrees/z_quantum_actions/Makefile
@@ -12,23 +12,6 @@ default:
 	@grep -E '^\w+(\-default)?:' $(TOP_DIR)/$(firstword $(MAKEFILE_LIST)) \
 	       | sed -r 's/-default//g; /default/d ; s/(.*)/\t make \1/g ; s/:.*$$//g'
 
-export VENV_NAME := my_little_venv
-ifeq ($(OS), Windows_NT)
-  VENV_BINDIR := Scripts
-  PYTHON_EXE := python.exe
-  # A workaround for Windows and Bash:
-  # By default, PATH will give the Windows Path, but we need to get the Path for the shell we'll be using
-  SHELL_PATH := $(shell env echo $$PATH)
-  PYTHON := $(shell env PATH="${VENV_NAME}/${VENV_BINDIR}:${SHELL_PATH}" ${PYTHON_EXE} -c 'import sys; print(sys.executable)')
-  # Convert a Windows path to a Unix path for Windows Github Actions
-  PYTHON := /$(subst \,/,$(subst :\,/,$(PYTHON)))
-  WHATEVER = $(shell wmic context)
-else
-  VENV_BINDIR := bin
-  PYTHON_EXE := python3
-  PYTHON := $(shell env PATH="${VENV_NAME}/${VENV_BINDIR}:${PATH}" ${PYTHON_EXE} -c 'import sys; print(sys.executable)')
-endif
-
 REPO := $(shell git config --get remote.origin.url)
 PYTHON_MOD := $(shell find src -maxdepth 3 -mindepth 3 -type d | sed '/.*cache/d; s/src\/python\/// ; s/\//./')
 PACKAGE_NAME := "foo"
@@ -73,9 +56,8 @@ dev-default: clean
 # `python3` here as it's more explicit, because $(PYTHON) would evaluate to 
 # something else after executing this task, which might be confusing.
 github_actions-default:
-	${PYTHON_EXE} -m venv ${VENV_NAME}
-	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install --upgrade pip
-	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" -m pip install -e '.[dev]'
+	${PYTHON} -m pip install --upgrade pip
+	${PYTHON} -m pip install -e '.[dev]'
 
 # flake8p is a wrapper library that runs flake8 from config in pyproject.toml
 # we can now use it instead of flake8 to lint the code
@@ -127,7 +109,7 @@ build-system-deps-default:
 # Note: on CI we only run this step, this means we use the github_actions target as a dependency.
 # Because of this, we don't update the $(PYTHON) variable and have to manually build the path to our venv Python.
 get-next-version-default: github_actions
-	"${VENV_NAME}/${VENV_BINDIR}/${PYTHON_EXE}" subtrees/z_quantum_actions/bin/get_next_version.py $(PACKAGE_NAME)
+	$(PYTHON) subtrees/z_quantum_actions/bin/get_next_version.py $(PACKAGE_NAME)
 
 # This is what converts the -default targets into base target names.
 # Do not remove!!!

--- a/subtrees/z_quantum_actions/Makefile
+++ b/subtrees/z_quantum_actions/Makefile
@@ -22,6 +22,7 @@ ifeq ($(OS), Windows_NT)
   PYTHON := $(shell env PATH="${VENV_NAME}/${VENV_BINDIR}:${SHELL_PATH}" ${PYTHON_EXE} -c 'import sys; print(sys.executable)')
   # Convert a Windows path to a Unix path for Windows Github Actions
   PYTHON := /$(subst \,/,$(subst :\,/,$(PYTHON)))
+  WHATEVER = $(shell wmic context)
 else
   VENV_BINDIR := bin
   PYTHON_EXE := python3

--- a/subtrees/z_quantum_actions/Makefile
+++ b/subtrees/z_quantum_actions/Makefile
@@ -12,6 +12,14 @@ default:
 	@grep -E '^\w+(\-default)?:' $(TOP_DIR)/$(firstword $(MAKEFILE_LIST)) \
 	       | sed -r 's/-default//g; /default/d ; s/(.*)/\t make \1/g ; s/:.*$$//g'
 
+ifeq ($(OS), Windows_NT)
+  PYTHON := $(shell python -c 'import sys; print(sys.executable)')
+  # Convert a Windows path to a Unix path for Windows Github Actions
+  PYTHON := /$(subst \,/,$(subst :\,/,$(PYTHON)))
+else
+  PYTHON := $(shell python -c 'import sys; print(sys.executable)')
+endif
+
 REPO := $(shell git config --get remote.origin.url)
 PYTHON_MOD := $(shell find src -maxdepth 3 -mindepth 3 -type d | sed '/.*cache/d; s/src\/python\/// ; s/\//./')
 PACKAGE_NAME := "foo"

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -439,8 +439,6 @@ class TestRayRuntimeMethods:
                     pytest.fail(
                         f"Timeout when awaiting for workflow finish. Full run: {wf_run}"
                     )
-                    break
-
 
                 time.sleep(0.2)
 

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -544,19 +544,19 @@ def test_run_and_get_output(
 # - Installing packages takes some time in general.
 # - Installing packages on company machines is very slow because of the antivirus
 #   scanning.
-# @pytest.mark.slow
-# def test_import_package_inside_ray(runtime: _dag.RayRuntime):
-#     # This package should not be installed before running test
-#     with pytest.raises(ModuleNotFoundError):
-#         import piccup  # type: ignore # noqa
-#
-#     run_id = runtime.create_workflow_run(_example_wfs.wf_using_python_imports.model)
-#     wf_result = runtime.get_workflow_run_outputs(run_id)
-#     assert wf_result == (2,)
-#
-#     # this package should be only used inside ray env
-#     with pytest.raises(ModuleNotFoundError):
-#         import piccup  # type: ignore # noqa
+@pytest.mark.slow
+def test_import_package_inside_ray(runtime: _dag.RayRuntime):
+    # This package should not be installed before running test
+    with pytest.raises(ModuleNotFoundError):
+        import piccup  # type: ignore # noqa
+
+    run_id = runtime.create_workflow_run(_example_wfs.wf_using_python_imports.model)
+    wf_result = runtime.get_workflow_run_outputs(run_id)
+    assert wf_result == (2,)
+
+    # this package should be only used inside ray env
+    with pytest.raises(ModuleNotFoundError):
+        import piccup  # type: ignore # noqa
 
 
 # This test is slow to run locally because:
@@ -565,22 +565,22 @@ def test_run_and_get_output(
 # - Installing packages takes some time in general.
 # - Installing packages on company machines is very slow because of the antivirus
 #   scanning.
-# @pytest.mark.slow
-# # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
-# # unraisable exceptions. Last tested with Ray 2.2.0.
-# @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-# def test_git_import_inside_ray(runtime: _dag.RayRuntime):
-#     # This package should not be installed before running test
-#     with pytest.raises(ModuleNotFoundError):
-#         import piccup  # type: ignore # noqa
-#
-#     run_id = runtime.create_workflow_run(_example_wfs.wf_using_git_imports.model)
-#     wf_result = runtime.get_workflow_run_outputs(run_id)
-#     assert wf_result == (2,)
-#
-#     # this package should be only used inside ray env
-#     with pytest.raises(ModuleNotFoundError):
-#         import piccup  # type: ignore # noqa
+@pytest.mark.slow
+# Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+# unraisable exceptions. Last tested with Ray 2.2.0.
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+def test_git_import_inside_ray(runtime: _dag.RayRuntime):
+    # This package should not be installed before running test
+    with pytest.raises(ModuleNotFoundError):
+        import piccup  # type: ignore # noqa
+
+    run_id = runtime.create_workflow_run(_example_wfs.wf_using_git_imports.model)
+    wf_result = runtime.get_workflow_run_outputs(run_id)
+    assert wf_result == (2,)
+
+    # this package should be only used inside ray env
+    with pytest.raises(ModuleNotFoundError):
+        import piccup  # type: ignore # noqa
 
 
 @pytest.mark.slow

--- a/tests/runtime/test_services_integration.py
+++ b/tests/runtime/test_services_integration.py
@@ -8,7 +8,7 @@ from orquestra.sdk._base._testing._connections import ray_suitable_temp_dir
 
 
 @pytest.mark.slow
-@pytest.mark.skip("PATH issues on CI: ORQSDK-771")
+#@pytest.mark.skip("PATH issues on CI: ORQSDK-771")
 def test_ray_roundtrip(monkeypatch: pytest.MonkeyPatch):
     with ray_suitable_temp_dir() as tmp_path:
         orq_dir = tmp_path / ".orquestra"

--- a/tests/runtime/test_services_integration.py
+++ b/tests/runtime/test_services_integration.py
@@ -10,6 +10,8 @@ from orquestra.sdk._base._testing._connections import ray_suitable_temp_dir
 @pytest.mark.slow
 #@pytest.mark.skip("PATH issues on CI: ORQSDK-771")
 def test_ray_roundtrip(monkeypatch: pytest.MonkeyPatch):
+    import os
+    print(os.getenv('PATH'))
     with ray_suitable_temp_dir() as tmp_path:
         orq_dir = tmp_path / ".orquestra"
         monkeypatch.setenv("ORQ_RAY_TEMP_PATH", str(orq_dir / "ray"))

--- a/tests/runtime/test_services_integration.py
+++ b/tests/runtime/test_services_integration.py
@@ -8,10 +8,7 @@ from orquestra.sdk._base._testing._connections import ray_suitable_temp_dir
 
 
 @pytest.mark.slow
-#@pytest.mark.skip("PATH issues on CI: ORQSDK-771")
 def test_ray_roundtrip(monkeypatch: pytest.MonkeyPatch):
-    import os
-    print(os.getenv('PATH'))
     with ray_suitable_temp_dir() as tmp_path:
         orq_dir = tmp_path / ".orquestra"
         monkeypatch.setenv("ORQ_RAY_TEMP_PATH", str(orq_dir / "ray"))


### PR DESCRIPTION
# The problem

We were unable to run the services integration tests due to the issues in PATHs - RAY executable couldnt be found.

# This PR's solution

Initial solution to just add RAY executable to path was problematic, because of the differences between OS's. To fix the problem in its roots, this PR properly creates and sources python venv, so the paths are correctly set and no more shenanigans in makefiles are needed.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
