### PR TITLE
Feat: Allow setting default source imports and dependency imports for all tasks in given WF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 🔥 *Features*
 - Sort WF runs by start date in `list wf` command. Show start date as one of the columns
 - Sort WF runs by start date in all workflow commands in prompt selection. Show start date with WF id
+- New parameters for `@workflow` decorator - default_source_import and default_dependency_imports.
+Defaults for imports for all tasks in given workflow can be specified on a workflow-decorator level now.
+If task defines its own imports (either source, dependencies or both) - it will overwrite workflow-defaults.
 
 👩‍🔬 *Experimental*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 🔥 *Features*
 - Sort WF runs by start date in `list wf` command. Show start date as one of the columns
 - Sort WF runs by start date in all workflow commands in prompt selection. Show start date with WF id
-- New parameters for `@workflow` decorator - default_source_import and default_dependency_imports.
-Defaults for imports for all tasks in given workflow can be specified on a workflow-decorator level now.
-If task defines its own imports (either source, dependencies or both) - it will overwrite workflow-defaults.
+- New parameters for `@workflow` decorator - `default_source_import` and `default_dependency_imports`.
+These parameters let you set the default imports for all tasks in given workflow.
+If a task defines its own imports (either source, dependencies, or both) - it will overwrite workflow defaults.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -511,7 +511,7 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
         )
 
     def resolve_task_dependencies(
-        self, wf_default_dependency_imports: Optional[Iterable[Import]] = None
+        self, wf_default_dependency_imports: Optional[Tuple[Import, ...]] = None
     ):
         # if user set imports explicitly, do nothing
         if not self._use_default_dependency_imports:

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -360,7 +360,7 @@ def parse_custom_name(
     format_dict = {}
     for ph in placeholders:
         if isinstance(signature.arguments[ph], ArtifactFuture):
-            fnc = signature.arguments[ph].invocation.task._fn_ref.function_name
+            fnc = signature.arguments[ph].invocation.task._fn_name
             format_dict[ph] = replacement_string.format(fnc)
             warnings.warn(
                 "Custom name contains placeholder with value"

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -415,7 +415,7 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
         self._use_default_source_import = source_import is None
 
         # task itself is not part of any workflow yet. Don't pass wf defaults
-        self.resolve_task_source_data()
+        self._resolve_task_source_data()
 
         if self._custom_image is None:
             if resources.gpu:
@@ -486,10 +486,11 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
             ),
         )
 
-    def resolve_task_source_data(
+    def _resolve_task_source_data(
         self, wf_default_source_import: Optional[Import] = None
     ):
-        # if user set source import explicitly, do nothing
+        # if user set source import explicitly, we use that import
+        # else we either take wf default, or base on if the session is interactive
         if self._use_default_source_import:
             if wf_default_source_import:
                 self._source_import = wf_default_source_import
@@ -512,7 +513,7 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
             else get_fn_ref(self.__sdk_task_body)
         )
 
