### PR TITLE
feat: Add workflow resources support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 🔥 *Features*
 - Sort WF runs by start date in `list wf` command. Show start date as one of the columns
 - Sort WF runs by start date in all workflow commands in prompt selection. Show start date with WF id
+- Set resources for workflows on CE via `resources` keyword argument in the `@workflow` decorator or with `.with_resources()` on a `WorkflowDef`.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -201,9 +201,10 @@ class WorkflowRunResponse(MinimalWorkflowRunResponse):
 class Resources(pydantic.BaseModel):
     """
     Implements:
-        https://github.com/zapatacomputing/workflow-driver/blob/6270a214fff40f53d7b25ec967f2e7875eb296e3/openapi/src/schemas/Resources.yaml
+        https://github.com/zapatacomputing/workflow-driver/blob/580c8d8/openapi/src/schemas/Resources.yaml
     """
 
+    nodes: Optional[int]
     cpu: Optional[str] = pydantic.Field(
         regex=r"^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
     )

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -264,7 +264,26 @@ Import = Union[
 
 
 class Resources(NamedTuple):
-    """The computational resources a workflow task requires"""
+    """
+    The computational resources a workflow or task requires.
+
+    If any of these options are omitted, (or is None) the runtime's default value will
+    be used.
+
+    If a runtime doesn't support a particular value, it may be silently ignored.
+    Please check the documentation for each runtime!
+
+    Args:
+        cpu: The requested CPU in "CPU units".
+            e.g. for a single CPU core use "1" or "1000m"
+        memory: The requested memory in "bytes".
+            Binary or decimal suffixes are supported. e.g. "10G" for 10 gigabytes
+        disk: The requested disk space in "bytes".
+            Binary or decimal suffixes are supported. e.g. "10Gi" for 10 gibibytes
+        gpu: Either "0" or "1" to use a GPU or not.
+        nodes: The number of nodes requested. This option only applies to workflows.
+            This should be a positive integer.
+    """
 
     cpu: Optional[str] = None
     memory: Optional[str] = None

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -270,6 +270,7 @@ class Resources(NamedTuple):
     memory: Optional[str] = None
     disk: Optional[str] = None
     gpu: Optional[str] = None
+    nodes: Optional[int] = None
 
     def is_empty(self) -> bool:
         # find out if all the Resources are None

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -12,6 +12,7 @@ import inspect
 import re
 import sys
 import typing as t
+import warnings
 from collections import OrderedDict, defaultdict
 from functools import singledispatch
 
@@ -19,6 +20,7 @@ from packaging.version import parse as parse_version
 from pip_api import Requirement
 
 import orquestra.sdk.schema.ir as model
+from orquestra.sdk.exceptions import NodesInTaskResourcesWarning
 from orquestra.sdk.schema import responses
 
 from .. import exceptions
@@ -259,7 +261,7 @@ def _make_import_model(imp: _dsl.Import):
         raise ValueError(f"Invalid DSL import type: {type(imp)}")
 
 
-def _make_resources_model(resources: _dsl.Resources):
+def _make_resources_model(resources: _dsl.Resources, is_task=True):
     """Create a resources object of the IR based on a resources
     of the DSL. If no resources are allocated then returns None.
     Args:
@@ -267,15 +269,25 @@ def _make_resources_model(resources: _dsl.Resources):
     Returns:
         resources object from the IR
     """
-    return (
-        model.Resources(
-            cpu=resources.cpu,
-            memory=resources.memory,
-            disk=resources.disk,
-            gpu=resources.gpu,
+    if resources.is_empty():
+        return None
+
+    if is_task and resources.nodes is not None:
+        warnings.warn(
+            NodesInTaskResourcesWarning(
+                "Tasks currently do not support the nodes resource."
+            )
         )
-        if not resources.is_empty()
-        else None
+        nodes = None
+    else:
+        nodes = resources.nodes
+
+    return model.Resources(
+        cpu=resources.cpu,
+        memory=resources.memory,
+        disk=resources.disk,
+        gpu=resources.gpu,
+        nodes=nodes,
     )
 
 
@@ -660,6 +672,7 @@ def flatten_graph(
                 is_prerelease=sys.version_info.releaselevel != "final",
             ),
         ),
+        resources=_make_resources_model(workflow_def._resources, is_task=False),
         # At the moment 'orq submit workflow-def <name>' assumes that the <name> is
         # the same as the underlying function. Orquestra Studio seems to get it from
         # the 'orq get workflow-def', so for now we have to keep .name attribute same

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -261,22 +261,22 @@ class WorkflowDef(Generic[_R]):
         gpu: Optional[Union[str, _dsl.Sentinel]] = _dsl.Sentinel.NO_UPDATE,
         nodes: Optional[Union[int, _dsl.Sentinel]] = _dsl.Sentinel.NO_UPDATE,
     ) -> "WorkflowDef":
-        """Assigns optional metadata related to task invocation used to generate this
-        artifact.
+        """
+        Assigns optional metadata related to this workflow definition object.
 
-        Doesn't modify existing invocations, returns a new one.
+        Doesn't modify the existing workflow definition, returns a new one.
 
         Example usage:
-            text = capitalize("hello").with_invocation_meta(
-                cpu="1000m",custom_image="zapatacomputing/orquestra-qml:v0.1.0-cuda"
-                )
+            wf_run = my_workflow().with_resources(
+                cpu="10", memory="10Gi"
+            ).run("my_cluster")
 
         Args:
-            cpu: amount of cpu assigned to the task invocation
-            memory: amount of memory assigned to the task invocation
-            disk: amount of disk assigned to the task invocation
-            gpu: amount of gpu assigned to the task invocation
-            custom_image: docker image used to run the task invocation
+            cpu: amount of cpu requested for the workflow
+            memory: amount of memory requested for the workflow
+            disk: amount of disk requested for the workflow
+            gpu: amount of gpu requested for the workflow
+            nodes: the number of nodes requested for the workflow
         """
         # Only use the new properties if they have not been changed.
         # None is a valid option, so we are using the Sentinel object pattern:
@@ -592,6 +592,12 @@ def workflow(
     """Decorator that produces a workflow definition.
 
     Args:
+        resources: !Unstable API! The resources that this workflow requires.
+            The exact behaviour depends on the runtime, based on a Compute Engine
+            workflow, you can set the cluster your workflow will use:
+            10 nodes with 20 CPUs and a GPU each would be:
+            resources=sdk.Resources(cpu="20", gpu="1", nodes=10)
+            If omitted, the cluster's default resources will be used.
         data_aggregation: Used to set up resources used during data step. If skipped,
             or assigned True default values will be used. If assigned False
             data aggregation step will not run.

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -84,7 +84,11 @@ class InvalidTaskDefinitionError(BaseRuntimeError):
 
 
 class NodesInTaskResourcesWarning(Warning):
-    pass
+    """
+    Raised when a "nodes" resource is passed to a Task.
+
+    Nodes currently only apply to workflows and this option will be ignored.
+    """
 
 
 # Workflow Errors

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -83,6 +83,10 @@ class InvalidTaskDefinitionError(BaseRuntimeError):
     pass
 
 
+class NodesInTaskResourcesWarning(Warning):
+    pass
+
+
 # Workflow Errors
 class WorkflowNotFoundError(BaseRuntimeError):
     pass

--- a/src/orquestra/sdk/schema/ir.py
+++ b/src/orquestra/sdk/schema/ir.py
@@ -160,6 +160,9 @@ class Resources(BaseModel):
     memory: t.Optional[str] = None
     disk: t.Optional[str] = None
     gpu: t.Optional[str] = None
+    # nodes should be a positive integer representing the number of nodes assigned
+    # to a workflow. If None, the runtime will choose.
+    # This only applies to workflows and not tasks.
     nodes: t.Optional[int] = None
 
 
@@ -384,4 +387,7 @@ class WorkflowDef(BaseModel):
 
     # Metadata defaults to None to allow older JSON to be loaded
     metadata: t.Optional[WorkflowMetadata] = None
+
+    # The resources that are available for the workflow to use.
+    # If none, the runtime will decide.
     resources: t.Optional[Resources] = None

--- a/src/orquestra/sdk/schema/ir.py
+++ b/src/orquestra/sdk/schema/ir.py
@@ -160,6 +160,7 @@ class Resources(BaseModel):
     memory: t.Optional[str] = None
     disk: t.Optional[str] = None
     gpu: t.Optional[str] = None
+    nodes: t.Optional[int] = None
 
 
 class DataAggregation(BaseModel):
@@ -383,3 +384,4 @@ class WorkflowDef(BaseModel):
 
     # Metadata defaults to None to allow older JSON to be loaded
     metadata: t.Optional[WorkflowMetadata] = None
+    resources: t.Optional[Resources] = None

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -116,7 +116,8 @@ class TestCreateWorkflowRun:
         # Then
         mocked_client.create_workflow_def.assert_called_once_with(my_workflow.model)
         mocked_client.create_workflow_run.assert_called_once_with(
-            workflow_def_id, _models.Resources(cpu=None, memory=None, gpu=None)
+            workflow_def_id,
+            _models.Resources(cpu=None, memory=None, gpu=None, nodes=None),
         )
         assert isinstance(wf_run_id, WorkflowRunId)
         assert (
@@ -142,7 +143,8 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id, _models.Resources(cpu=None, memory="10Gi", gpu=None)
+                workflow_def_id,
+                _models.Resources(cpu=None, memory="10Gi", gpu=None, nodes=None),
             )
 
         def test_with_cpu(
@@ -163,7 +165,8 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id, _models.Resources(cpu="1000m", memory=None, gpu=None)
+                workflow_def_id,
+                _models.Resources(cpu="1000m", memory=None, gpu=None, nodes=None),
             )
 
         def test_with_gpu(
@@ -184,7 +187,8 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id, _models.Resources(cpu=None, memory=None, gpu="1")
+                workflow_def_id,
+                _models.Resources(cpu=None, memory=None, gpu="1", nodes=None),
             )
 
         def test_maximum_resource(
@@ -203,7 +207,32 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id, _models.Resources(cpu="5000m", memory="3G", gpu="1")
+                workflow_def_id,
+                _models.Resources(cpu="5000m", memory="3G", gpu="1", nodes=None),
+            )
+
+        def test_resources_from_workflow(
+            self,
+            mocked_client: MagicMock,
+            runtime: _ce_runtime.CERuntime,
+            workflow_def_id: str,
+            workflow_run_id: str,
+        ):
+            # Given
+            mocked_client.create_workflow_def.return_value = workflow_def_id
+            mocked_client.create_workflow_run.return_value = workflow_run_id
+
+            # When
+            _ = runtime.create_workflow_run(
+                my_workflow()
+                .with_resources(cpu="1", memory="1.5G", gpu="1", nodes=20)
+                .model
+            )
+
+            # Then
+            mocked_client.create_workflow_run.assert_called_once_with(
+                workflow_def_id,
+                _models.Resources(cpu="1", memory="1.5G", gpu="1", nodes=20),
             )
 
     class TestWorkflowDefFailure:

--- a/tests/sdk/v2/test_artifact_future_methods.py
+++ b/tests/sdk/v2/test_artifact_future_methods.py
@@ -12,21 +12,47 @@ from orquestra.sdk import exceptions
 from orquestra.sdk._base import _workflow
 from orquestra.sdk._base._dsl import DEFAULT_IMAGE, ArtifactFuture
 
-resources_no_default = {
+_TaskResourcesArgs = t.TypedDict(
+    "_TaskResourcesArgs",
+    {
+        "cpu": t.Optional[str],
+        "memory": t.Optional[str],
+        "disk": t.Optional[str],
+        "gpu": t.Optional[str],
+    },
+    total=False,
+)
+
+
+TASK_RESOURCES_ARGS: _TaskResourcesArgs = {
     "cpu": "2000m",
     "memory": "100Gi",
     "disk": "99Gi",
     "gpu": "1",
 }
 
-custom_image_no_default = {
+TASK_RESOURCES_EXPECTED = {
+    "cpu": "2000m",
+    "memory": "100Gi",
+    "disk": "99Gi",
+    "gpu": "1",
+    "nodes": None,
+}
+
+CUSTOM_IMAGE_NOT_DEFAULT = {
     "custom_image": "zapatacomputing/orquestra-not-default",
 }
 
-metadata_no_default = {**resources_no_default, **custom_image_no_default}
+CUSTOM_METADATA = {
+    "cpu": "2000m",
+    "memory": "100Gi",
+    "disk": "99Gi",
+    "gpu": "1",
+    "custom_image": "zapatacomputing/orquestra-not-default",
+}
 
 
-@sdk.task(resources=sdk.Resources(**resources_no_default))
+@sdk.task(resources=sdk.Resources(**TASK_RESOURCES_ARGS))
 def _resourced_task(ii: int = 0) -> int:
     return ii
 
@@ -40,7 +66,7 @@ class ObjWithTask:
     def __init__(self, ii: int = 0) -> None:
         self._ii = ii
 
-    @sdk.task(resources=sdk.Resources(**resources_no_default))
+    @sdk.task(resources=sdk.Resources(**TASK_RESOURCES_ARGS))
     def get_id(
         self,
     ) -> int:
@@ -48,7 +74,7 @@ class ObjWithTask:
 
 
 def get_task(ind: bool = True):
-    @sdk.task(resources=sdk.Resources(**resources_no_default))
+    @sdk.task(resources=sdk.Resources(**TASK_RESOURCES_ARGS))
     def task_get_number(number: int = 0):
         return number
 
@@ -63,28 +89,30 @@ def two_ouputs_task():
 @sdk.workflow
 def wf_assign_resources_to_deconstructed_task_invocation():
     result1, result2 = two_ouputs_task()
-    result1.with_resources(cpu=resources_no_default["cpu"])
+    result1.with_resources(cpu=TASK_RESOURCES_ARGS["cpu"])
     return [result1, result2]
 
 
 @sdk.workflow
 def wf_deconstruc_task_invocation_with_resources_assignment():
     result = two_ouputs_task()
-    result1, result2 = result.with_resources(cpu=resources_no_default["cpu"])
+    result1, result2 = result.with_resources(cpu=TASK_RESOURCES_ARGS["cpu"])
     return [result1, result2]
 
 
 @sdk.workflow
 def wf_assign_custom_image_to_deconstructed_task_invocation():
     result1, result2 = two_ouputs_task()
-    result1.with_custom_image(custom_image_no_default["custom_image"])
+    result1.with_custom_image(CUSTOM_IMAGE_NOT_DEFAULT["custom_image"])
     return [result1, result2]
 
 
 @sdk.workflow
 def wf_deconstruc_task_invocation_with_custom_image_assignment():
     result = two_ouputs_task()
-    result1, result2 = result.with_custom_image(custom_image_no_default["custom_image"])
+    result1, result2 = result.with_custom_image(
+        CUSTOM_IMAGE_NOT_DEFAULT["custom_image"]
+    )
     return [result1, result2]
 
 
@@ -92,8 +120,8 @@ def wf_deconstruc_task_invocation_with_custom_image_assignment():
 def wf_assign_metadata_to_deconstructed_task_invocation():
     result1, result2 = two_ouputs_task()
     result1.with_invocation_meta(
-        custom_image=custom_image_no_default["custom_image"],
-        gpu=resources_no_default["gpu"],
+        custom_image=CUSTOM_IMAGE_NOT_DEFAULT["custom_image"],
+        gpu=TASK_RESOURCES_ARGS["gpu"],
     )
     return [result1, result2]
 
@@ -102,8 +130,8 @@ def wf_assign_metadata_to_deconstructed_task_invocation():
 def wf_deconstruc_task_invocation_with_metadata_assignment():
     result = two_ouputs_task()
     result1, result2 = result.with_invocation_meta(
-        custom_image=custom_image_no_default["custom_image"],
-        gpu=resources_no_default["gpu"],
+        custom_image=CUSTOM_IMAGE_NOT_DEFAULT["custom_image"],
+        gpu=TASK_RESOURCES_ARGS["gpu"],
     )
     return [result1, result2]
 
@@ -117,7 +145,7 @@ def wf_task_call():
 def wf_with_resources_call():
     future = _task_without_resources()
     assert isinstance(future, ArtifactFuture)
-    new_future = future.with_resources(**resources_no_default)
+    new_future = future.with_resources(**TASK_RESOURCES_ARGS)
     return [future, new_future]
 
 
@@ -125,7 +153,7 @@ def wf_with_resources_call():
 def wf_with_custom_image_call():
     future = _task_without_resources()
     assert isinstance(future, ArtifactFuture)
-    new_future = future.with_custom_image(custom_image_no_default["custom_image"])
+    new_future = future.with_custom_image(CUSTOM_IMAGE_NOT_DEFAULT["custom_image"])
     return [future, new_future]
 
 
@@ -133,7 +161,7 @@ def wf_with_custom_image_call():
 def wf_with_invocation_meta_call():
     future = _task_without_resources()
     assert isinstance(future, ArtifactFuture)
-    new_future = future.with_invocation_meta(**metadata_no_default)
+    new_future = future.with_invocation_meta(**CUSTOM_METADATA)
     return [future, new_future]
 
 
@@ -141,8 +169,8 @@ def wf_with_invocation_meta_call():
 def wf_with_resources_and_custom_image_call():
     future = _task_without_resources()
     assert isinstance(future, ArtifactFuture)
-    new_future = future.with_resources(**resources_no_default).with_custom_image(
-        **custom_image_no_default
+    new_future = future.with_resources(**TASK_RESOURCES_ARGS).with_custom_image(
+        **CUSTOM_IMAGE_NOT_DEFAULT
     )
     return [future, new_future]
 
@@ -160,7 +188,7 @@ def wf_with_method_task():
 def wf_with_mixed_calls():
     simple_obj = ObjWithTask(13)
     simple_obj.get_id()
-    return _task_without_resources().with_invocation_meta(**metadata_no_default)
+    return _task_without_resources().with_invocation_meta(**CUSTOM_METADATA)
 
 
 class TestArifactFutureMethodsCalls:
@@ -290,8 +318,8 @@ class TestArifactFutureMethodsCalls:
         assert len(set(invocation.task_id for invocation in invocations)) == 1
 
         assert invocations[0].resources is not None
-        assert invocations[0].resources.dict() == resources_no_default
-        assert invocations[0].custom_image == custom_image_no_default["custom_image"]
+        assert invocations[0].resources.dict() == TASK_RESOURCES_EXPECTED
+        assert invocations[0].custom_image == CUSTOM_IMAGE_NOT_DEFAULT["custom_image"]
 
         assert invocations[1].resources is None
         assert invocations[1].custom_image is DEFAULT_IMAGE
@@ -310,7 +338,7 @@ class TestArifactFutureMethodsCalls:
         invocations = [*wf_model.task_invocations.values()]
         assert len(set(invocation.task_id for invocation in invocations)) == 1
         assert invocations[0].resources is not None
-        assert invocations[0].resources.dict() == resources_no_default
+        assert invocations[0].resources.dict() == TASK_RESOURCES_EXPECTED
 
         assert invocations[1].resources is None
         assert invocations[1].custom_image == invocations[0].custom_image
@@ -328,7 +356,7 @@ class TestArifactFutureMethodsCalls:
 
         invocations = [*wf_model.task_invocations.values()]
         assert len(set(invocation.task_id for invocation in invocations)) == 1
-        assert invocations[0].custom_image == custom_image_no_default["custom_image"]
+        assert invocations[0].custom_image == CUSTOM_IMAGE_NOT_DEFAULT["custom_image"]
 
         assert invocations[1].resources == invocations[0].resources
         assert invocations[1].custom_image == DEFAULT_IMAGE
@@ -347,8 +375,8 @@ class TestArifactFutureMethodsCalls:
         invocations = [*wf_model.task_invocations.values()]
         assert len(set(invocation.task_id for invocation in invocations)) == 1
         assert invocations[0].resources is not None
-        assert invocations[0].resources.dict() == resources_no_default
-        assert invocations[0].custom_image == custom_image_no_default["custom_image"]
+        assert invocations[0].resources.dict() == TASK_RESOURCES_EXPECTED
+        assert invocations[0].custom_image == CUSTOM_IMAGE_NOT_DEFAULT["custom_image"]
 
         assert invocations[1].resources is None
         assert invocations[1].custom_image is DEFAULT_IMAGE

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -1136,3 +1136,16 @@ def test_metadata_on_dev(monkeypatch: pytest.MonkeyPatch):
     assert wf.metadata.sdk_version.minor == 42
     assert wf.metadata.sdk_version.patch == 0
     assert wf.metadata.sdk_version.is_prerelease
+
+
+def test_warning_when_nodes_passed_to_task():
+    @_dsl.task(resources=_dsl.Resources(nodes=100))
+    def _task():
+        return
+
+    @_workflow.workflow
+    def _wf():
+        return _task()
+
+    with pytest.warns(exceptions.NodesInTaskResourcesWarning):
+        _ = _wf().model


### PR DESCRIPTION
# The problem

We want folks to be able to choose the resources when running workflows on CE.

# This PR's solution

* Adds `resources` to the `@workflow` decorator.
* Adds a `.with_resources()` method to `WorkflowDef` to override resources.
* Adds `resources` to `WorkflowDef` IR model.
* Adds `CERuntime` support for workflow resources.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
