### PR TITLE
Fix: Move constant deserialization inside ray remote function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 🐛 *Bug Fixes*
 * Stopping a QE workflow after it has already stopped will no longer raise an exception.
 * Attempting to use the "in-process" runtime on the CLI will no longer raise an exception. Instead, a message teeling you to use the Python API or Ray will be printed.
+* Fix dependency issues causing CE workflows to fail if WF constant was library-dependent object.
 
 
 💅 *Improvements*

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -49,14 +49,6 @@ def multioutput_task():
     return "Zapata", "Computing"
 
 
-@sdk.task(dependency_imports=[sdk.PythonImports("piccup")])
-def task_with_import():
-    import piccup  # type: ignore # noqa
-
-    # return whatever - make sure it just doesnt assert on import
-    return 2
-
-
 @sdk.task(dependency_imports=[sdk.GithubImport("alexjuda/piccup", git_ref="master")])
 def task_with_git_import():
     import piccup  # type: ignore # noqa
@@ -160,11 +152,6 @@ def wf_using_inline_imports():
     full_name = concat("Emiliano", last_cap)
 
     return [full_name, company_cap]
-
-
-@sdk.workflow
-def wf_using_python_imports():
-    return [task_with_import()]
 
 
 @sdk.workflow

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -57,7 +57,7 @@ def task_with_import():
     return 2
 
 
-@sdk.task(dependency_imports=[sdk.GithubImport("alexjuda/piccup")])
+@sdk.task(dependency_imports=[sdk.GithubImport("alexjuda/piccup", git_ref="master")])
 def task_with_git_import():
     import piccup  # type: ignore # noqa
 
@@ -169,7 +169,7 @@ def wf_using_python_imports():
 
 @sdk.workflow
 def wf_using_git_imports():