-    def resolve_task_dependencies(
+    def _resolve_task_dependencies(
         self, wf_default_dependency_imports: Optional[Tuple[Import, ...]] = None
     ):
         # if user set imports explicitly, do nothing

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -360,7 +360,7 @@ def parse_custom_name(
     format_dict = {}
     for ph in placeholders:
         if isinstance(signature.arguments[ph], ArtifactFuture):
-            fnc = signature.arguments[ph].invocation.task.fn_ref.function_name
+            fnc = signature.arguments[ph].invocation.task._fn_ref.function_name
             format_dict[ph] = replacement_string.format(fnc)
             warnings.warn(
                 "Custom name contains placeholder with value"
@@ -402,26 +402,26 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
             raise NotImplementedError("Built-in functions are not supported as Tasks")
         super(TaskDef, self).__init__(fn)
         self.__sdk_task_body = fn
-        self.fn_name = fn.__name__
-        self.output_metadata = output_metadata
-        self.parameters = parameters
-        self.resources = resources
-        self.custom_image = custom_image
-        self.custom_name = custom_name
-        self.dependency_imports = dependency_imports
+        self._fn_ref = fn_ref
+        self._fn_name = fn.__name__
+        self._output_metadata = output_metadata
+        self._parameters = parameters
+        self._resources = resources
+        self._custom_image = custom_image
+        self._custom_name = custom_name
+        self._dependency_imports = dependency_imports
         self._use_default_dependency_imports = dependency_imports is None
-        self.source_import = source_import
+        self._source_import = source_import
         self._use_default_source_import = source_import is None
-        self.fn_ref = fn_ref
 
         # task itself is not part of any workflow yet. Don't pass wf defaults
         self.resolve_task_source_data()
 
-        if self.custom_image is None:
+        if self._custom_image is None:
             if resources.gpu:
-                self.custom_image = GPU_IMAGE
+                self._custom_image = GPU_IMAGE
             else:
-                self.custom_image = DEFAULT_IMAGE
+                self._custom_image = DEFAULT_IMAGE
 
     @property
     def n_outputs(self):
@@ -429,24 +429,24 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
             '"n_outputs" is deprecated. Please use "output_metadata".',
             DeprecationWarning,
         )
-        return self.output_metadata.n_outputs
+        return self._output_metadata.n_outputs
 
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:
         # In case of local run the workflow is executed as a python script
         if DIRECT_EXECUTION:
             return self.__sdk_task_body(*args, **kwargs)
         if (
-            not isinstance(self.source_import, InlineImport)
-            and isinstance(self.fn_ref, ModuleFunctionRef)
-            and self.fn_ref.module == "__main__"
+            not isinstance(self._source_import, InlineImport)
+            and isinstance(self._fn_ref, ModuleFunctionRef)
+            and self._fn_ref.module == "__main__"
         ):
             err = (
-                f"function {self.fn_name} is defined inside __main__ "
+                f"function {self._fn_name} is defined inside __main__ "
                 "module. Please move task function to different file and import, "
                 "it or mark this task function as inline import \n\n"
                 "example: \n"
                 "@sdk.task(source_import=sdk.InlineImport())\n"
-                f"def {self.fn_name}(): ..."
+                f"def {self._fn_name}(): ..."
             )
             raise InvalidTaskDefinitionError(err)
         try:
@@ -467,7 +467,7 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
             missing_self_arg = r".*(missing a required argument:)[^a-zA-Z\d]*(self).*"
             if re.match(missing_self_arg, str(exc)):
                 error_message = (
-                    f"The task {self.fn_name} seems to be a method, if so"
+                    f"The task {self._fn_name} seems to be a method, if so"
                     " modify it to not be a method.\n"
                 ) + error_message
             raise WorkflowSyntaxError(error_message) from exc
@@ -479,9 +479,9 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
                     self,
                     args=args,
                     kwargs=tuple(kwargs.items()),
-                    resources=self.resources,
-                    custom_name=parse_custom_name(self.custom_name, signature),
-                    custom_image=self.custom_image,
+                    resources=self._resources,
+                    custom_name=parse_custom_name(self._custom_name, signature),
+                    custom_image=self._custom_image,
                 )
             ),
         )
@@ -492,21 +492,23 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
         # if user set source import explicitly, do nothing
         if self._use_default_source_import:
             if wf_default_source_import:
-                self.source_import = wf_default_source_import
+                self._source_import = wf_default_source_import
             # Set the default Import based on if the session is interactive
             elif _is_interactive():
-                self.source_import = InlineImport()
+                self._source_import = InlineImport()
             else:
-                self.source_import = LocalImport(module=self.__sdk_task_body.__module__)
+                self._source_import = LocalImport(
+                    module=self.__sdk_task_body.__module__
+                )
         self._resolve_fn_ref()
 
     def _resolve_fn_ref(self):
         # resolve fn_ref is based on task source import. If user doesn't pass it,
         # resolve_source_import should set it
