### PR TITLE
feat: Apply resources to Ray remote functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 
 🥷 *Internal*
+* RayRuntime can now be configured to pass resources to underlying remote functions
 
 
 📃 *Docs*

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -40,6 +40,13 @@ Example:
     ORQ_RAY_DOWNLOAD_GIT_IMPORTS=1
 """
 
+RAY_SET_TASK_RESOURCES_ENV = "ORQ_RAY_SET_TASK_RESOURCES"
+"""
+Used to configure if Ray uses a task invocation's resources
+Example:
+    ORQ_RAY_SET_TASK_RESOURCES=1
+"""
+
 PASSPORT_FILE_ENV = "ORQUESTRA_PASSPORT_FILE"
 """
 Consumed by the Workflow SDK to set auth in remote contexts

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -89,6 +89,9 @@ else:
             metadata: t.Dict[str, t.Any],
             runtime_env: t.Optional[RuntimeEnv],
             catch_exceptions: t.Optional[bool],
+            num_cpus: t.Optional[t.Union[int, float]] = None,
+            num_gpus: t.Optional[t.Union[int, float]] = None,
+            memory: t.Optional[t.Union[int, float]] = None,
         ):
             # The type hint for 'ray.workflow.options' kwargs is invalid. We can
             # work it around by Any.
@@ -97,9 +100,17 @@ else:
                 "metadata": metadata,
                 "catch_exceptions": catch_exceptions,
             }
+            ray_optional_opts = {}
+            if num_cpus is not None:
+                ray_optional_opts["num_cpus"] = num_cpus
+            if num_gpus is not None:
+                ray_optional_opts["num_gpus"] = num_gpus
+            if memory is not None:
+                ray_optional_opts["memory"] = memory
             return ray_remote_fn.options(
                 **ray.workflow.options(**workflow_opts),
                 runtime_env=runtime_env,
+                **ray_optional_opts,
             )
 
         # ----- Ray Workflow -----

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -31,8 +31,13 @@ from .._base import (
     serde,
 )
 from .._base._db import WorkflowDB
-from .._base._env import RAY_DOWNLOAD_GIT_IMPORTS_ENV, RAY_GLOBAL_WF_RUN_ID_ENV
+from .._base._env import (
+    RAY_DOWNLOAD_GIT_IMPORTS_ENV,
+    RAY_GLOBAL_WF_RUN_ID_ENV,
+    RAY_SET_TASK_RESOURCES_ENV,
+)
 from .._base.abc import ArtifactValue, LogReader, RuntimeInterface
+from ..kubernetes.quantity import parse_quantity
 from ..schema import ir
 from ..schema.configs import RuntimeConfiguration
 from ..schema.local_database import StoredWorkflowRun
