### PR TITLE
refactor: remove obsolete RuntimeInterface methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ def my_wf():
 * On QE, Github URLs will be converted to SSH URLs.
 * `TaskOutputMetadata` model was added to the workflow def IR schema.
 * Removed `corq` code.
+* Old `RuntimeInterface` methods have been removed.
 
 
 📃 *Docs*

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -136,10 +136,6 @@ class CERuntime(RuntimeInterface):
             )
         return workflow_run_id
 
-    def get_all_workflow_runs_status(self) -> List[WorkflowRun]:
-        """Gets the status of all workflow runs."""
-        raise NotImplementedError()
-
     def get_workflow_run_status(self, workflow_run_id: WorkflowRunId) -> WorkflowRun:
         """
         Gets the status of a workflow run
@@ -166,22 +162,6 @@ class CERuntime(RuntimeInterface):
                 f"`{workflow_run_id}` "
                 "- the authorization token was rejected by the remote cluster."
             ) from e
-
-    def get_workflow_run_outputs(self, workflow_run_id: WorkflowRunId) -> Sequence[Any]:
-        """Returns the output artifacts of a workflow run
-
-        For example, for this workflow:
-
-            @sdk.workflow
-            def my_wf():
-                return [my_task(), another_task()]
-
-        this method will return an iterable that yields the results from my_task and
-        another_task().
-
-        This method blocks until the workflow is completed
-        """
-        raise NotImplementedError()
 
     def get_workflow_run_outputs_non_blocking(
         self, workflow_run_id: WorkflowRunId

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -133,13 +133,10 @@ class InProcessRuntime(abc.RuntimeInterface):
         self._workflow_def_store[run_id] = workflow_def
         return run_id
 
-    def get_workflow_run_outputs(self, workflow_run_id: WfRunId) -> t.Sequence[t.Any]:
-        return self._output_store[workflow_run_id]
-
     def get_workflow_run_outputs_non_blocking(
         self, workflow_run_id: WfRunId
     ) -> t.Sequence[t.Any]:
-        return self.get_workflow_run_outputs(workflow_run_id)
+        return self._output_store[workflow_run_id]
 
     def get_available_outputs(
         self, workflow_run_id: WfRunId
@@ -260,11 +257,6 @@ class InProcessRuntime(abc.RuntimeInterface):
 
     @classmethod
     def from_runtime_configuration(cls, *args, **kwargs):
-        raise NotImplementedError(
-            "This functionality isn't available for 'in_process' runtime"
-        )
-
-    def get_all_workflow_runs_status(self, *args, **kwargs):
         raise NotImplementedError(
             "This functionality isn't available for 'in_process' runtime"
         )

--- a/src/orquestra/sdk/_base/_qe/_client.py
+++ b/src/orquestra/sdk/_base/_qe/_client.py
@@ -189,7 +189,7 @@ class QEClient:
 
     def get_workflow_list(self):
         # For future filtering of workflow runs
-        # "detail": True lets get_all_workflow_runs_status use the same code as
+        # "detail": True lets list_workflow_runs use the same code as
         # get_workflow_run_status for parsing the workflow representation returned
         # from QE
         params: t.Dict[str, t.Any] = {"detail": "true"}

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -86,32 +86,8 @@ class RuntimeInterface(ABC):
         raise NotImplementedError()
 
     @abstractmethod
-    def get_all_workflow_runs_status(self) -> t.List[WorkflowRun]:
-        """Gets the status of all workflow runs."""
-        raise NotImplementedError()
-
-    @abstractmethod
     def get_workflow_run_status(self, workflow_run_id: WorkflowRunId) -> WorkflowRun:
         """Gets the status of a workflow run"""
-        raise NotImplementedError()
-
-    @abstractmethod
-    def get_workflow_run_outputs(
-        self, workflow_run_id: WorkflowRunId
-    ) -> t.Sequence[ArtifactValue]:
-        """Returns the output artifacts of a workflow run
-
-        For example, for this workflow:
-
-            @sdk.workflow
-            def my_wf():
-                return [my_task(), another_task()]
-
-        this method will return an iterable that yields the results from my_task and
-        another_task().
-
-        This method blocks until the workflow is completed
-        """
         raise NotImplementedError()
 
     @abstractmethod

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -835,19 +835,21 @@ class RayRuntime(RuntimeInterface):
     def get_workflow_run_outputs_non_blocking(
         self, workflow_run_id: WorkflowRunId
     ) -> t.Sequence[t.Any]:
-        workflow_status = self.get_workflow_run_status(workflow_run_id)
+        try:
+            workflow_status = self.get_workflow_run_status(workflow_run_id)
+        except exceptions.WorkflowRunNotFoundError:
+            raise
+
         workflow_state = workflow_status.status.state
         if workflow_state != State.SUCCEEDED:
             raise exceptions.WorkflowRunNotSucceeded(
                 f"{workflow_run_id} has not succeeded. {workflow_state}",
                 workflow_state,
             )
-        try:
-            return self._client.get_workflow_output(workflow_run_id)
-        except ValueError as e:
-            raise exceptions.NotFoundError(
-                f"Workflow run {workflow_run_id} wasn't found"
-            ) from e
+
+        # By this line we're assuming the workflow run exists, otherwise we wouldn't get
+        # its status. If the following line raises errors we treat them as unexpected.
+        return self._client.get_workflow_output(workflow_run_id)
 
     def get_available_outputs(
         self, workflow_run_id: WorkflowRunId

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -560,90 +560,6 @@ class TestCreateWorkflowRun:
         assert yaml_wf not in captured_without_yaml.err
 
 
-class TestGetAllWorkflowRunsStatus:
-    def test_empty_db(self, monkeypatch, runtime, mocked_responses):
-        # Testing an empty local DB. We should ignore workflows from QE
-        _get_workflow_runs_list = Mock(return_value=[])
-        monkeypatch.setattr(
-            _db.WorkflowDB, "get_workflow_runs_list", _get_workflow_runs_list
-        )
-        mocked_responses.add(
-            responses.GET,
-            "http://localhost/v1/workflowlist",
-            json=QE_RESPONSES["list"],
-        )
-
-        result = runtime.get_all_workflow_runs_status()
-
-        assert result == []
-
-    def test_with_local_runs(self, monkeypatch, runtime, mocked_responses):
-        # Mock the local DB with a local run
-        _get_workflow_runs_list = Mock(
-            return_value=[
-                StoredWorkflowRun(
-                    workflow_run_id="hello-there-abc123-r000",  # noqa: E501
-                    config_name="hello",
-                    workflow_def=TEST_WORKFLOW,
-                )
-            ]
-        )
-        monkeypatch.setattr(
-            _db.WorkflowDB, "get_workflow_runs_list", _get_workflow_runs_list
-        )
-        mocked_responses.add(
-            responses.GET,
-            "http://localhost/v1/workflowlist",
-            json=QE_RESPONSES["list"],
-        )
-
-        result = runtime.get_all_workflow_runs_status()
-
-        assert result == [
-            WorkflowRun(
-                id="hello-there-abc123-r000",
-                workflow_def=TEST_WORKFLOW,
-                task_runs=[
-                    TaskRun(
-                        id="hello-there-abc123-r000-2738763496",
-                        invocation_id="invocation-1-task-multi-output-test",
-                        status=RunStatus(
-                            state=State.SUCCEEDED,
-                            start_time=datetime.datetime(
-                                1989, 12, 13, 9, 3, 49, tzinfo=datetime.timezone.utc
-                            ),
-                            end_time=datetime.datetime(
-                                1989, 12, 13, 9, 4, 28, tzinfo=datetime.timezone.utc
-                            ),
-                        ),
-                    ),
-                    TaskRun(
-                        id="hello-there-abc123-r000-3825957270",
-                        invocation_id=("invocation-0-task-make-greeting-message"),
-                        status=RunStatus(
-                            state=State.SUCCEEDED,
-                            start_time=datetime.datetime(
-                                1989, 12, 13, 9, 4, 29, tzinfo=datetime.timezone.utc
-                            ),
-                            end_time=datetime.datetime(
-                                1989, 12, 13, 9, 5, 8, tzinfo=datetime.timezone.utc
-                            ),
-                        ),
-                    ),
-                ],
-                status=RunStatus(
-                    state=State.SUCCEEDED,
-                    start_time=datetime.datetime(
-                        1989, 12, 13, 9, 3, 49, tzinfo=datetime.timezone.utc
-                    ),
-                    end_time=datetime.datetime(
-                        1989, 12, 13, 9, 5, 14, tzinfo=datetime.timezone.utc
-                    ),
-                ),
-            )
-        ]
-
-
 def _mock_artifact_resp(
     responses,
     wf_run_id: WorkflowRunId,
@@ -950,12 +866,6 @@ class TestGetWorkflowRunStatus:
                 end_time=None,
             ),
         )
-
-
-class TestGetWorkflowRunOutputs:
-    def test_raises(self, runtime):
-        with pytest.raises(NotImplementedError):
-            runtime.get_workflow_run_outputs("hello-there-abc123-r000")
 
 
 class TestGetWorkflowRunOutputsNonBlocking:
@@ -1504,7 +1414,7 @@ class TestHTTPErrors:
         for telltale in telltales:
             assert telltale in str(exc_info)
 
-    def test_get_all_workflow_run_status(
+    def test_list_workflow_runs(
         self,
         error_code,
         expected_exception,
@@ -1513,6 +1423,7 @@ class TestHTTPErrors:
         runtime,
         mocked_responses,
     ):
+        # DB read 1: getting list of stored wf run IDs
         monkeypatch.setattr(
             _db.WorkflowDB,
             "get_workflow_runs_list",
@@ -1526,13 +1437,26 @@ class TestHTTPErrors:
                 ]
             ),
         )
+        # DB read 2: get the workflow def from the DB. The current implementation
+        # suffers from the "n+1 Queries Problem" but we don't plan to fix it for QE.
+        monkeypatch.setattr(
+            _db.WorkflowDB,
+            "get_workflow_run",
+            Mock(
+                return_value=StoredWorkflowRun(
+                    workflow_run_id="hello-there-abc123-r000",
+                    config_name="hello",
+                    workflow_def=TEST_WORKFLOW,
+                )
+            ),
+        )
         mocked_responses.add(
             responses.GET,
-            "http://localhost/v1/workflowlist",
+            "http://localhost/v1/workflow",
             status=error_code,
         )
         with pytest.raises(expected_exception) as exc_info:
-            runtime.get_all_workflow_runs_status()
+            runtime.list_workflow_runs()
         for telltale in telltales:
             assert telltale in str(exc_info)
 

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -570,7 +570,7 @@ def test_run_and_get_output(
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class Test3rdPartyLibraries:
     @staticmethod
-    def test_constants_n_inline_imports(runtime: _dag.RayRuntime):
+    def test_constants_and_inline_imports(runtime: _dag.RayRuntime):
         """
         This test uses already generated workflow def from json file. If necessary, it
         can be recreated using ./data/python_package/original_workflow.py