-        assert self.source_import is not None
-        self.fn_ref = (
+        assert self._source_import is not None
+        self._fn_ref = (
             InlineFunctionRef(self.__sdk_task_body.__name__, self.__sdk_task_body)
-            if isinstance(self.source_import, InlineImport)
+            if isinstance(self._source_import, InlineImport)
             else get_fn_ref(self.__sdk_task_body)
         )
 
@@ -518,7 +520,7 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
             return
 
         if wf_default_dependency_imports:
-            self.dependency_imports = wf_default_dependency_imports
+            self._dependency_imports = wf_default_dependency_imports
 
 
 # TaskInvocation is using a Plain Old Python Object on purpose:
@@ -614,11 +616,11 @@ class ArtifactFuture:
         )
 
     def __getitem__(self, index):
-        if not self.invocation.task.output_metadata.is_subscriptable:
+        if not self.invocation.task._output_metadata.is_subscriptable:
             raise TypeError("This ArtifactFuture is not subscriptable")
         if not isinstance(index, int):
             raise TypeError("ArtifactFuture indices must be integers")
-        if index >= self.invocation.task.output_metadata.n_outputs:
+        if index >= self.invocation.task._output_metadata.n_outputs:
             raise IndexError("ArtifactFuture index out of range")
         return ArtifactFuture(
             invocation=self.invocation,
@@ -628,7 +630,7 @@ class ArtifactFuture:
         )
 
     def __iter__(self):
-        if not self.invocation.task.output_metadata.is_subscriptable:
+        if not self.invocation.task._output_metadata.is_subscriptable:
             raise TypeError("This ArtifactFuture is not iterable")
         futures = [
             ArtifactFuture(
@@ -637,7 +639,7 @@ class ArtifactFuture:
                 custom_name=self.custom_name,
                 serialization_format=self.serialization_format,
             )
-            for next_index in range(self.invocation.task.output_metadata.n_outputs)
+            for next_index in range(self.invocation.task._output_metadata.n_outputs)
         ]
         return iter(futures)
 
@@ -684,7 +686,7 @@ class ArtifactFuture:
             custom_image: docker image used to run the task invocation
         """
         self._check_if_destructured(
-            fn_name=self.invocation.task.fn_name,
+            fn_name=self.invocation.task._fn_name,
             assign_type="invocation metadata",
         )
 
@@ -748,7 +750,7 @@ class ArtifactFuture:
             gpu: amount of gpu assigned to the task invocation
         """
         self._check_if_destructured(
-            fn_name=self.invocation.task.fn_name,
+            fn_name=self.invocation.task._fn_name,
             assign_type="resources",
         )
 
