### PR TITLE
Feat: Add start time value and sort by it to CLI commands and prompts that list WFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Workflow definitions now require at least one task in order to be submitted. This check is performed during traversal, and raises a WorkflowSyntaxError if no tasks are required to be executed.
 
 🔥 *Features*
-
+- Sort WF runs by start date in `list wf` command. Show start date as one of the columns
+- Sort WF runs by start date in all workflow commands in prompt selection. Show start date with WF id
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
+++ b/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
@@ -234,7 +234,13 @@ def _format_multiple_runs(runs: t.Sequence[responses.WorkflowRun]):
     headers = ["workflow run ID", "status", "tasks succeeded", "start time"]
     # leave start_time at datetime.datetime format, so we can easily sort by it
     rows = [
-        [run.id, run.status.state.value, _tasks_number_summary(run), run.status.start_time] for run in runs
+        [
+            run.id,
+            run.status.state.value,
+            _tasks_number_summary(run),
+            run.status.start_time,
+        ]
+        for run in runs
     ]
     # take into account that we might be missing start time. Try our best to sort
     # by start time of the workflow

--- a/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
+++ b/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
@@ -246,7 +246,7 @@ def _format_multiple_runs(runs: t.Sequence[responses.WorkflowRun]):
     # by start time of the workflow
     rows.sort(key=lambda row: row[3] if row[3] else datetime.fromtimestamp(0))
     for row in rows:
-        row[3] = _format_datetime(row[3])
+        row[3] = row[3].astimezone().replace(tzinfo=None).ctime()
 
     print(tabulate.tabulate(rows, headers=headers))
 

--- a/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
+++ b/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
@@ -231,10 +231,17 @@ def _print_single_run(run: responses.WorkflowRun, project_dir: t.Optional[str]):
 
 
 def _format_multiple_runs(runs: t.Sequence[responses.WorkflowRun]):
-    headers = ["workflow run ID", "status", "tasks succeeded"]
+    headers = ["workflow run ID", "status", "tasks succeeded", "start time"]
+    # leave start_time at datetime.datetime format, so we can easily sort by it
     rows = [
-        [run.id, run.status.state.value, _tasks_number_summary(run)] for run in runs
+        [run.id, run.status.state.value, _tasks_number_summary(run), run.status.start_time] for run in runs
     ]
+    # take into account that we might be missing start time. Try our best to sort
+    # by start time of the workflow
+    rows.sort(key=lambda row: row[3] if row[3] else datetime.fromtimestamp(0))
+    for row in rows:
+        row[3] = _format_datetime(row[3])
+
     print(tabulate.tabulate(rows, headers=headers))
 
 

--- a/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
+++ b/src/orquestra/sdk/_base/cli/_corq/_format/per_command.py
@@ -246,7 +246,11 @@ def _format_multiple_runs(runs: t.Sequence[responses.WorkflowRun]):
     # by start time of the workflow
     rows.sort(key=lambda row: row[3] if row[3] else datetime.fromtimestamp(0))
     for row in rows:
