### PR TITLE
fix: Ensure decimal types are converted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,7 @@
 
 
 🐛 *Bug Fixes*
-
-
+* Ensure `int`-like resource values are passed to Ray correctly
 
 💅 *Improvements*
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -417,12 +417,12 @@ def _make_ray_dag(
             if ir_invocation.resources.cpu is not None:
                 cpu = parse_quantity(ir_invocation.resources.cpu)
                 cpu_int = cpu.to_integral_value()
-                ray_options["num_cpus"] = cpu_int if cpu == cpu_int else float(cpu)
+                ray_options["num_cpus"] = int(cpu_int) if cpu == cpu_int else float(cpu)
             if ir_invocation.resources.memory is not None:
                 memory = parse_quantity(ir_invocation.resources.memory)
                 memory_int = memory.to_integral_value()
                 ray_options["memory"] = (
-                    memory_int if memory == memory_int else float(memory)
+                    int(memory_int) if memory == memory_int else float(memory)
                 )
             if ir_invocation.resources.gpu is not None:
                 # Fractional GPUs not supported currently


### PR DESCRIPTION
# The problem

Passing a parsed quantity from k8s to Ray's resources resulted in an error 
Float-like values were OK.

# This PR's solution

* Ensure `int` types are `int`.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
