### PR TITLE
tests: Fix test isolation in docs examples

### DIFF
--- a/docs/examples/tests/conftest.py
+++ b/docs/examples/tests/conftest.py
@@ -24,6 +24,6 @@ def shared_ray_conn():
 
 @pytest.fixture(scope="module")
 def change_db_location(change_test_dir):
-    os.environ["ORQ_DB_LOCATION"] = os.path.join(change_test_dir, "db.db")
+    os.environ["ORQ_DB_PATH"] = os.path.join(change_test_dir, "db.db")
     yield
-    del os.environ["ORQ_DB_LOCATION"]
+    del os.environ["ORQ_DB_PATH"]


### PR DESCRIPTION
# The problem

Previously I made a PR that changed the name of environment variables, however I missed one in the docs tests.

This meant these tests would modify your local state instead of being isolated.

# This PR's solution

Updates the `conftest.py` for docs to match the new environment variable.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
