### PR TITLE
feat: raise an exception if workflows have zero tasks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 🚨 *Breaking Changes*
 
+- Workflow definitions now require at least one task in order to be submitted. This check is performed during traversal, and raises a WorkflowSyntaxError if no tasks are required to be executed.
 
 🔥 *Features*
 

--- a/docs/examples/tests/test_workflow_syntax.py
+++ b/docs/examples/tests/test_workflow_syntax.py
@@ -149,6 +149,10 @@ class Snippets:
             """
             return text[::-1]
 
+        @sdk.task
+        def further_workflow_tasks() -> int:
+            return 0
+
         @sdk.workflow
         def wf():
             greeting = "hello"
@@ -156,7 +160,7 @@ class Snippets:
             # The result workflow will contain an embedded `"olleh"` serialized value.
             ...
             # </snippet>
-            return reversed_greeting
+            return reversed_greeting, further_workflow_tasks()
 
         return wf
 
@@ -438,7 +442,7 @@ class TestSnippets:
         model = wf.model
 
         # Then
-        assert len(model.task_invocations) == 0
+        assert len(model.task_invocations) == 1
 
     @staticmethod
     def test_task_in_task_fails(change_test_dir):

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -118,13 +118,18 @@ class WorkflowDef(Generic[_R]):
         model = _traversal.flatten_graph(self, _futures)
 
         if len(model.task_invocations) < 1:
-            raise WorkflowSyntaxError(
-                f"The workflow '{model.name}' "
-                f"(defined at {model.fn_ref.file_path} line {model.fn_ref.line_number})"
-                " cannot be submitted as it does not define any tasks to be executed. "
+            helpstr = f"The workflow '{model.name}' "
+            if hasattr(model.fn_ref, "file_path"):  # If possible add the file and line.
+                helpstr += f"(defined at {model.fn_ref.file_path}"
+                if hasattr(model.fn_ref, "line_number"):
+                    helpstr += f" line {model.fn_ref.line_number}"
+                helpstr += ") "
+            helpstr += (
+                "cannot be submitted as it does not define any tasks to be executed. "
                 "Please modify the workflow definition to define at least one task "
                 "and retry submitting the workflow."
             )
+            raise WorkflowSyntaxError(helpstr)
         return model
 
     @property

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -101,6 +101,8 @@ class WorkflowDef(Generic[_R]):
             orquestra.sdk.exceptions.DirtyGitRepo: (warning) when a task def used by
                 this workflow def has a "GitImport" and the git repo that contains it
                 has uncommitted changes.
+            orquestra.sdk.exceptions.WorkflowSyntaxError: when there are no tasks
+                defined for this workflow.
         """
         from orquestra.sdk._base import _traversal
 
@@ -113,7 +115,14 @@ class WorkflowDef(Generic[_R]):
         else:
             _futures = futures
 
-        return _traversal.flatten_graph(self, _futures)
+        model = _traversal.flatten_graph(self, _futures)
+
+        if len(model.task_invocations) < 1:
+            raise WorkflowSyntaxError(
+                f"The workflow '{model.name}' requires 0 tasks to be executed. "
+                "Workflows must execute at least one task."
+            )
+        return model
 
     @property
     def graph(self):

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -119,8 +119,11 @@ class WorkflowDef(Generic[_R]):
 
         if len(model.task_invocations) < 1:
             raise WorkflowSyntaxError(
-                f"The workflow '{model.name}' requires 0 tasks to be executed. "
-                "Workflows must execute at least one task."
+                f"The workflow '{model.name}' "
+                f"(defined at {model.fn_ref.file_path} line {model.fn_ref.line_number})"
+                " cannot be submitted as it does not define any tasks to be executed. "
+                "Please modify the workflow definition to define at least one task "
+                "and retry submitting the workflow."
             )
         return model
 

--- a/tests/runtime/api/test_api_with_qe.py
+++ b/tests/runtime/api/test_api_with_qe.py
@@ -12,7 +12,6 @@ import responses
 import orquestra.sdk as sdk
 import orquestra.sdk._base._db as _db
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import _api
 from orquestra.sdk._base._testing._example_wfs import my_workflow
 from orquestra.sdk.schema.configs import RuntimeName
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
@@ -147,9 +146,13 @@ class TestStartWorkflowRun:
     def test_raises_exception_if_worflow_name_does_not_match_qe_reqs(remote_config):
         workflow_name = "NameThatDoesNotMatchQEReqs"
 
+        @sdk.task
+        def simple_task():
+            return 0
+
         @sdk.workflow(custom_name=workflow_name)
         def BadNameWorkflow():
-            return [None]
+            return [simple_task()]
 
         run = BadNameWorkflow().prepare(remote_config)
 

--- a/tests/runtime/db/test_migration.py
+++ b/tests/runtime/db/test_migration.py
@@ -23,9 +23,13 @@ class TestProjectToSharedDBMigration:
         mock_workflow_db_location: Path,
     ):
         # Given
+        @sdk.task
+        def simple_task():
+            return 0
+
         @sdk.workflow
         def test():
-            return 0
+            return simple_task()
 
         workflow_def = test.model
 
@@ -108,9 +112,13 @@ class TestProjectToSharedDBMigration:
         mock_workflow_db_location: Path,
     ):
         # Given
+        @sdk.task
+        def simple_task():
+            return 0
+
         @sdk.workflow
         def test():
-            return 0
+            return simple_task()
 
         workflow_def = test.model
 

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -514,13 +514,17 @@ class TestCreateWorkflowRun:
             "ends-with-non.alphanumeric-",
         ],
     )