-        row[3] = row[3].astimezone().replace(tzinfo=None).ctime()
+        row[3] = (
+            row[3].astimezone().replace(tzinfo=None).ctime()
+            if isinstance(row[3], datetime)  # just in case startime doesnt exist
+            else ""
+        )
 
     print(tabulate.tabulate(rows, headers=headers))
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -6,10 +6,7 @@ When the user doesn't pass in all the required information as CLI arguments we n
 resolve the information from other sources. This module contains the CLI argument
 resolution logic extracted as components reusable across similar CLI commands.
 """
-import datetime
 import typing as t
-
-from tabulate import tabulate
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _services
@@ -128,10 +125,8 @@ class WFRunResolver:
 
         wfs = self._wf_run_repo.list_wf_runs(config)
 
-        tabulated_labels = self._presenter.wf_list_for_prompt(wfs)
-
-        prompt_choices = [(tabulated_labels[i], wf.id) for i, wf in enumerate(wfs)]
-
+        wfs, tabulated_labels = self._presenter.wf_list_for_prompt(wfs)
+        prompt_choices = [(label, wf.id) for label, wf in zip(tabulated_labels, wfs)]
         selected_id = self._prompter.choice(prompt_choices, message="Workflow run ID")
 
         return selected_id
@@ -144,9 +139,8 @@ class WFRunResolver:
 
         runs = self._wf_run_repo.list_wf_runs(config)
 
-        tabulated_labels = self._presenter.wf_list_for_prompt(runs)
-
-        prompt_choices = [(tabulated_labels[i], wf) for i, wf in enumerate(runs)]
+        runs, tabulated_labels = self._presenter.wf_list_for_prompt(runs)
+        prompt_choices = [(label, wf) for label, wf in zip(tabulated_labels, runs)]
 
         selected_run = self._prompter.choice(prompt_choices, message="Workflow run ID")
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -126,16 +126,15 @@ class WFRunResolver:
 
         # Query the runtime for suitable workflow run IDs.
         wfs = self._wf_run_repo.list_wf_runs(config)
-
         # sort wfs by submission date. Take into account when there is no start_time
         wfs.sort(
             key=lambda wf: wf.status.start_time
             if wf.status.start_time
-            else datetime.datetime.fromtimestamp(0)
+            else datetime.datetime.fromtimestamp(0),
+            reverse=True,
         )
-
-        # Create labels of wf shown to the user by prompter.
-        # Label is <wf_id> <start_time> tabulated nicely to format good looking table
+        # Create labels of wf that are printed by prompter
+        # Label is <wf_id> <start_time> tabulated nicely to create good-looking table
         labels = [
             [
                 wf.id,

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -125,9 +125,6 @@ class WFRunResolver:
             return wf_run_id
 
         # Query the runtime for suitable workflow run IDs.
-        # TODO: figure out sensible filters when listing workflow runs is implemented
-        # in the public API.
-        # Related ticket: https://zapatacomputing.atlassian.net/browse/ORQSDK-671
         wfs = self._wf_run_repo.list_wf_runs(config)
 
         # sort wfs by submission date. Take into account when there is no start_time
@@ -137,10 +134,10 @@ class WFRunResolver:
             else datetime.datetime.fromtimestamp(0)
         )
 
-        # Create labels  of wf shown to the user by prompter.
+        # Create labels of wf shown to the user by prompter.
         # Label is <wf_id> <start_time> tabulated nicely to format good looking table
         labels = [
-            [wf.id, wf.status.start_time.isoformat() if wf.status.start_time else ""]
+            [wf.id, wf.status.start_time.astimezone().replace(tzinfo=None).ctime() if wf.status.start_time else ""]
             for wf in wfs
         ]
         tabulated_labels = tabulate(labels, tablefmt="plain").split("\n")

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -137,7 +137,12 @@ class WFRunResolver:
         # Create labels of wf shown to the user by prompter.
         # Label is <wf_id> <start_time> tabulated nicely to format good looking table
         labels = [
-            [wf.id, wf.status.start_time.astimezone().replace(tzinfo=None).ctime() if wf.status.start_time else ""]
+            [
+                wf.id,
+                wf.status.start_time.astimezone().replace(tzinfo=None).ctime()
+                if wf.status.start_time
+                else "",
+            ]
             for wf in wfs
         ]
         tabulated_labels = tabulate(labels, tablefmt="plain").split("\n")

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -8,6 +8,7 @@ resolution logic extracted as components reusable across similar CLI commands.
 """
 import datetime
 import typing as t
+
 from tabulate import tabulate
 
 from orquestra.sdk import exceptions
@@ -130,11 +131,18 @@ class WFRunResolver:
         wfs = self._wf_run_repo.list_wf_runs(config)
 
         # sort wfs by submission date. Take into account when there is no start_time
-        wfs.sort(key=lambda wf: wf.status.start_time if wf.status.start_time else datetime.datetime.fromtimestamp(0))
+        wfs.sort(
+            key=lambda wf: wf.status.start_time
+            if wf.status.start_time
+            else datetime.datetime.fromtimestamp(0)
+        )
 
         # Create labels  of wf shown to the user by prompter.
         # Label is <wf_id> <start_time> tabulated nicely to format good looking table
