### PR TITLE
fix: TaskRun.get_inputs() with multi-output tasks

### DIFF
--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -356,7 +356,7 @@ class TestTaskRun:
             assert parent.task_run_id == "top-task-run"
             assert parent.workflow_run_id == wf_run_id
 
-    class TestGetInput:
+    class TestGetInputs:
         @staticmethod
         @pytest.mark.parametrize(
             "workflow, expected_args, expected_kwargs",

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -228,7 +228,7 @@ class TestTaskRun:
 
             task_run = _api.TaskRun(
                 task_run_id="a_run",
-                task_invocation_id="inv1",
+                task_invocation_id="invocation-0-task-make-greeting-message",
                 workflow_run_id="wf.1",
                 runtime=runtime,
                 wf_def=wf_def_model,

--- a/tests/sdk/v2/data/multi_outputs/defs.py
+++ b/tests/sdk/v2/data/multi_outputs/defs.py
@@ -1,0 +1,35 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+
+from orquestra import sdk
+
+
+@sdk.task(source_import=sdk.InlineImport())
+def a(thing=None):
+    return thing or "hello-arg"
+
+
+@sdk.task(source_import=sdk.InlineImport())
+def b(*args):
+    return 1, 2, 3, 4
+
+
+@sdk.workflow
+def wf():
+    w, x, y, z = b()
+    return a(a(None)), b(b()), b(w, x, y, z)
+
+
+def main():
+    r = wf().run("in_process")
+    r.wait_until_finished()
+    tasks = list(r.get_tasks())
+    task = next(t for t in tasks if t.task_invocation_id == "invocation-2-task-b")
+    print(task)
+    breakpoint()
+    print(task.get_inputs())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sdk/v2/data/multi_outputs/defs.py
+++ b/tests/sdk/v2/data/multi_outputs/defs.py
@@ -1,7 +1,7 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
-
+import typing as t
 from orquestra import sdk
 
 
@@ -21,13 +21,37 @@ def wf():
     return a(a(None)), b(b()), b(w, x, y, z)
 
 
+inline_task = sdk.task(source_import=sdk.InlineImport())
+
+
+@inline_task
+def multi_outputs():
+    return 1, 2
+
+
+@inline_task
+def sum_tuple(ints_tuple: t.Tuple[int, ...]) -> int:
+    return sum(ints_tuple)
+
+
+@sdk.workflow
+def wf_simplified():
+    packed = multi_outputs()
+    return sum_tuple(packed)
+
+
 def main():
-    r = wf().run("in_process")
+    wf_def = wf_simplified()
+    r = wf_def.run("in_process")
     r.wait_until_finished()
     tasks = list(r.get_tasks())
-    task = next(t for t in tasks if t.task_invocation_id == "invocation-2-task-b")
+    task = next(
+        t for t in tasks if t.task_invocation_id == "invocation-0-task-sum-tuple"
+    )
     print(task)
     breakpoint()
+
+    wf_def.graph.render("wf")
     print(task.get_inputs())
 
 

--- a/tests/sdk/v2/data/task_run_workflow_defs.py
+++ b/tests/sdk/v2/data/task_run_workflow_defs.py
@@ -1,11 +1,14 @@
 ################################################################################
 # © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
-import orquestra.sdk as sdk
+from orquestra import sdk
 
 
 @sdk.task
 def return_num(*args):
+    """
+    Returns number of arguments.
+    """
     return len(args)
 
 
@@ -67,5 +70,6 @@ def task_multiple_outputs():
 
 @sdk.workflow
 def wf_multi_output_task():
-    art_1, _ = task_multiple_outputs()
-    return [return_num(art_1)]
+    num1, _ = task_multiple_outputs()
+    nums_packed = task_multiple_outputs()
+    return [return_num(num1), return_num(nums_packed), return_num(*nums_packed)]


### PR DESCRIPTION
# The problem

#75 introduced a regression.

# This PR's solution

I've added the test case and a fix prototype. It's not fully fledged yet.

# Checklist

_Check that this PR satisfies the following items:_

- [ ] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [ ] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