-    def test_raises_exception_if_worflow_name_does_not_match_qe_reqs(
+    def test_raises_exception_if_workflow_name_does_not_match_qe_reqs(
         workflow_name,
         runtime,
     ):
+        @sdk.task
+        def simple_task():
+            return None
+
         @sdk.workflow(custom_name=workflow_name)
         def BadNameWorkflow():
-            return [None]
+            return [simple_task()]
 
         workflow = BadNameWorkflow.model
 

--- a/tests/sdk/v2/test_artifact_future_methods.py
+++ b/tests/sdk/v2/test_artifact_future_methods.py
@@ -110,7 +110,7 @@ def wf_deconstruc_task_invocation_with_metadata_assignment():
 
 @sdk.workflow
 def wf_task_call():
-    [_task_without_resources(), _resourced_task()]
+    return [_task_without_resources(), _resourced_task()]
 
 
 @sdk.workflow

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -231,6 +231,13 @@ def daisy_chain():
     return [plus_2]
 
 
+@_workflow.workflow
+def no_tasks():
+    first = "emiliano"
+    last = "zapata"
+    return [first, last]
+
+
 # Exposing a function from PyPI-available library
 numpy_eye = _dsl.external_module_task(
     module="numpy",
@@ -303,24 +310,25 @@ def multiple_task_outputs():
 
 @_workflow.workflow
 def constant_return():
-    return [42]
+    a = simple_task(1)
+    return [42, a]
 
 
 @_workflow.workflow
 def constant_collisions():
-    return [1.0, 1, True]
+    return [1.0, 1, True, simple_task(1)]
 
 
 @_workflow.workflow(
     data_aggregation=_dsl.DataAggregation(run=False, resources=_dsl.Resources(cpu="1"))
 )
 def workflow_with_data_aggregation():
-    return [1]
+    return [simple_task(1)]
 
 
 @_workflow.workflow(data_aggregation=_dsl.DataAggregation(run=True))
 def workflow_with_data_aggregation_no_resources():
-    return [1]
+    return [simple_task(1)]
 
 
 @_workflow.workflow(
@@ -329,7 +337,7 @@ def workflow_with_data_aggregation_no_resources():
     )
 )
 def workflow_with_data_aggregation_set_gpu():
-    return [1]
+    return [simple_task(1)]
 
 
 @_dsl.task()
@@ -431,10 +439,10 @@ class TestFlattenGraph:
 
     def test_constant_return_workflow(self):
         wf = constant_return.model
-        assert len(wf.task_invocations) == 0
-        assert len(wf.tasks) == 0
-        assert len(wf.constant_nodes) == 1
-        assert len(wf.output_ids) == 1
+        assert len(wf.task_invocations) == 1
+        assert len(wf.tasks) == 1
+        assert len(wf.constant_nodes) == 2
+        assert len(wf.output_ids) == 2
         assert wf.output_ids[0] in wf.constant_nodes
 
     def test_equal_constants_different_types(self):
@@ -504,6 +512,15 @@ class TestFlattenGraph:
         assert len(tasks) == 1
         assert tasks[0].dependency_import_ids is not None
         assert tasks[0].source_import_id not in tasks[0].dependency_import_ids
+
+    def test_raises_exception_for_zero_tasks(self):
+        # preconditions
+        with pytest.raises(exceptions.WorkflowSyntaxError) as e:
+            pass
+        assert (
+            str(e)
+            == "The workflow 'no_tasks' requires 0 tasks to be executed. Workflows must execute at least one task."  # noqa: E501
+        )
 
 
 class ContextManager(t.Protocol):

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -516,7 +516,7 @@ class TestFlattenGraph:
     def test_raises_exception_for_zero_tasks(self):
         # preconditions
         with pytest.raises(exceptions.WorkflowSyntaxError) as e:
-            pass
+            no_tasks.model
         assert (
             "The workflow 'no_tasks' requires 0 tasks to be executed. Workflows must execute at least one task."  # noqa: E501
             in str(e)

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -517,9 +517,8 @@ class TestFlattenGraph:
         # preconditions
         with pytest.raises(exceptions.WorkflowSyntaxError) as e:
             no_tasks.model
-        assert (
-            "The workflow 'no_tasks' requires 0 tasks to be executed. Workflows must execute at least one task."  # noqa: E501
-            in str(e)
+        assert e.match(
+            r"The workflow 'no_tasks' \(defined at .+\.py line \d+\) cannot be submitted as it does not define any tasks to be executed. Please modify the workflow definition to define at least one task and retry submitting the workflow."  # noqa: E501
         )
 
 

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -518,8 +518,8 @@ class TestFlattenGraph:
         with pytest.raises(exceptions.WorkflowSyntaxError) as e:
             pass
         assert (
-            str(e)
-            == "The workflow 'no_tasks' requires 0 tasks to be executed. Workflows must execute at least one task."  # noqa: E501
+            "The workflow 'no_tasks' requires 0 tasks to be executed. Workflows must execute at least one task."  # noqa: E501
+            in str(e)
         )
 
 


### PR DESCRIPTION
[ORQSDK-774]

# The problem

On QE you get an HTTP error stating that you need at least 1 task to be executed if your WF doesn't use any tasks. This is not the case on local Ray or CE. We should ensure that this is consistent across all runtimes.

# This PR's solution

- Adds a check during traversal that raises a WorkflowSyntaxError when no task invocations are identified. 
  - The exception reads: "The workflow '[wf name]' cannot be submitted as it does not define any tasks to be executed. Please modify the workflow definition to define at least one task and retry submitting the workflow."
  - If the source file and line can be identified, these are also included in the message.

# Checklist

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`


[ORQSDK-774]: https://zapatacomputing.atlassian.net/browse/ORQSDK-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