@@ -772,7 +774,7 @@ class ArtifactFuture:
             custom_image: docker image used to run the task invocation
         """
         self._check_if_destructured(
-            fn_name=self.invocation.task.fn_name,
+            fn_name=self.invocation.task._fn_name,
             assign_type="custom image",
         )
 

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -344,8 +344,12 @@ def _make_task_model(
     task: _dsl.TaskDef,
     imports_dict: t.Dict[_dsl.Import, model.Import],
 ) -> model.TaskDef:
+    # fn_ref and source_imports are completely resolved during
+    # creation of import_models_dict. At this point every task should have
+    # those variables set - and they are needed to make task model
     assert task._fn_ref is not None
     assert task._source_import is not None
+
     fn_ref_model = _make_fn_ref(task._fn_ref)
 
     source_import = imports_dict[task._source_import]
@@ -602,8 +606,8 @@ def flatten_graph(
     # to avoid git fetch spam for the same repos over and over.
     cached_git_import_dict: t.Dict[t.Tuple, model.Import] = {}
     for invocation in graph.invocations.keys():
-        invocation.task.resolve_task_source_data(workflow_def.default_source_import)
-        invocation.task.resolve_task_dependencies(
+        invocation.task._resolve_task_source_data(workflow_def.default_source_import)
+        invocation.task._resolve_task_dependencies(
             workflow_def.default_dependency_imports
         )
         for imp in [

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -344,6 +344,8 @@ def _make_task_model(
     task: _dsl.TaskDef,
     imports_dict: t.Dict[_dsl.Import, model.Import],
 ) -> model.TaskDef:
+    assert task.fn_ref is not None
+    assert task.source_import is not None
     fn_ref_model = _make_fn_ref(task.fn_ref)
 
     source_import = imports_dict[task.source_import]

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -14,6 +14,7 @@ from typing import (
     Callable,
     Dict,
     Generic,
+    Iterable,
     List,
     NamedTuple,
     Optional,
@@ -34,6 +35,7 @@ from ._ast import CallVisitor, NodeReference, NodeReferenceType, normalize_inden
 from ._dsl import (
     DataAggregation,
     FunctionRef,
+    Import,
     Secret,
     TaskDef,
     UnknownPlaceholderInCustomNameWarning,
@@ -70,6 +72,8 @@ class WorkflowDef(Generic[_R]):
         data_aggregation: Optional[DataAggregation] = None,
         workflow_args: Optional[Tuple[Any, ...]] = None,
         workflow_kwargs: Optional[Dict[str, Any]] = None,
+        default_source_import: Optional[Import] = None,
+        default_dependency_imports: Optional[Iterable[Import]] = None,
     ):
         self._name = name
         self._fn = workflow_fn
@@ -77,6 +81,8 @@ class WorkflowDef(Generic[_R]):
         self._data_aggregation = data_aggregation
         self._workflow_args = workflow_args or ()
         self._workflow_kwargs = workflow_kwargs or {}
+        self.default_source_import = default_source_import
+        self.default_dependency_imports = default_dependency_imports
 
     @property
     def name(self) -> str:
@@ -263,12 +269,16 @@ class WorkflowTemplate(Generic[_P, _R]):
         fn_ref: FunctionRef,
         is_parametrized: bool,
         data_aggregation: Optional[Union[DataAggregation, bool]] = None,
+        default_source_import: Optional[Import] = None,
+        default_dependency_imports: Optional[Iterable[Import]] = None,
     ):
         self._custom_name = custom_name
         self._fn = workflow_fn
         self._fn_ref = fn_ref
         self._data_aggregation = data_aggregation
         self._is_parametrized = is_parametrized
+        self._default_source_import = default_source_import
+        self._default_dependency_imports = default_dependency_imports
 
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> WorkflowDef[_R]:
         """
@@ -340,7 +350,16 @@ class WorkflowTemplate(Generic[_P, _R]):
                 raise WorkflowSyntaxError(
                     "Workflow arguments must be known at submission time. "
                 )
-        return WorkflowDef(name, self._fn, self._fn_ref, data_aggregation, args, kwargs)
+        return WorkflowDef(
+            name,
+            self._fn,
+            self._fn_ref,
+            data_aggregation,
+            args,
+            kwargs,
+            self._default_source_import,
+            self._default_dependency_imports,
+        )
 
     @property
     def is_parametrized(self) -> bool:
@@ -514,6 +533,8 @@ def workflow(
     *,
     data_aggregation: Optional[Union[DataAggregation, bool]] = None,
     custom_name: Optional[str] = None,
+    default_source_import: Optional[Import] = None,
+    default_dependency_imports: Optional[Iterable[Import]] = None,
 ) -> Callable[[Callable[_P, _R]], WorkflowTemplate[_P, _R]]:
     ...
 