-        labels = [[wf.id, wf.status.start_time.isoformat() if wf.status.start_time else ''] for wf in wfs]
+        labels = [
+            [wf.id, wf.status.start_time.isoformat() if wf.status.start_time else ""]
+            for wf in wfs
+        ]
         tabulated_labels = tabulate(labels, tablefmt="plain").split("\n")
 
         prompt_choices = [(tabulated_labels[i], wf.id) for i, wf in enumerate(wfs)]

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -438,7 +438,7 @@ class SummaryRepo:
         wf_runs.sort(
             key=lambda wf_run: wf_run.status.start_time
             if wf_run.status.start_time
-            else datetime.datetime.fromtimestamp(0)
+            else datetime.datetime.fromtimestamp(0).astimezone(datetime.timezone.utc)
         )
 
         return ui_models.WFList(wf_rows=[_ui_model_from_wf(wf) for wf in wf_runs])

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -404,11 +404,7 @@ def _ui_model_from_wf(wf_run: WorkflowRun):
         workflow_run_id=wf_run.id,
         status=wf_run.status.state.value,
         tasks_succeeded=_tasks_number_summary(wf_run),
-        start_time=(
-            wf_run.status.start_time.astimezone().replace(tzinfo=None).ctime()
-            if wf_run.status.start_time
-            else ""
-        ),
+        start_time=wf_run.status.start_time,
     )
 
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -438,7 +438,9 @@ class SummaryRepo:
         wf_runs.sort(
             key=lambda wf_run: wf_run.status.start_time
             if wf_run.status.start_time
-            else datetime.datetime.fromtimestamp(0).astimezone(datetime.timezone.utc)
+            else datetime.datetime.fromtimestamp(0).replace(
+                tzinfo=datetime.timezone.utc
+            )
         )
 
         return ui_models.WFList(wf_rows=[_ui_model_from_wf(wf) for wf in wf_runs])

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -6,6 +6,7 @@ Repositories that encapsulate data access used by dorq commands.
 
 The "data" layer. Shouldn't directly depend on the "view" layer.
 """
+import datetime
 import importlib
 import os
 import sys
@@ -390,6 +391,27 @@ def _ui_model_from_task_run(task_run: TaskRun, wf_def: WorkflowDef):
     )
 
 
+def _tasks_number_summary(wf_run: WorkflowRun) -> str:
+    total = len(wf_run.task_runs)
+    finished = sum(
+        1 for task_run in wf_run.task_runs if task_run.status.state == State.SUCCEEDED
+    )
+    return f"{finished}/{total}"
+
+
+def _ui_model_from_wf(wf_run: WorkflowRun):
+    return ui_models.WFList.WFRow(
+        workflow_run_id=wf_run.id,
+        status=wf_run.status.state.value,
+        tasks_succeeded=_tasks_number_summary(wf_run),
+        start_time=(
+            wf_run.status.start_time.astimezone().replace(tzinfo=None).ctime()
+            if wf_run.status.start_time
+            else ""
+        ),
+    )
+
+
 class SummaryRepo:
     """
     Performs data wrangling to derive UI models that we can show to the user.
@@ -414,6 +436,16 @@ class SummaryRepo:
             n_tasks_succeeded=n_succeeded,
             n_task_invocations_total=n_total,
         )
