### PR TITLE
fix: Remove in_process runtime from CLI options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 🐛 *Bug Fixes*
 * Stopping a QE workflow after it has already stopped will no longer raise an exception.
+* Attempting to use the "in-process" runtime on the CLI will no longer raise an exception. Instead, a message teeling you to use the Python API or Ray will be printed.
 
 
 💅 *Improvements*

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -62,6 +62,7 @@ SPECIAL_CONFIG_NAME_DICT = {
 # as SPECIAL_CONFIG_NAME_DICT might have duplicate names which could be confusing for
 # the user
 UNIQUE_CONFIGS = {RAY_CONFIG_NAME_ALIAS, IN_PROCESS_CONFIG_NAME}
+CLI_IGNORED_CONFIGS = {IN_PROCESS_CONFIG_NAME}
 
 
 # region: runtime options

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -10,6 +10,7 @@ import typing as t
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _services
+from orquestra.sdk._base._config import IN_PROCESS_CONFIG_NAME
 from orquestra.sdk.schema.configs import ConfigName
 from orquestra.sdk.schema.ir import TaskInvocationId
 from orquestra.sdk.schema.workflow_run import (
@@ -21,6 +22,11 @@ from orquestra.sdk.schema.workflow_run import (
 
 from . import _repos
 from ._ui import _prompts
+
+
+def _check_for_in_process(config_names: t.Sequence[ConfigName]):
+    if IN_PROCESS_CONFIG_NAME in config_names:
+        raise exceptions.InProcessFromCLIError()
 
 
 class ConfigResolver:
@@ -38,6 +44,7 @@ class ConfigResolver:
 
     def resolve(self, config: t.Optional[ConfigName]) -> ConfigName:
         if config is not None:
+            _check_for_in_process((config,))
             return config
 
         # 1.2. Prompt the user.
@@ -49,6 +56,7 @@ class ConfigResolver:
         self, configs: t.Optional[t.Sequence[str]]
     ) -> t.Sequence[ConfigName]:
         if configs is not None and len(configs) > 0:
+            _check_for_in_process(configs)
             return configs
 
         # Prompt the user.
@@ -86,6 +94,7 @@ class WFConfigResolver:
         self, wf_run_id: t.Optional[WorkflowRunId], config: t.Optional[ConfigName]
     ) -> ConfigName:
         if config is not None:
+            _check_for_in_process((config,))
             return config
 
         if wf_run_id is not None:

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -422,7 +422,11 @@ class ConfigRepo:
     """
 
     def list_config_names(self) -> t.Sequence[ConfigName]:
-        return sdk.RuntimeConfig.list_configs()
+        return [
+            config
+            for config in sdk.RuntimeConfig.list_configs()
+            if config not in _config.CLI_IGNORED_CONFIGS
+        ]
 
     def store_token_in_config(self, uri, token, ce):
         runtime_name = RuntimeName.CE_REMOTE if ce else RuntimeName.QE_REMOTE

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -113,7 +113,7 @@ def _(_: exceptions.UserCancelledPrompt) -> ResponseStatusCode:
 def _(_: exceptions.InProcessFromCLIError) -> ResponseStatusCode:
     click.echo(
         (
-            'The "{0}" runtime is designed for debugging and testing'
+            'The "{0}" runtime is designed for debugging and testing '
             "via the Python API only. The results and workflow states are not "
             "persisted.\n\nYou may want to:\n"
             ' - Use the Python API to debug workflows with the "{0}" runtime.\n'

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -8,6 +8,7 @@ from functools import singledispatch
 import click
 
 from orquestra.sdk import exceptions
+from orquestra.sdk._base._config import IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_ALIAS
 from orquestra.sdk.schema.responses import ResponseStatusCode
 
 
@@ -105,4 +106,19 @@ def _(e: exceptions.LoginURLUnavailableError) -> ResponseStatusCode:
 
 @pretty_print_exception.register
 def _(_: exceptions.UserCancelledPrompt) -> ResponseStatusCode:
+    return ResponseStatusCode.USER_CANCELLED
+
+
+@pretty_print_exception.register
+def _(_: exceptions.InProcessFromCLIError) -> ResponseStatusCode:
+    click.echo(
+        (
+            'The "{0}" runtime is designed for debugging and testing'
+            "via the Python API only. The results and workflow states are not "
+            "persisted.\n\nYou may want to:\n"
+            ' - Use the Python API to debug workflows with the "{0}" runtime.\n'
+            ' - Try the "{1}" runtime if you want to run a workflow locally via'
+            " the CLI."
+        ).format(IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_ALIAS)
+    )
     return ResponseStatusCode.USER_CANCELLED

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -119,6 +119,6 @@ def _(_: exceptions.InProcessFromCLIError) -> ResponseStatusCode:
             ' - Use the Python API to debug workflows with the "{0}" runtime.\n'
             ' - Try the "{1}" runtime if you want to run a workflow locally via'
             " the CLI."
-        ).format(IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_ALIAS)
+        ).format(IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_ALIAS),
     )
     return ResponseStatusCode.USER_CANCELLED

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -178,3 +178,7 @@ class UserCancelledPrompt(BaseRuntimeError):
 class LoginURLUnavailableError(BaseRuntimeError):
     def __init__(self, base_uri: str):
         self.base_uri = base_uri
+
+
+class InProcessFromCLIError(NotFoundError):
+    """Raised when the user requests the in-process runtime when using the CLI"""

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -65,6 +65,16 @@ class TestConfigResolver:
         # Resolver should return the user's choice.
         assert resolved_config == selected_config
 
+    @staticmethod
+    def test_with_in_process():
+        # Given
+        config = "in_process"
+        resolver = _arg_resolvers.ConfigResolver(config_repo=Mock(), prompter=Mock())
+
+        # When/Then
+        with pytest.raises(exceptions.InProcessFromCLIError):
+            resolver.resolve(config)
+
     class TestResolveMultiple:
         @staticmethod
         def test_passing_single_config_directly():

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1062,7 +1062,6 @@ class TestConfigRepo:
             assert set(names) == {
                 # built-ins
                 "ray",
-                "in_process",
                 # config entries
                 "test_config_default",
                 "test_config_no_runtime_options",

--- a/tests/cli/dorq/ui/test_errors.py
+++ b/tests/cli/dorq/ui/test_errors.py
@@ -78,3 +78,29 @@ class TestPrettyPrintException:
         # Verifies that user sees the stack trace. This is useful for bug reports and
         # debugging.
         assert "Traceback (most recent call last):\n  File" in captured.err
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "exc,stdout_marker",
+        [
+            (
+                exceptions.InProcessFromCLIError,
+                'The "in_process" runtime is designed for debugging and testingvia the Python API only',
+            ),
+        ],
+    )
+    def tests_prints_exception_without_traceback(capsys, exc, stdout_marker: str):
+        # Given
+        try:
+            # Simulate raising the exception object. This is supposed to realistically
+            # set the stack trace.
+            raise exc
+        except Exception as e:
+            # When
+            _errors.pretty_print_exception(e)
+
+        # Then
+        captured = capsys.readouterr()
+
+        # Verifies that we describe the failure reason to the user.
+        assert stdout_marker in captured.out

--- a/tests/cli/dorq/ui/test_errors.py
+++ b/tests/cli/dorq/ui/test_errors.py
@@ -85,7 +85,7 @@ class TestPrettyPrintException:
         [
             (
                 exceptions.InProcessFromCLIError,
-                'The "in_process" runtime is designed for debugging and testingvia the'
+                'The "in_process" runtime is designed for debugging and testing via the'
                 " Python API only",
             ),
         ],

--- a/tests/cli/dorq/ui/test_errors.py
+++ b/tests/cli/dorq/ui/test_errors.py
@@ -85,7 +85,8 @@ class TestPrettyPrintException:
         [
             (
                 exceptions.InProcessFromCLIError,
-                'The "in_process" runtime is designed for debugging and testingvia the Python API only',
+                'The "in_process" runtime is designed for debugging and testingvia the'
+                " Python API only",
             ),
         ],
     )


### PR DESCRIPTION
# The problem

We have a "in process" runtime which is suitable for debugging workflows inside a Jupyter notebook or Python script.
If you tried using this with the CLI, you would see a "NotFoundError".

# This PR's solution

- Removes "in_process" from being able to be selected by the config prompt.
- Adds an error message when the "in_process" config option is passed directly to the CLI via the `-c` option.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
