### PR TITLE
docs: All dependencies in quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
 `orquestra-sdk` is a Python library for expressing and executing computational workflows locally and on the [Orquestra](https://www.zapatacomputing.com/orquestra) platform.
 
 `orquestra-sdk` provides:
+
 - A Python DSL to express your workflows
 - An API for managing and using secrets inside workflows
 - An API for executing and managing your workflows
-- A CLI tool for executing and managing workflows 
+- A CLI tool for executing and managing workflows
 
 ## Installation
 
 Orquestra Workflow SDK is published to PyPI and should be installed from there via `pip`:
 
-```
-pip install orquestra-sdk[all]
+```bash
+pip install "orquestra-sdk[all]"
 ```
 
 ## Usage

--- a/docs/tutorials/installing-macos-linux.rst
+++ b/docs/tutorials/installing-macos-linux.rst
@@ -39,7 +39,7 @@ Install the Orquestra Workflow SDK by running:
 
 .. code-block:: bash
 
-    pip install orquestra-sdk[all]
+    pip install "orquestra-sdk[all]"
 
 .. only:: internal
 

--- a/docs/tutorials/installing-windows.rst
+++ b/docs/tutorials/installing-windows.rst
@@ -108,7 +108,7 @@ You can install the Workflow SDK with:
 
 .. code-block::
 
-    pip install orquestra-sdk[all]
+    pip install "orquestra-sdk[all]"
 
 We highly recommended installing Orquestra Workflow SDK inside a virtual environment, which can be
 easily created with ``python -m venv <venv name>``.

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -24,7 +24,7 @@ except ModuleNotFoundError:
                 raise ModuleNotFoundError(
                     "In order to run workflows locally using Ray, "
                     "please make sure you install the optional dependencies with:\n"
-                    "`pip install orquestra-sdk[all]`",
+                    "`pip install 'orquestra-sdk[all]'`",
                     name="ray",
                 )
 


### PR DESCRIPTION
# The problem

While trying to run a workflow I encountered this issue:

```zsh
python workflow_defs.py                                            
Traceback (most recent call last):
  File "workflow_defs.py", line 27, in <module>
    logger = workflow_logger()
  File "/Users/vladimir/micromamba/envs/zapata/lib/python3.8/site-packages/orquestra/sdk/_base/_log_adapter.py", line 170, in workflow_logger
    wf_run_id, task_inv_id, task_run_id = get_ray_backend_ids()
  File "/Users/vladimir/micromamba/envs/zapata/lib/python3.8/site-packages/orquestra/sdk/_base/_log_adapter.py", line 90, in get_ray_backend_ids
    return orquestra.sdk._ray._dag.get_current_ids()
  File "/Users/vladimir/micromamba/envs/zapata/lib/python3.8/site-packages/orquestra/sdk/_ray/_dag.py", line 977, in get_current_ids
    client = _client.RayClient()
  File "/Users/vladimir/micromamba/envs/zapata/lib/python3.8/site-packages/orquestra/sdk/_ray/_client.py", line 24, in __init__
    raise ModuleNotFoundError(
ModuleNotFoundError: In order to run workflows locally using Ray, please make sure you install the optional dependencies with:
`pip install orquestra-sdk[all]`
(zapata) ➜  continuous-geo-paper git:(test/volodyaco/pickling-models) ✗ pip install orquestra-sdk[all]
zsh: no matches found: orquestra-sdk[all]
```

`pip install "orquestra-sdk[all]"` works, though.

# This PR's solution

Fixes documentation for this installation message.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