+
+    def wf_list_summary(self, wf_runs: t.List[WorkflowRun]) -> ui_models.WFList:
+
+        wf_runs.sort(
+            key=lambda wf_run: wf_run.status.start_time
+            if wf_run.status.start_time
+            else datetime.datetime.fromtimestamp(0)
+        )
+
+        return ui_models.WFList(wf_rows=[_ui_model_from_wf(wf) for wf in wf_runs])
 
 
 class ConfigRepo:

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_models.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_models.py
@@ -9,6 +9,7 @@ Ideally, most data transformations would be already done (like counting the numb
 inished tasks) but should be easy to assert on in tests (e.g. we prefer ``datetime``
 objects instead of date strings).
 """
+import datetime
 import typing as t
 from dataclasses import dataclass
 
@@ -51,6 +52,6 @@ class WFList:
         workflow_run_id: str
         status: str
         tasks_succeeded: str
-        start_time: str
+        start_time: t.Optional[datetime.datetime]
 
     wf_rows: t.Sequence[WFRow]

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_models.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_models.py
@@ -38,3 +38,19 @@ class WFRunSummary:
     task_rows: t.Sequence[TaskRow]
     n_tasks_succeeded: int
     n_task_invocations_total: int
+
+
+@dataclass(frozen=True)
+class WFList:
+    """
+    UI model for ``orq wf list``
+    """
+
+    @dataclass(frozen=True)
+    class WFRow:
+        workflow_run_id: str
+        status: str
+        tasks_succeeded: str
+        start_time: str
+
+    wf_rows: t.Sequence[WFRow]

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -10,7 +10,7 @@ import sys
 import typing as t
 import webbrowser
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Iterator, List
 
@@ -288,7 +288,7 @@ class PromptPresenter:
             wfs,
             key=lambda wf: wf.status.start_time
             if wf.status.start_time
-            else datetime.fromtimestamp(0),
+            else datetime.fromtimestamp(0).astimezone(timezone.utc),
             reverse=True,
         )
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -267,3 +267,7 @@ class WFRunPresenter:
             )
         click.echo("Task details")
         click.echo(tabulate(task_rows, headers="firstrow"))
+
+    def show_wf_list(self, summary: ui_models.WFList):
+        click.echo("Workflow List")
+        click.echo(tabulate([wf_row for wf_row in summary.wf_rows]))

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -288,7 +288,7 @@ class PromptPresenter:
             wfs,
             key=lambda wf: wf.status.start_time
             if wf.status.start_time
-            else datetime.fromtimestamp(0).astimezone(timezone.utc),
+            else datetime.fromtimestamp(0).replace(tzinfo=timezone.utc),
             reverse=True,
         )
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -270,4 +270,5 @@ class WFRunPresenter:
 
     def show_wf_list(self, summary: ui_models.WFList):
         click.echo("Workflow List")
-        click.echo(tabulate([wf_row for wf_row in summary.wf_rows]))
+        headers = ["workflow run ID", "status", "tasks succeeded", "start time"]
+        click.echo(tabulate([wf_row for wf_row in summary.wf_rows], headers=headers))

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -280,7 +280,10 @@ class WFRunPresenter:
 
 class PromptPresenter:
     def wf_list_for_prompt(self, wfs):
-        # sort wfs by submission date. Take into account when there is no start_time
+        # Create labels of wf that are printed by prompter
+        # Label is <wf_id> <start_time> tabulated nicely to create good-looking
+        # table
+        # There is also expectations that labels correspond to matching wfs list indices
         wfs = sorted(
             wfs,
             key=lambda wf: wf.status.start_time
@@ -288,10 +291,8 @@ class PromptPresenter:
             else datetime.fromtimestamp(0),
             reverse=True,
         )
-        # Create labels of wf that are printed by prompter
-        # Label is <wf_id> <start_time> tabulated nicely to create good-looking
-        # table
+
         labels = [[wf.id, _format_datetime(wf.status.start_time)] for wf in wfs]
         tabulated_labels = tabulate(labels, tablefmt="plain").split("\n")
 
-        return tabulated_labels
+        return wfs, tabulated_labels

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -269,6 +269,5 @@ class WFRunPresenter:
         click.echo(tabulate(task_rows, headers="firstrow"))
 
     def show_wf_list(self, summary: ui_models.WFList):
-        click.echo("Workflow List")
-        headers = ["workflow run ID", "status", "tasks succeeded", "start time"]
-        click.echo(tabulate([wf_row for wf_row in summary.wf_rows], headers=headers))
+        headers = ["Workflow Run ID", "Status", "Tasks Succeeded", "Start Time"]
+        click.echo(tabulate(summary.wf_rows, headers=headers))

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_list.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_list.py
@@ -25,7 +25,9 @@ class Action:
 
     def __init__(
         self,
-        presenter=_presenters.WrappedCorqOutputPresenter(),
+        presenter=_presenters.WFRunPresenter(),
+        error_presenter=_presenters.WrappedCorqOutputPresenter(),
+        summary_repo=_repos.SummaryRepo(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.ConfigResolver] = None,
         wf_run_filter_resolver: t.Optional[_arg_resolvers.WFRunFilterResolver] = None,
@@ -39,8 +41,10 @@ class Action:
             wf_run_filter_resolver or _arg_resolvers.WFRunFilterResolver()
         )
 
+        self._summary_repo = summary_repo
         # text IO
         self._presenter = presenter
+        self._error_presenter = error_presenter
 
     def on_cmd_call(
         self,
@@ -59,7 +63,7 @@ class Action:
                 interactive=interactive,
             )
         except Exception as e:
-            self._presenter.show_error(e)
+            self._error_presenter.show_error(e)
 
     def _on_cmd_call_with_exceptions(
         self,
@@ -95,5 +99,6 @@ class Action:
                 state=resolved_state,
             )
 
+        summary = self._summary_repo.wf_list_summary(wf_runs)
         # Display to the user
-        self._presenter.show_wf_runs_list(wf_runs)
+        self._presenter.show_wf_list(summary)

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -470,7 +470,7 @@ class TestWFRunResolver:
                 [
                     (
                         "2  " + (current_time + timedelta(seconds=time_delta)).ctime(),
-                        listed_runs[1], # this has later start_time than [0]
+                        listed_runs[1],  # this has later start_time than [0]
                     ),
                     ("1  " + current_time.ctime(), listed_runs[0]),
                 ],

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -350,8 +350,8 @@ class TestWFRunResolver:
                 run.id = id
                 run.status = RunStatus(
                     state=State.RUNNING,
-                    start_time=datetime.fromtimestamp(ts),
-                    end_time=datetime.fromtimestamp(ts),
+                    start_time=datetime.fromtimestamp(ts, tz=timezone.utc),
+                    end_time=datetime.fromtimestamp(ts, tz=timezone.utc),
                 )
                 return run
 

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -345,7 +345,7 @@ class TestWFRunResolver:
             User didn't pass ``wf_run_id``.
             """
             # Given