@@ -523,6 +544,8 @@ def workflow(
     *,
     data_aggregation: Optional[Union[DataAggregation, bool]] = None,
     custom_name: Optional[str] = None,
+    default_source_import: Optional[Import] = None,
+    default_dependency_imports: Optional[Iterable[Import]] = None,
 ) -> Union[
     WorkflowTemplate[_P, _R],
     Callable[[Callable[_P, _R]], WorkflowTemplate[_P, _R]],
@@ -534,6 +557,14 @@ def workflow(
             or assigned True default values will be used. If assigned False
             data aggregation step will not run.
         custom_name: custom name for the workflow
+        default_source_import: Set default source import for all tasks inside
+           this workflow
+           Important: if task defines its own individual source import, wf-scoped
+           default_source_import will be ignored
+        default_dependency_imports: Set default dependency imports for all tasks inside
+           this workflow
+           Important: if task defines its own individual dependency imports, wf-scoped
+           default_dependency_imports will be ignored for that particular task
 
     You can use the Python API to submit workflows for execution::
 
@@ -576,6 +607,8 @@ def workflow(
             fn_ref=fn_ref,
             is_parametrized=len(signature.parameters) > 0,
             data_aggregation=data_aggregation,
+            default_source_import=default_source_import,
+            default_dependency_imports=default_dependency_imports,
         )
         functools.update_wrapper(template, fn)
         return template

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -557,14 +557,15 @@ def workflow(
             or assigned True default values will be used. If assigned False
             data aggregation step will not run.
         custom_name: custom name for the workflow
-        default_source_import: Set default source import for all tasks inside
-           this workflow
-           Important: if task defines its own individual source import, wf-scoped
-           default_source_import will be ignored
-        default_dependency_imports: Set default dependency imports for all tasks inside
-           this workflow
-           Important: if task defines its own individual dependency imports, wf-scoped
-           default_dependency_imports will be ignored for that particular task
+        default_source_import: Set the default source import for all tasks inside
+           this workflow.
+           Important: if a task defines its own individual source import, the workflow
+           scoped default_source_import will be ignored.
+        default_dependency_imports: Set the default dependency imports for all tasks
+           inside this workflow.
+           Important: if a task defines its own individual dependency imports, the
+           workflow scoped default_dependency_imports will be ignored for that
+           particular task
 
     You can use the Python API to submit workflows for execution::
 

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -764,7 +764,7 @@ def test_task_code_unavailable_at_building_dag(runtime: _dag.RayRuntime):
     task_id = list(wf_def.tasks.keys())[0]
 
     # ignoring mypy, this is supposed to be module fn repo
-    wf_def.tasks[task_id].fn_ref.module = "nope"  # type: ignore
+    wf_def.tasks[task_id]._fn_ref.module = "nope"  # type: ignore
 
     # when
     wf_id = runtime.create_workflow_run(wf_def)

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -764,7 +764,7 @@ def test_task_code_unavailable_at_building_dag(runtime: _dag.RayRuntime):
     task_id = list(wf_def.tasks.keys())[0]
 
     # ignoring mypy, this is supposed to be module fn repo
-    wf_def.tasks[task_id]._fn_ref.module = "nope"  # type: ignore
+    wf_def.tasks[task_id].fn_ref.module = "nope"  # type: ignore
 
     # when
     wf_id = runtime.create_workflow_run(wf_def)

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -103,7 +103,7 @@ class TestArtifactFuturePublicMethods:
             if attr != "custom_image":
                 if future.invocation.resources is None:
                     assert (
-                        new_future.invocation.resources == future.invocation.resources
+                        new_future.invocation.resources == future.invocation._resources
                     )
                 else:
                     assert getattr(new_future.invocation.resources, attr) == getattr(
@@ -132,7 +132,7 @@ class TestArtifactFuturePublicMethods:
             assert getattr(new_future.invocation.resources, attr) == expected_value
         else:
             if future.invocation.resources is None:
-                assert new_future.invocation.resources == future.invocation.resources
+                assert new_future.invocation.resources == future.invocation._resources
             else:
                 assert getattr(new_future.invocation.resources, attr) == getattr(
                     future.invocation.resources, attr
@@ -185,8 +185,8 @@ def task_no_source():
 def test_task_no_linenumber_if_source_inaccessible():
     task_no_source.__code__ = task_no_source.__code__.replace(co_filename="fake")
     local_task = _dsl.task(task_no_source)
-    assert isinstance(local_task.fn_ref, _dsl.ModuleFunctionRef)
-    assert local_task.fn_ref.line_number is None
+    assert isinstance(local_task._fn_ref, _dsl.ModuleFunctionRef)
+    assert local_task._fn_ref.line_number is None
 
 
 def test_external_file_task_calling():
@@ -260,7 +260,7 @@ def test_accessing_deprecated_n_outputs():
         return 0, 1
 
     with pytest.warns(DeprecationWarning):
-        assert _local_task.n_outputs == _local_task.output_metadata.n_outputs == 2
+        assert _local_task.n_outputs == _local_task._output_metadata.n_outputs == 2
 
 
 def test_iter_artifact_future():
@@ -356,13 +356,13 @@ def test_resourced_task_with_custom_gpu_image():
         return "hello"
 
     hello = _local_task()
-    assert hello.invocation.task.custom_image == _dsl.GPU_IMAGE
+    assert hello.invocation.task._custom_image == _dsl.GPU_IMAGE
 
 
 def test_resourced_task_with_default_gpu_image():
     future = _resourced_task()
 
-    assert future.invocation.task.custom_image == _dsl.GPU_IMAGE
+    assert future.invocation.task._custom_image == _dsl.GPU_IMAGE
 
 
 def test_task_with_default_image():
@@ -371,7 +371,7 @@ def test_task_with_default_image():
         return "hello"
 
     hello = _local_task()
-    assert hello.invocation.task.custom_image == _dsl.DEFAULT_IMAGE
+    assert hello.invocation.task._custom_image == _dsl.DEFAULT_IMAGE
 
 
 @pytest.fixture
@@ -560,7 +560,7 @@ def test_default_for_interactive_mode(monkeypatch):
         ...
 
     # type comparison to check if in interactive mode default is INLINE
-    assert type(task.source_import) is type(inline_task.source_import)  # noqa
+    assert type(task._source_import) is type(inline_task._source_import)  # noqa
 
 
 def test_default_for_non_interactive_mode(monkeypatch):
@@ -575,7 +575,7 @@ def test_default_for_non_interactive_mode(monkeypatch):
         ...
 
     # type comparison to check if in  non-interactive mode default is INLINE
-    assert type(task.source_import) is type(local_task.source_import)  # noqa
+    assert type(task._source_import) is type(local_task._source_import)  # noqa
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/v2/test_task_ast_parsing.py
+++ b/tests/sdk/v2/test_task_ast_parsing.py
@@ -18,8 +18,8 @@ def _a_top_level_task():
 
 class TestNOutputsEdgeCases:
     def test_top_level(self):
-        assert _a_top_level_task.output_metadata.n_outputs == 2
-        assert _a_top_level_task.output_metadata.is_subscriptable
+        assert _a_top_level_task._output_metadata.n_outputs == 2
+        assert _a_top_level_task._output_metadata.is_subscriptable
 
     def test_nested_function(self):
         # In the future it might be nice to look only at the outer-most return.
@@ -38,8 +38,8 @@ class TestNOutputsEdgeCases:
                 # A return with three outputs
                 return 1, 2, 3
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_union_signature(self):
         with pytest.warns(UserWarning):
@@ -51,8 +51,8 @@ class TestNOutputsEdgeCases:
                 else:
                     return 42, 100
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
 
 class TestNOutputsByNodeType:
@@ -61,40 +61,40 @@ class TestNOutputsByNodeType:
         def _a_task():
             return
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_pass(self):
         @sdk.task
         def _a_task():
             pass
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_no_return(self):
         @sdk.task
         def _a_task():
             print("hello!")
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_single_literal(self):
         @sdk.task
         def _a_task():
             return "hello"
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_two_literals(self):
         @sdk.task
         def _a_task():
             return "hello", "there"
 
-        assert _a_task.output_metadata.n_outputs == 2
-        assert _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 2
+        assert _a_task._output_metadata.is_subscriptable
 
     def test_single_variable(self):
         @sdk.task
@@ -102,8 +102,8 @@ class TestNOutputsByNodeType:
             results = "hello", "there"
             return results
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_overriding(self):
         @sdk.task(n_outputs=2)
@@ -111,8 +111,8 @@ class TestNOutputsByNodeType:
             results = "hello", "there"
             return results
 
-        assert _a_task.output_metadata.n_outputs == 2
-        assert _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 2
+        assert _a_task._output_metadata.is_subscriptable
 
     def test_module_function_call(self):
         @sdk.task
@@ -121,16 +121,16 @@ class TestNOutputsByNodeType:
             hello = "hello"
             return os.path.join(hello, "world")
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_module_attr(self):
         @sdk.task
         def _a_task():
             return os.path.sep
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_inner_function_call(self):
         @sdk.task
@@ -140,8 +140,8 @@ class TestNOutputsByNodeType:
 
             return _inner()
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_method_call(self, caplog):
         @sdk.task
@@ -149,8 +149,8 @@ class TestNOutputsByNodeType:
             text = "hello"
             return text.capitalize()
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
         assert "Assuming a single output for node" not in caplog.text
 
     def test_fstring(self):
@@ -158,8 +158,8 @@ class TestNOutputsByNodeType:
         def _a_task(name: str):
             return f"hello, {name}"
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_starred_tuple(self):
         @sdk.task
@@ -167,16 +167,16 @@ class TestNOutputsByNodeType:
             names = ["emiliano", "zapata"]
             return ("hello", *names, "world")
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_set(self):
         @sdk.task
         def _a_task(name: str):
             return {"hello", name}
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_starred_set(self):
         @sdk.task
@@ -184,16 +184,16 @@ class TestNOutputsByNodeType:
             names = ["emiliano", "zapata"]
             return {"hello", *names, name}
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_set_comp(self):
         @sdk.task
         def _a_task(name: str):
             return {word for word in "hello world".split()}
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_empty_sequences(self):
         @sdk.task
@@ -210,15 +210,15 @@ class TestNOutputsByNodeType:
 
         # Let's treat an empty sequences similarly to how we treat empty returns
         assert (
-            _empty_list.output_metadata.n_outputs
-            == _empty_dict.output_metadata.n_outputs
-            == _empty_return.output_metadata.n_outputs
+            _empty_list._output_metadata.n_outputs
+            == _empty_dict._output_metadata.n_outputs
+            == _empty_return._output_metadata.n_outputs
             == 1
         )
         assert (
-            _empty_list.output_metadata.is_subscriptable
-            == _empty_dict.output_metadata.is_subscriptable
-            == _empty_return.output_metadata.is_subscriptable
+            _empty_list._output_metadata.is_subscriptable
+            == _empty_dict._output_metadata.is_subscriptable
+            == _empty_return._output_metadata.is_subscriptable
             is False
         )
 
@@ -227,16 +227,16 @@ class TestNOutputsByNodeType:
         def _a_task():
             return ["hello", "world"]
 
-        assert _a_task.output_metadata.n_outputs == 2
-        assert _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 2
+        assert _a_task._output_metadata.is_subscriptable
 
     def test_list_a_lot_of_elements(self):
         @sdk.task
         def _a_task():
             return ["hello", "world", "hello", "world", "hello"]
 
-        assert _a_task.output_metadata.n_outputs == 5
-        assert _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 5
+        assert _a_task._output_metadata.is_subscriptable
 
     def test_starred_list(self):
         @sdk.task
@@ -244,16 +244,16 @@ class TestNOutputsByNodeType:
             names = ["emiliano", "zapata"]
             return ["hello", *names, "world"]
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_list_comp(self):
         @sdk.task
         def _a_task():
             return [word.upper() for word in "hello world".split()]
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_dict(self):
         @sdk.task
@@ -261,32 +261,32 @@ class TestNOutputsByNodeType:
             val2 = "val2"
             return {"key1": "val1", "key2": val2}
 
-        assert _a_task.output_metadata.n_outputs == 2
-        assert _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 2
+        assert _a_task._output_metadata.is_subscriptable
 
     def test_starred_dict(self):
         @sdk.task
         def _a_task():
             return {**{"hello": "world"}, "hey": "there"}
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_dict_comp(self):
         @sdk.task
         def _a_task():
             return {f"key{i}": f"val{i}" for i in range(3)}
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_generator(self):
         @sdk.task
         def _a_task():
             return (word for word in "hello world".split())
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_subscript(self):
         @sdk.task
@@ -294,8 +294,8 @@ class TestNOutputsByNodeType:
             words = {"hello": "world"}
             return words["hello"]
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_bin_op(self):
         @sdk.task
@@ -304,8 +304,8 @@ class TestNOutputsByNodeType:
             b = ["emiliano", "zapata"]
             return a + b
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_unary_op(self):
         @sdk.task
@@ -313,8 +313,8 @@ class TestNOutputsByNodeType:
             num1 = 42
             return -num1
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_bool_op(self):
         @sdk.task
@@ -322,13 +322,13 @@ class TestNOutputsByNodeType:
             num1 = 42
             return num1 < 0 and num1 > -100
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable
 
     def test_comparison(self):
         @sdk.task
         def _a_task():
             return 42 > 12
 
-        assert _a_task.output_metadata.n_outputs == 1
-        assert not _a_task.output_metadata.is_subscriptable
+        assert _a_task._output_metadata.n_outputs == 1
+        assert not _a_task._output_metadata.is_subscriptable

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -1136,3 +1136,54 @@ def test_metadata_on_dev(monkeypatch: pytest.MonkeyPatch):
     assert wf.metadata.sdk_version.minor == 42
     assert wf.metadata.sdk_version.patch == 0
     assert wf.metadata.sdk_version.is_prerelease
+
+
+def test_wf_default_imports():
+    @_dsl.task
+    def no_overwrite_task():
+        return 21
+
+    @_dsl.task(
+        source_import=_dsl.GitImport(repo_url="overwrite", git_ref="source"),
+        dependency_imports=[_dsl.GitImport(repo_url="overwrite", git_ref="dep")],
+    )
+    def do_overwrite_task():
+        return 21
+
+    @_dsl.task(source_import=_dsl.GitImport(repo_url="another", git_ref="source"))
+    def overwrite_source_only_task():
+        return 21
+
+    @_workflow.workflow(
+        default_source_import=_dsl.GitImport(repo_url="2", git_ref="1"),
+        default_dependency_imports=[_dsl.GitImport(repo_url="3", git_ref="6")],
+    )
+    def wf_with_default_imports():
+        return [no_overwrite_task(), do_overwrite_task(), overwrite_source_only_task()]
+
+    wf_model = wf_with_default_imports.model
+    for id, task_model in wf_model.tasks.items():
+        assert task_model.dependency_import_ids
+        dep_import = wf_model.imports[task_model.dependency_import_ids[0]]
+        source_import = wf_model.imports[task_model.source_import_id]
+        if task_model.fn_ref.function_name == "no_overwrite_task":
+            assert isinstance(dep_import, model.GitImport)
+            assert dep_import.git_ref == "6"
+            assert dep_import.repo_url.original_url == "3"
+            assert isinstance(source_import, model.GitImport)
+            assert source_import.git_ref == "1"
+            assert source_import.repo_url.original_url == "2"
+        elif task_model.fn_ref.function_name == "do_overwrite_task":
+            assert isinstance(dep_import, model.GitImport)
+            assert dep_import.git_ref == "dep"
+            assert dep_import.repo_url.original_url == "overwrite"
+            assert isinstance(source_import, model.GitImport)
+            assert source_import.git_ref == "source"
+            assert source_import.repo_url.original_url == "overwrite"
+        elif task_model.fn_ref.function_name == "overwrite_source_only_task":
+            assert isinstance(dep_import, model.GitImport)
+            assert dep_import.git_ref == "6"
+            assert dep_import.repo_url.original_url == "3"
+            assert isinstance(source_import, model.GitImport)
+            assert source_import.git_ref == "source"
+            assert source_import.repo_url.original_url == "another"


### PR DESCRIPTION
# The problem

Usually a lot of tasks in a single WF require the same dependencies. To this day users would have to define them separately in each and every task definition

# This PR's solution

User can define default-dependencies and default-source-import on WF level, which are used by each and every task inside a workflow unless task specifies their own dependencies. Then task-ones are overwriting default ones.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
