### PR TITLE
internal: skip slow tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ include subtrees/z_quantum_actions/Makefile
 # (override)
 test:
 	PYTHONPATH="." $(PYTHON) -m pytest \
-		-m "not needs_separate_project" \
 		--ignore=tests/runtime/performance \
 		--ignore=tests/sdk/v2/typing \
 		--durations=10 \
@@ -28,7 +27,6 @@ test:
 # (override)
 coverage:
 	PYTHONPATH="." $(PYTHON) -m pytest \
-		-m "not needs_separate_project" \
 		--cov=src \
 		--cov-fail-under=$(MIN_COVERAGE) \
 		--cov-report xml \
@@ -112,7 +110,7 @@ style-fix:
 # Run tests, but discard the ones that exceptionally slow to run locally.
 test-fast:
 	PYTHONPATH="." $(PYTHON) -m pytest \
-		-m "not needs_separate_project and not slow" \
+		-m "not slow" \
 		--ignore=tests/runtime/performance \
 		--ignore=tests/sdk/v2/typing \
 		--durations=10 \

--- a/docs/examples/tests/test_logging.py
+++ b/docs/examples/tests/test_logging.py
@@ -42,6 +42,7 @@ class Snippets:
         wf().run("in_process")
 
 
+@pytest.mark.slow
 class TestSnippets:
     wf_id = None
 

--- a/docs/examples/tests/test_remote.py
+++ b/docs/examples/tests/test_remote.py
@@ -127,6 +127,7 @@ class Snippets:
         # </snippet>
 
 
+@pytest.mark.slow
 class TestSnippets:
     wf_id = "test_workflow_id"
     config_name = "test-remote-tutorial-config"

--- a/docs/examples/tests/test_workflow_syntax.py
+++ b/docs/examples/tests/test_workflow_syntax.py
@@ -336,6 +336,7 @@ class Snippets:
         return wf
 
 
+@pytest.mark.slow
 class TestSnippets:
     @staticmethod
     def test_same_module():

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,8 +2,6 @@
 log_level=INFO
 log_cli=True
 markers =
-   needs_separate_project: tests that need setting up a separate project repo and 'orq' configuration before running. Aren't ran on the CI.
-   host_only: Tests that don't work in the dev container used by Orquestra Studio
    slow: Tests that take long time to run locally. Skipped by 'make test-fast'.
 # By default, treat warnings as errors
 filterwarnings =

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -793,6 +793,7 @@ def test_task_code_unavailable_at_building_dag(runtime: _dag.RayRuntime):
     )
 
 
+@pytest.mark.slow
 # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
 # unraisable exceptions. Last tested with Ray 2.0.1.
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")

--- a/tests/runtime/test_log_adapter.py
+++ b/tests/runtime/test_log_adapter.py
@@ -6,6 +6,8 @@ import sys
 import typing as t
 from unittest.mock import Mock
 
+import pytest
+
 from orquestra.sdk._base import _log_adapter
 from orquestra.sdk._ray import _dag, _ray_logs
 
@@ -63,6 +65,7 @@ def test_get_ray_backend_ids(monkeypatch):
 
 
 class TestMakeLogger:
+    @pytest.mark.skip
     class TestIntegration:
         """
         It's very difficult to verify how we arrange loggers and formatters because

--- a/tests/sdk/v2/secrets/test_importing.py
+++ b/tests/sdk/v2/secrets/test_importing.py
@@ -13,6 +13,7 @@ import sys
 import pytest
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize(
     "code_lines",
     [

--- a/tests/sdk/v2/test_api_tutorial_scripts.py
+++ b/tests/sdk/v2/test_api_tutorial_scripts.py
@@ -87,6 +87,7 @@ class TempConfigFile(object):
             )
 
 
+@pytest.mark.slow
 def test_quickstart(capsys, _examples_dir):
     command = f"{PYTHON_EXECUTABLE} {_examples_dir}/quickstart.py"
     result_status = run_command(command, shell=True, stdout=True)
@@ -105,6 +106,7 @@ def test_quickstart(capsys, _examples_dir):
     assert expected_output in captured.out
 
 
+@pytest.mark.slow
 def test_config_management(capsys, _examples_dir):
     """
     The config management example prints the details of a config three times: once


### PR DESCRIPTION
# Context

We have a mix of unit and integration tests, and the boundary is difficult to draw. Some tests take a long time to run. On the other hand, local development is very iterative, and we don't want to waste time re-running long tests unless necessary. This is why we have `make test-fast`.

# The problem

Some new tests have been added that slow `make test-fast` down.

# This PR's solution

1. I've marked any test case that takes more than 0.5s on my machine as "slow". This skips it from `make test-fast`. This doesn't affect the CI, it runs all tests. Of course, the threshold is totally based on a personal preference.
2. I've noticed we don't use some marks anymore, so I removed their definitions from `pytest.ini`.

Now, `make test-fast` takes "only" 20.59s. Before: 47.22s

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
