### PR TITLE
chore: limit github action workflows

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # The job ID has to match repo settings for PR required checks
   TestCoverage:
@@ -24,6 +28,8 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.8", "3.9"]
+
+    timeout-minutes: 15
 
     name: Coverage - Python ${{ matrix.python }} - ${{ matrix.os }}
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.8", "3.9"]
 
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     name: Coverage - Python ${{ matrix.python }} - ${{ matrix.os }}
 

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -14,10 +14,15 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # The job ID has to match repo settings for PR required checks
   TestPerformance:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -22,7 +22,7 @@ jobs:
   # The job ID has to match repo settings for PR required checks
   TestPerformance:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -14,6 +14,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # The job ID has to match repo settings for PR required checks
   style:
@@ -25,6 +29,7 @@ jobs:
         python: ["3.8", "3.9"]
 
     name: Style - Python ${{ matrix.python }}
+    timeout-minutes: 15
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,7 +29,7 @@ jobs:
         python: ["3.8", "3.9"]
 
     name: Style - Python ${{ matrix.python }}
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -14,10 +14,15 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # The job ID has to match repo settings for PR required checks
   TypeChecking:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -22,7 +22,7 @@ jobs:
   # The job ID has to match repo settings for PR required checks
   TypeChecking:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Git Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# The problem

We've had some issues with Windows tests hanging for 6 hours (this might be a `grpcio` issue, but that's something else to look at).

# This PR's solution

Adds:
- 15 minute limit to workflow jobs
- Concurrency limits based on the workflow and the ref.

`github.ref` docs:
> The fully-formed ref of the branch or tag that triggered the workflow run. For workflows triggered by push, this is the branch or tag ref that was pushed. For workflows triggered by pull_request, this is the pull request merge branch. For workflows triggered by release, this is the release tag created. For other triggers, this is the branch or tag ref that triggered the workflow run. This is only set if a branch or tag is available for the event type. The ref given is fully-formed, meaning that for branches the format is refs/heads/<branch_name>, for pull requests it is refs/pull/<pr_number>/merge, and for tags it is refs/tags/<tag_name>. For example, refs/heads/feature-branch-1.

`github.workflow` docs:
> The name of the workflow. If the workflow file doesn't specify a name, the value of this property is the full path of the workflow file in the repository.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