--- a/tests/sdk/v2/test_in_process_runtime.py
+++ b/tests/sdk/v2/test_in_process_runtime.py
@@ -73,7 +73,7 @@ def test_secret_inside_ir(
     monkeypatch.setattr(_client.SecretsClient, "get_secret", get_secret)
 
     run_id = runtime.create_workflow_run(wf_with_secrets().model)
-    result = runtime.get_workflow_run_outputs(run_id)
+    result = runtime.get_workflow_run_outputs_non_blocking(run_id)
 
     assert result == "Mocked"
 
@@ -92,13 +92,7 @@ class TestQueriesAfterRunning:
     class TestGetWorkflowRunOutputs:
         @staticmethod
         def test_output_values(runtime, run_id):
-            assert runtime.get_workflow_run_outputs(run_id) == 3
-
-        @staticmethod
-        def test_matches_non_blocking(runtime, run_id):
-            outputs = runtime.get_workflow_run_outputs(run_id)
-
-            assert outputs == runtime.get_workflow_run_outputs_non_blocking(run_id)
+            assert runtime.get_workflow_run_outputs_non_blocking(run_id) == 3
 
         @staticmethod
         def test_multiple_runs(runtime):
@@ -108,8 +102,8 @@ class TestQueriesAfterRunning:
             run_id1 = runtime.create_workflow_run(wf_def1)
             run_id2 = runtime.create_workflow_run(wf_def2)
 
-            outputs1 = runtime.get_workflow_run_outputs(run_id1)
-            outputs2 = runtime.get_workflow_run_outputs(run_id2)
+            outputs1 = runtime.get_workflow_run_outputs_non_blocking(run_id1)
+            outputs2 = runtime.get_workflow_run_outputs_non_blocking(run_id2)
 
             assert run_id1 != run_id2
             assert outputs1 != outputs2
@@ -238,7 +232,6 @@ class TestUnsupportedMethods:
         "method",
         [
             InProcessRuntime.from_runtime_configuration,
-            InProcessRuntime.get_all_workflow_runs_status,
         ],
     )
     def test_raises(runtime, method):


### PR DESCRIPTION
# The problem

It's been a while since we reflected on `RuntimeInterface` methods. Originally this interface was public so we couldn't remove old methods; we only kept adding new ones. Nowadays, this interface isn't used by our users, so we're free to change it how we like.


# This PR's solution

Removes methods we don't use/implement anymore.

- `RuntimeInterface.get_workflow_run_outputs()`
- `RuntimeInterface.get_all_workflow_runs_status()`. The only usage is replaced with `list_workflow_runs()`.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