-            current_time = datetime.now()
+            current_time = datetime.now().astimezone()
 
             def return_wf(id, time_delay_in_sec: int):
                 run = Mock()

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -350,8 +350,8 @@ class TestWFRunResolver:
                 run.id = id
                 run.status = RunStatus(
                     state=State.RUNNING,
-                    start_time=datetime.fromtimestamp(ts, tz=timezone.utc),
-                    end_time=datetime.fromtimestamp(ts, tz=timezone.utc),
+                    start_time=datetime.fromtimestamp(ts).astimezone(),
+                    end_time=datetime.fromtimestamp(ts).astimezone(),
                 )
                 return run
 

--- a/tests/cli/dorq/ui/data/wf_runs/running.txt
+++ b/tests/cli/dorq/ui/data/wf_runs/running.txt
@@ -3,7 +3,7 @@ Workflow overview
 workflow def name  hello_orq
 run ID             wf.1
 status             RUNNING
-start time         Fri Feb 24 13:26:07 2023
+start time         Fri Feb 24 08:26:07 2023
 end time
 tasks succeeded    1 / 2
 -----------------  ------------------------
@@ -11,5 +11,5 @@ tasks succeeded    1 / 2
 Task details
 function       invocation ID    status     start_time                end_time                  message
 -------------  ---------------  ---------  ------------------------  ------------------------  ---------