@@ -354,7 +359,7 @@ def _gather_kwargs(
 
 
 def _make_ray_dag(
-    client: RayClient, wf: ir.WorkflowDef, wf_run_id: str, project_dir: Path
+    client: RayClient, wf: ir.WorkflowDef, wf_run_id: str, project_dir: t.Optional[Path]
 ):
     ray_consts: t.Dict[ir.ConstantNodeId, t.Any] = {
         id: serde.deserialize_constant(node) for id, node in wf.constant_nodes.items()
@@ -365,6 +370,10 @@ def _make_ray_dag(
         )
     # a mapping of "artifact ID" <-> "the ray Future needed to get the value"
     ray_futures: t.Dict[ir.ArtifactNodeId, t.Any] = {}
+
+    # Environment variable is used to configure if we apply task invocation resources
+    # to a Ray remote's options
+    add_resources = os.getenv(RAY_SET_TASK_RESOURCES_ENV) == "1"
 
     for ir_invocation in _graphs.iter_invocations_topologically(wf):
         # Prep args, kwargs, and the specs required to unpack tuples
@@ -402,6 +411,23 @@ def _make_ray_dag(
             "runtime_env": (_client.RuntimeEnv(pip=pip) if len(pip) > 0 else None),
             "catch_exceptions": False,
         }
+
+        # Task resources
+        if add_resources and ir_invocation.resources is not None:
+            if ir_invocation.resources.cpu is not None:
+                cpu = parse_quantity(ir_invocation.resources.cpu)
+                cpu_int = cpu.to_integral_value()
+                ray_options["num_cpus"] = cpu_int if cpu == cpu_int else float(cpu)
+            if ir_invocation.resources.memory is not None:
+                memory = parse_quantity(ir_invocation.resources.memory)
+                memory_int = memory.to_integral_value()
+                ray_options["memory"] = (
+                    memory_int if memory == memory_int else float(memory)
+                )
+            if ir_invocation.resources.gpu is not None:
+                # Fractional GPUs not supported currently
+                gpu = int(ir_invocation.resources.gpu)
+                ray_options["num_gpus"] = gpu
 
         ray_future = _make_ray_dag_node(
             client=client,

--- a/tests/runtime/ray/test_client.py
+++ b/tests/runtime/ray/test_client.py
@@ -1,0 +1,65 @@
+from unittest.mock import Mock
+
+import pytest
+
+from orquestra.sdk._ray._client import RayClient
+
+
+class TestClient:
+    class TestAddOptions:
+        @pytest.fixture
+        def client(self):
+            return RayClient()
+
+        @pytest.fixture
+        def remote_fn(self):
+            return Mock()
+
+        @pytest.fixture
+        def required_kwargs(self):
+            return {
+                "name": "mocked name",
+                "metadata": {},
+                "catch_exceptions": False,
+                "runtime_env": None,
+            }
+
+        def test_required_args(self, client: RayClient, remote_fn, required_kwargs):
+            client.add_options(remote_fn, **required_kwargs)
+            remote_fn.options.assert_called_with(
+                _metadata={
+                    "workflow.io/options": {
+                        "task_id": required_kwargs["name"],
+                        "metadata": required_kwargs["metadata"],
+                        "catch_exceptions": required_kwargs["catch_exceptions"],
+                    }
+                },
+                runtime_env=required_kwargs["runtime_env"],
+            )
+
+        @pytest.mark.parametrize(
+            "kwargs,expected",
+            [
+                ({}, {}),
+                ({"num_cpus": None}, {}),
+                ({"num_cpus": 2}, {"num_cpus": 2}),
+                ({"num_gpus": 1}, {"num_gpus": 1}),
+                ({"memory": 1}, {"memory": 1}),
+            ],
+        )
+        def test_resources(
+            self, client: RayClient, remote_fn, required_kwargs, kwargs, expected
+        ):
+            print(kwargs)
+            client.add_options(remote_fn, **required_kwargs, **kwargs)
+            remote_fn.options.assert_called_with(
+                _metadata={
+                    "workflow.io/options": {
+                        "task_id": required_kwargs["name"],
+                        "metadata": required_kwargs["metadata"],
+                        "catch_exceptions": required_kwargs["catch_exceptions"],
+                    }
+                },
+                runtime_env=required_kwargs["runtime_env"],
+                **expected,
+            )

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -7,13 +7,17 @@ Ray connection, see tests/ray/test_integration.py instead.
 """
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import Mock, PropertyMock, create_autospec
+from typing import Dict, Union
+from unittest.mock import ANY, Mock, PropertyMock, call, create_autospec
 
 import pytest
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _services
 from orquestra.sdk._base._config import RuntimeConfiguration, RuntimeName
+from orquestra.sdk._base._testing._example_wfs import (
+    workflow_parametrised_with_resources,
+)
 from orquestra.sdk._ray import _client, _dag, _ray_logs
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.workflow_run import State
@@ -588,3 +592,87 @@ class TestPipString:
             imp = ir.InlineImport(id="mock-import")
             pip = _dag._pip_string(imp)
             assert pip == []
+
+
+class TestResourcesInMakeDag:
+    @pytest.fixture
+    def wf_run_id(self):
+        return "mocked_wf_run_id"
+
+    @pytest.fixture
+    def client(self):
+        return create_autospec(_dag.RayClient)
+
+    @pytest.fixture
+    def patch_env(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setenv("ORQ_RAY_SET_TASK_RESOURCES", "1")
+
+    @pytest.mark.parametrize(
+        "resources, expected",
+        [
+            ({}, {}),
+            ({"cpu": "1000m"}, {}),
+            ({"memory": "1Gi"}, {}),
+            ({"gpu": "1"}, {}),
+            ({"cpu": "2", "memory": "10G", "gpu": "1"}, {}),
+        ],
+    )
+    def test_without_env_variable(
+        self,
+        client: Mock,
+        wf_run_id: str,
+        resources: Dict[str, str],
+        expected: Dict[str, Union[int, float]],
+    ):
+        workflow = workflow_parametrised_with_resources(**resources).model
+        _ = _dag._make_ray_dag(client, workflow, wf_run_id, None)
+        calls = client.add_options.call_args_list
+
+        # We should only have two calls: our invocation and the aggregation step
+        assert len(calls) == 2
+        # Checking our call did not have any resources included
+        assert calls[0] == call(
+            ANY,
+            name=ANY,
+            metadata=ANY,
+            runtime_env=ANY,
+            catch_exceptions=ANY,
+            **expected
+        )
+
+    @pytest.mark.parametrize(
+        "resources, expected",
+        [
+            ({}, {}),
+            ({"cpu": "1000m"}, {"num_cpus": 1.0}),
+            ({"memory": "1Gi"}, {"memory": 1073741824}),
+            ({"gpu": "1"}, {"num_gpus": 1}),
+            (
+                {"cpu": "2", "memory": "10G", "gpu": "1"},
+                {"num_cpus": 2, "memory": 10000000000, "num_gpus": 1},
+            ),
+        ],
+    )
+    def test_with_env_variable(
+        self,
+        patch_env,
+        client: Mock,
+        wf_run_id: str,
+        resources: Dict[str, str],
+        expected: Dict[str, Union[int, float]],
+    ):
+        workflow = workflow_parametrised_with_resources(**resources).model
+        _ = _dag._make_ray_dag(client, workflow, wf_run_id, None)
+        calls = client.add_options.call_args_list
+
+        # We should only have two calls: our invocation and the aggregation step
+        assert len(calls) == 2
+        # Checking our call did not have any resources included
+        assert calls[0] == call(
+            ANY,
+            name=ANY,
+            metadata=ANY,
+            runtime_env=ANY,
+            catch_exceptions=ANY,
+            **expected
+        )


### PR DESCRIPTION
# The problem

Sometimes we want to let Ray decided when to schedule tasks based on available resources.

# This PR's solution

* Adds a config env variable to switch applying resources on
* Takes resources from a task invocation and applies them to a Ray remote function

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