-    return [task_with_import()]
+    return [task_with_git_import()]
 
 
 @sdk.task

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -198,7 +198,7 @@ def _make_ray_dag_node(
     def _ray_remote(*inner_args, **inner_kwargs):
         if project_dir is not None:
             dispatch.ensure_sys_paths([str(project_dir)])
-        inner_args = (
+        inner_args = tuple(
             serde.deserialize_constant(arg)
             if isinstance(arg, t.get_args(ir.ConstantNode))
             else arg

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -198,12 +198,12 @@ def _make_ray_dag_node(
     def _ray_remote(*inner_args, **inner_kwargs):
         if project_dir is not None:
             dispatch.ensure_sys_paths([str(project_dir)])
-        inner_args = tuple(
+        inner_args = *(
             serde.deserialize_constant(arg)
             if isinstance(arg, t.get_args(ir.ConstantNode))
             else arg
             for arg in inner_args
-        )
+        ),
         inner_kwargs = {
             key: serde.deserialize_constant(value)
             if isinstance(value, t.get_args(ir.ConstantNode))

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -380,11 +380,8 @@ def _gather_kwargs(
 def _make_ray_dag(
     client: RayClient, wf: ir.WorkflowDef, wf_run_id: str, project_dir: t.Optional[Path]
 ):
-    ray_consts: t.Dict[ir.ConstantNodeId, t.Any] = {
-        # id: serde.deserialize_constant(node) for id, node in wf.constant_nodes.items()
-        id: node
-        for id, node in wf.constant_nodes.items()
-    }
+    ray_consts: t.Dict[ir.ConstantNodeId, t.Any] = wf.constant_nodes
+
     for id, secret in wf.secret_nodes.items():
         ray_consts[id] = secrets.get(
             secret.secret_name, config_name=secret.secret_config

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -399,14 +399,14 @@ def _make_ray_dag(
 
     for ir_invocation in _graphs.iter_invocations_topologically(wf):
         # Prep args, kwargs, and the specs required to unpack tuples
-        ray_args, pos_unpack_specs, pos_deserialize_specs = _gather_args(
+        ray_args, pos_unpack_specs, pos_arg_indices_to_deserialize = _gather_args(
             arg_ids=ir_invocation.args_ids,
             ray_consts=ray_consts,
             ray_futures=ray_futures,
             artifact_nodes=wf.artifact_nodes,
         )
 
-        ray_kwargs, kw_unpack_specs, kw_deserialize_specs = _gather_kwargs(
+        ray_kwargs, kw_unpack_specs, kw_arg_keys_to_deserialize = _gather_kwargs(
             kwarg_ids=ir_invocation.kwargs_ids,
             ray_consts=ray_consts,
             ray_futures=ray_futures,
@@ -459,8 +459,8 @@ def _make_ray_dag(
             ray_kwargs=ray_kwargs,
             pos_unpack_specs=pos_unpack_specs,
             kw_unpack_specs=kw_unpack_specs,
-            pos_deserialize_specs=pos_deserialize_specs,
-            kw_deserialize_specs=kw_deserialize_specs,
+            pos_arg_indices_to_deserialize=pos_arg_indices_to_deserialize,
+            kw_arg_keys_to_deserialize=kw_arg_keys_to_deserialize,
             project_dir=project_dir,
         )
 
@@ -468,7 +468,7 @@ def _make_ray_dag(
             ray_futures[output_id] = ray_future
 
     # Gather futures for the last, fake task, and decide what args we need to unwrap.
-    aggr_task_args, aggr_task_specs, aggr_deserialize_specs = _gather_args(
+    aggr_task_args, aggr_task_specs, pos_arg_indices_to_deserialize = _gather_args(
         arg_ids=wf.output_ids,
         ray_consts=ray_consts,
         ray_futures=ray_futures,
@@ -489,8 +489,8 @@ def _make_ray_dag(
         ray_kwargs={},
         pos_unpack_specs=aggr_task_specs,
         kw_unpack_specs=[],
-        pos_deserialize_specs=aggr_deserialize_specs,
-        kw_deserialize_specs=[],
+        pos_arg_indices_to_deserialize=pos_arg_indices_to_deserialize,
+        kw_arg_keys_to_deserialize=[],
         project_dir=None,
     )
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -198,12 +198,14 @@ def _make_ray_dag_node(
     def _ray_remote(*inner_args, **inner_kwargs):
         if project_dir is not None:
             dispatch.ensure_sys_paths([str(project_dir)])
-        inner_args = *(
-            serde.deserialize_constant(arg)
-            if isinstance(arg, t.get_args(ir.ConstantNode))
-            else arg
-            for arg in inner_args
-        ),
+        inner_args = (
+            *(
+                serde.deserialize_constant(arg)
+                if isinstance(arg, t.get_args(ir.ConstantNode))
+                else arg
+                for arg in inner_args
+            ),
+        )
         inner_kwargs = {
             key: serde.deserialize_constant(value)
             if isinstance(value, t.get_args(ir.ConstantNode))

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1409,7 +1409,6 @@ class TestWorkflowDefRepoIntegration:
                 "my_workflow",
                 "exception_wf",
                 "wf_using_inline_imports",
-                "wf_using_python_imports",
                 "wf_using_git_imports",
                 "serial_wf_with_slow_middle_task",
                 "serial_wf_with_file_triggers",

--- a/tests/runtime/ray/data/python_package/original_workflow.py
+++ b/tests/runtime/ray/data/python_package/original_workflow.py
@@ -1,0 +1,21 @@
+import polars as pl
+
+import orquestra.sdk as sdk
+
+
+@sdk.task(
+    source_import=sdk.InlineImport(),
+    dependency_imports=[sdk.PythonImports("polars")],
+)
+def my_fn(df):
+    return df.item()
+
+
+@sdk.workflow
+def wf():
+    thing = pl.DataFrame({"a": 21})
+    return my_fn(thing)
+
+
+if __name__ == "__main__":
+    print(wf.model.json())

--- a/tests/runtime/ray/data/python_package/original_workflow.py
+++ b/tests/runtime/ray/data/python_package/original_workflow.py
@@ -1,4 +1,4 @@
-import polars as pl # type: ignore
+import polars as pl  # type: ignore
 
 import orquestra.sdk as sdk
 

--- a/tests/runtime/ray/data/python_package/original_workflow.py
+++ b/tests/runtime/ray/data/python_package/original_workflow.py
@@ -1,4 +1,4 @@
-import polars as pl
+import polars as pl # type: ignore
 
 import orquestra.sdk as sdk
 

--- a/tests/runtime/ray/data/python_package/python_package_dependent_workflow.json
+++ b/tests/runtime/ray/data/python_package/python_package_dependent_workflow.json
@@ -1,0 +1,107 @@
+{
+  "name": "wf",
+  "fn_ref": {
+    "module": "__main__",
+    "function_name": "wf",
+    "file_path": "a.py",
+    "line_number": 11,
+    "type": "MODULE_FUNCTION_REF"
+  },
+  "imports": {
+    "inline-import-1": {
+      "id": "inline-import-1",
+      "type": "INLINE_IMPORT"
+    },
+    "python-import-e0459ec73a": {
+      "id": "python-import-e0459ec73a",
+      "packages": [
+        {
+          "name": "polars",
+          "extras": [],
+          "version_constraints": [],
+          "environment_markers": ""
+        }
+      ],
+      "pip_options": [],
+      "type": "PYTHON_IMPORT"
+    }
+  },
+  "tasks": {
+    "task-my-fn-d3914c5e63": {
+      "id": "task-my-fn-d3914c5e63",
+      "fn_ref": {
+        "function_name": "my_fn",
+        "encoded_function": [
+          "gASVtAMAAAAAAACMF2Nsb3VkcGlja2xlLmNsb3VkcGlja2xllIwOX21ha2VfZnVuY3Rpb26Uk5Qo\naACMDV9idWlsdGluX3R5cGWUk5SMCENvZGVUeXBllIWUUpQoSwFLAEsASwFLAktDQwh8AKAAoQBT\nAJROhZSMBGl0ZW2UhZSMAmRmlIWUjARhLnB5lIwFbXlfZm6USwRDAgAFlCkpdJRSlH2UKIwLX19w\nYWNrYWdlX1+UTowIX19uYW1lX1+UjAhfX21haW5fX5SMCF9fZmlsZV9flGgOdU5OTnSUUpSMHGNs\nb3VkcGlja2xlLmNsb3VkcGlja2xlX2Zhc3SUjBJfZnVuY3Rpb25fc2V0c3RhdGWUk5RoGX2UKIwX\nX1Rhc2tEZWZfX3Nka190YXNrX2JvZHmUaBmMBmZuX3JlZpSMGG9ycXVlc3RyYS5zZGsuX2Jhc2Uu\nX2RzbJSMEUlubGluZUZ1bmN0aW9uUmVmlJOUaA9oGYaUgZSMDXNvdXJjZV9pbXBvcnSUaCCMDElu\nbGluZUltcG9ydJSTlCmBlIwPb3V0cHV0X21ldGFkYXRhlGggjBJUYXNrT3V0cHV0TWV0YWRhdGGU\nk5SJSwGGlIGUjApwYXJhbWV0ZXJzlIwLY29sbGVjdGlvbnOUjAtPcmRlcmVkRGljdJSTlClSlGgM\naCCMDVRhc2tQYXJhbWV0ZXKUk5RoDGggjA1QYXJhbWV0ZXJLaW5klJOUjBVQT1NJVElPTkFMX09S\nX0tFWVdPUkSUhZRSlIaUgZRzjBJkZXBlbmRlbmN5X2ltcG9ydHOUaCCMDVB5dGhvbkltcG9ydHOU\nk5QpgZR9lCiMDXVzZV9maWxlX3BhdGiUiYwIcGFja2FnZXOUjAZwb2xhcnOUhZR1YoWUjAlyZXNv\ndXJjZXOUaCCMCVJlc291cmNlc5STlChOTk5OdJSBlIwMY3VzdG9tX2ltYWdllIwoemFwYXRhY29t\ncHV0aW5nL29ycXVlc3RyYS1kZWZhdWx0OnYwLjAuMJSMC2N1c3RvbV9uYW1llE51fZQoaBVoD4wM\nX19xdWFsbmFtZV9flGgPjA9fX2Fubm90YXRpb25zX1+UfZSMDl9fa3dkZWZhdWx0c19flE6MDF9f\nZGVmYXVsdHNfX5ROjApfX21vZHVsZV9flGgWjAdfX2RvY19flE6MC19fY2xvc3VyZV9flE6MF19j\nbG91ZHBpY2tsZV9zdWJtb2R1bGVzlF2UjAtfX2dsb2JhbHNfX5R9lHWGlIZSMC4=\n"
+        ],
+        "type": "INLINE_FUNCTION_REF"
+      },
+      "parameters": [
+        {
+          "name": "df",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        }
+      ],
+      "source_import_id": "inline-import-1",
+      "dependency_import_ids": [
+        "python-import-e0459ec73a"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    }
+  },
+  "artifact_nodes": {
+    "artifact-0-my-fn": {
+      "id": "artifact-0-my-fn",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": null
+    }
+  },
+  "constant_nodes": {
+    "constant-0": {
+      "id": "constant-0",
+      "chunks": [
+        "gASVqAAAAAAAAACMFnBvbGFycy5kYXRhZnJhbWUuZnJhbWWUjAlEYXRhRnJhbWWUk5QpgZRdlIwU\ncG9sYXJzLnNlcmllcy5zZXJpZXOUjAZTZXJpZXOUk5QpgZRDUAMAAAAAAAAABAAAAAAAAABuYW1l\nAQAAAAAAAABhCAAAAAAAAABkYXRhdHlwZQgAAAAGAAAAAAAAAHZhbHVlcwEAAAAAAAAAARUAAAAA\nAAAAlGJhYi4=\n"
+      ],
+      "serialization_format": "ENCODED_PICKLE",
+      "value_preview": "shape: (1, 1"
+    }
+  },
+  "secret_nodes": {},
+  "task_invocations": {
+    "invocation-0-task-my-fn": {
+      "id": "invocation-0-task-my-fn",
+      "task_id": "task-my-fn-d3914c5e63",
+      "args_ids": [
+        "constant-0"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-0-my-fn"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    }
+  },
+  "output_ids": [
+    "artifact-0-my-fn"
+  ],
+  "data_aggregation": null,
+  "metadata": {
+    "sdk_version": {
+      "original": "0.45.2.dev11+gf708e3b",
+      "major": 0,
+      "minor": 45,
+      "patch": 2,
+      "is_prerelease": true
+    },
+    "python_version": {
+      "original": "3.8.12 (default, Jun 28 2022, 14:32:09) \n[Clang 13.1.6 (clang-1316.0.21.2.5)]",
+      "major": 3,
+      "minor": 8,
+      "patch": 12,
+      "is_prerelease": false
+    }
+  }
+}

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -569,11 +569,12 @@ def test_import_package_inside_ray(runtime: _dag.RayRuntime):
 # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
 # unraisable exceptions. Last tested with Ray 2.2.0.
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
-def test_git_import_inside_ray(runtime: _dag.RayRuntime):
+def test_git_import_inside_ray(monkeypatch, runtime: _dag.RayRuntime):
     # This package should not be installed before running test
     with pytest.raises(ModuleNotFoundError):
         import piccup  # type: ignore # noqa
 
+    monkeypatch.setenv(name="ORQ_RAY_SET_TASK_RESOURCES", value="1")
     run_id = runtime.create_workflow_run(_example_wfs.wf_using_git_imports.model)
     wf_result = runtime.get_workflow_run_outputs(run_id)
     assert wf_result == (2,)


### PR DESCRIPTION
# The problem

Constants were deserialised during dag creation. It causes that SDK would require all libraries required for all constants during dag creation time. It wasn't an issue in local ray, but is when using CE

# This PR's solution

Deserialise constants in ray.remote function with all proper task dependencies already installed in ray venv

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