-generate_data  inv-1-gen-dat    SUCCEEDED  Fri Feb 24 13:26:07 2023  Fri Feb 24 13:28:37 2023
-train_model    inv-2-tra-mod    RUNNING    Fri Feb 24 13:28:37 2023
+generate_data  inv-1-gen-dat    SUCCEEDED  Fri Feb 24 08:26:07 2023  Fri Feb 24 08:26:07 2023
+train_model    inv-2-tra-mod    RUNNING    Fri Feb 24 08:26:07 2023

--- a/tests/cli/dorq/ui/data/wf_runs/running.txt
+++ b/tests/cli/dorq/ui/data/wf_runs/running.txt
@@ -1,15 +1,15 @@
 Workflow overview
------------------  --------------------------------
+-----------------  ------------------------
 workflow def name  hello_orq
 run ID             wf.1
 status             RUNNING
-start time         2023-02-24T07:26:07.704015-05:00
+start time         Fri Feb 24 13:26:07 2023
 end time
 tasks succeeded    1 / 2
------------------  --------------------------------
+-----------------  ------------------------
 
 Task details
-function       invocation ID    status     start_time                        end_time                          message
--------------  ---------------  ---------  --------------------------------  --------------------------------  ---------
-generate_data  inv-1-gen-dat    SUCCEEDED  2023-02-24T07:26:07.704015-05:00  2023-02-24T07:28:37.000123-05:00
-train_model    inv-2-tra-mod    RUNNING    2023-02-24T07:28:37.000123-05:00
+function       invocation ID    status     start_time                end_time                  message
+-------------  ---------------  ---------  ------------------------  ------------------------  ---------
+generate_data  inv-1-gen-dat    SUCCEEDED  Fri Feb 24 13:26:07 2023  Fri Feb 24 13:28:37 2023
+train_model    inv-2-tra-mod    RUNNING    Fri Feb 24 13:28:37 2023

--- a/tests/cli/dorq/ui/data/wf_runs/waiting.txt
+++ b/tests/cli/dorq/ui/data/wf_runs/waiting.txt
@@ -3,7 +3,7 @@ Workflow overview
 workflow def name  hello_orq
 run ID             wf.1
 status             WAITING
-start time         Fri Feb 24 13:26:07 2023
+start time         Fri Feb 24 08:26:07 2023
 end time
 tasks succeeded    0 / 21
 -----------------  ------------------------

--- a/tests/cli/dorq/ui/data/wf_runs/waiting.txt
+++ b/tests/cli/dorq/ui/data/wf_runs/waiting.txt
@@ -1,12 +1,12 @@
 Workflow overview
------------------  --------------------------------
+-----------------  ------------------------
 workflow def name  hello_orq
 run ID             wf.1
 status             WAITING
-start time         2023-02-24T12:26:07.704015+00:00
+start time         Fri Feb 24 13:26:07 2023
 end time
 tasks succeeded    0 / 21
------------------  --------------------------------
+-----------------  ------------------------
 
 Task details
 function    invocation ID    status    start_time    end_time    message

--- a/tests/cli/dorq/ui/test_presenters.py
+++ b/tests/cli/dorq/ui/test_presenters.py
@@ -421,10 +421,16 @@ class TestWorkflowRunPresenter:
             ),
         ],
     )
-    def test_show_wf_run(capsys, summary: ui_models.WFRunSummary, expected_path: Path):
+    def test_show_wf_run(
+        monkeypatch, capsys, summary: ui_models.WFRunSummary, expected_path: Path
+    ):
         # Given
         presenter = _presenters.WFRunPresenter()
-
+        monkeypatch.setattr(
+            _presenters,
+            "_format_datetime",
+            lambda x: "Fri Feb 24 08:26:07 2023" if x else "",
+        )
         # When
         presenter.show_wf_run(summary)
 

--- a/tests/cli/dorq/ui/test_presenters.py
+++ b/tests/cli/dorq/ui/test_presenters.py
@@ -350,7 +350,7 @@ ET_INSTANT_1 = datetime(
     26,
     7,
     704015,
-    tzinfo=timezone(timedelta(hours=-5)),
+    tzinfo=timezone.utc,
 )
 ET_INSTANT_2 = datetime(
     2023,
@@ -360,7 +360,7 @@ ET_INSTANT_2 = datetime(
     28,
     37,
     123,
-    tzinfo=timezone(timedelta(hours=-5)),
+    tzinfo=timezone.utc,
 )
 
 

--- a/tests/cli/dorq/workflow/test_list.py
+++ b/tests/cli/dorq/workflow/test_list.py
@@ -4,14 +4,14 @@
 """
 Unit tests for 'orq wf list' glue code.
 """
-
+import datetime
 import typing as t
 from unittest.mock import Mock
 
 import pytest
 
 from orquestra.sdk._base.cli._dorq._workflow import _list
-
+from orquestra.sdk.schema.workflow_run import RunStatus, State
 
 class TestAction:
     """
@@ -28,6 +28,18 @@ class TestAction:
         Verifies how we pass variables between subcomponents.
         """
         # Given
+
+        def return_wf():
+            run = Mock()
+            run.id = "fake id"
+            run.status = RunStatus(
+                state=State.RUNNING,
+                start_time=datetime.datetime.fromtimestamp(0),
+                end_time=datetime.datetime.fromtimestamp(0),
+            )
+            run.task_runs = []
+            return run
+
         # CLI inputs
         config = ["<config sentinel>"]
         limit: t.Any = "<limit sentinel>"
@@ -44,11 +56,16 @@ class TestAction:
         presenter = Mock()
 
         wf_run_repo = Mock()
-        wf_runs = ["<wf run sentinel 1>", "<wf run sentinel 2>"]
+
+        wf_runs = [return_wf(), return_wf()]
         wf_run_repo.list_wf_runs.return_value = wf_runs
 
         config_resolver = Mock()
         config_resolver.resolve_multiple.return_value = resolved_configs
+
+        summary_repo = Mock()
+        showed_mocks = [Mock(), Mock()]
+        summary_repo.wf_list_summary.return_value = showed_mocks
 
         wf_run_filter_resolver = Mock()
         wf_run_filter_resolver.resolve_limit.return_value = resolved_limit
@@ -57,6 +74,7 @@ class TestAction:
 
         action = _list.Action(
             presenter=presenter,
+            summary_repo=summary_repo,
             wf_run_repo=wf_run_repo,
             config_resolver=config_resolver,
             wf_run_filter_resolver=wf_run_filter_resolver,
@@ -97,7 +115,8 @@ class TestAction:
 
         # We expect printing of the workflow runs returned from the repo.
         expected_wf_runs_list = wf_runs + wf_runs
-        presenter.show_wf_runs_list.assert_called_with(expected_wf_runs_list)
+        summary_repo.wf_list_summary.assert_called_with(expected_wf_runs_list)
+        presenter.show_wf_list.assert_called_with(showed_mocks)
 
         # This specifies all of the filters, so we shouldn't get anything flagging up
         # to the user

--- a/tests/cli/dorq/workflow/test_list.py
+++ b/tests/cli/dorq/workflow/test_list.py
@@ -13,6 +13,7 @@ import pytest
 from orquestra.sdk._base.cli._dorq._workflow import _list
 from orquestra.sdk.schema.workflow_run import RunStatus, State
 
+
 class TestAction:
     """
     Test boundaries::


### PR DESCRIPTION
# The problem

With many WFs submited by the user, its hard to distinguish WFs from each other. 

# This PR's solution

This PR helps to sort WFs by their start time, as well as show the start time. In includes both <wf list> command, as well as any other command DORQ command that prompts user to choose WF for further action.

Prompter:
![image](https://user-images.githubusercontent.com/108305907/226643652-f06865ed-06e6-4f04-88bf-6961e907cdc4.png)


WF list command:
![image](https://user-images.githubusercontent.com/108305907/226643949-d009230f-301a-460e-bba2-6135614e7ea9.png)

Reverse order of those 2 is intentional - for prompter the cursor starts at the top of the list (thus, newest workflows)
for list WF the command line auto-scrolls to the bottom, so newest are at the bottom


# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
