### PR TITLE
fix: Allow single import as dependency_imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Workflow definitions now require at least one task in order to be submitted. This check is performed during traversal, and raises a WorkflowSyntaxError if no tasks are required to be executed.
 - Remove TaskDef.model and TaskDef.import_models interfaces
+- Public API classes `sdk.GitImport`, `sdk.GithubImport`, `sdk.LocalImport`, `sdk.InlineImport` now use `dataclasses.dataclass` instead of `typing.NamedTuple`.
 
 🔥 *Features*
 - Sort WF runs by start date in `list wf` command. Show start date as one of the columns
@@ -14,6 +15,7 @@
 - New parameters for `@workflow` decorator - `default_source_import` and `default_dependency_imports`.
 These parameters let you set the default imports for all tasks in given workflow.
 If a task defines its own imports (either source, dependencies, or both) - it will overwrite workflow defaults.
+- Allow single imports as `dependency_imports` in `@task` decorators.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -11,7 +11,7 @@ import re
 import traceback
 import warnings
 from collections import OrderedDict
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from string import Formatter

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -11,6 +11,7 @@ import re
 import traceback
 import warnings
 from collections import OrderedDict
+from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
 from string import Formatter
@@ -39,8 +40,6 @@ if TYPE_CHECKING:
     import pip_api
 
 import wrapt  # type: ignore
-
-import orquestra.sdk.schema.ir as ir
 
 from ..exceptions import DirtyGitRepo, InvalidTaskDefinitionError, WorkflowSyntaxError
 from . import _ast
@@ -85,7 +84,8 @@ class Secret(NamedTuple):
     config_name: Optional[str] = None
 
 
-class GitImportWithAuth(NamedTuple):
+@dataclass(frozen=True, eq=True)
+class GitImportWithAuth:
     """
     A task import that uses a private Git repo
 
@@ -98,7 +98,8 @@ class GitImportWithAuth(NamedTuple):
     auth_secret: Optional[Secret]
 
 
-class GitImport(NamedTuple):
+@dataclass(frozen=True, eq=True)
+class GitImport:
     """A task import that uses a Git repository"""
 
     repo_url: str
@@ -199,11 +200,12 @@ class PythonImports:
         # Path to a `requirements.txt` file
         file: Optional[str] = None,
     ):
-        self.use_file_path = False
+        self._file: Optional[Path]
         if file is not None:
-            self.file = pathlib.Path(file)
-            self.use_file_path = True
-        self.packages = packages
+            self._file = pathlib.Path(file)
+        else:
+            self._file = None
+        self._packages = packages
 
     def resolved(self) -> List[pip_api.Requirement]:
         import pip_api
@@ -211,14 +213,14 @@ class PythonImports:
         # on Windows file cannot be reopened when it's opened with delete=True
         # So the temp file is closed first and then deleted manually.
         tmp_file = NamedTemporaryFile(mode="w+", delete=False)
-        if self.use_file_path:
+        if self._file is not None:
             # gather all requirements from file
-            with open(self.file) as file:
+            with open(self._file) as file:
                 lines = file.readlines()
             for line in lines:
                 tmp_file.write(line)
         # gather all requirements passed by the user
-        for package in self.packages:
+        for package in self._packages:
             tmp_file.write(f"{package}\n")
         tmp_file.flush()
         tmp_file.close()
@@ -235,8 +237,18 @@ class PythonImports:
             req for req in requirements.values() if isinstance(req, pip_api.Requirement)
         ]
 
+    def __eq__(self, other):
+        if not isinstance(other, PythonImports):
+            return False
 
-class LocalImport(NamedTuple):
+        return self._file == other._file and self._packages == other._packages
+
+    def __hash__(self):
+        return hash((self._file, self._packages))
+
+
+@dataclass(frozen=True, eq=True)
+class LocalImport:
     """Used to specify that the source code is only available locally.
     e.g. not committed to any git repo or in a Python package
     """
@@ -244,7 +256,8 @@ class LocalImport(NamedTuple):
     module: str
 
 
-class InlineImport(NamedTuple):
+@dataclass(frozen=True, eq=True)
+class InlineImport:
     """
     A task import that stores the function "inline" with the workflow definition.
     """
@@ -252,6 +265,17 @@ class InlineImport(NamedTuple):
     pass
 
 
+# If updating this list, you must also update the Import type.
+# These are both here to more easily support isinstance(obj, Import)
+# Python 3.10 fixes this by allowing Unions in isinstance checks
+ImportTypes = (
+    LocalImport,
+    GitImport,
+    GitImportWithAuth,
+    DeferredGitImport,
+    PythonImports,
+    InlineImport,
+)
 Import = Union[
     LocalImport,
     GitImport,
@@ -922,7 +946,7 @@ def task(fn: Callable[_P, _R]) -> TaskDef[_P, _R]:
 def task(
     *,
     source_import: Optional[Import] = None,
-    dependency_imports: Optional[Iterable[Import]] = None,
+    dependency_imports: Union[Iterable[Import], Import, None] = None,
     resources: Resources = Resources(),
     n_outputs: Optional[int] = None,
     custom_image: Optional[str] = None,
@@ -936,7 +960,7 @@ def task(
     fn: Callable[_P, _R],
     *,
     source_import: Optional[Import] = None,
-    dependency_imports: Optional[Iterable[Import]] = None,
+    dependency_imports: Union[Iterable[Import], Import, None] = None,
     resources: Resources = Resources(),
     n_outputs: Optional[int] = None,
     custom_image: Optional[str] = None,
@@ -949,7 +973,7 @@ def task(
     fn: Optional[Callable[_P, _R]] = None,
     *,
     source_import: Optional[Import] = None,
-    dependency_imports: Optional[Iterable[Import]] = None,
+    dependency_imports: Union[Iterable[Import], Import, None] = None,
     resources: Resources = Resources(),
     n_outputs: Optional[int] = None,
     custom_image: Optional[str] = None,
@@ -982,9 +1006,14 @@ def task(
             every char that is non-alphanumeric will be changed to dash ("-").
             Also only first 128 characters of the name will be used
     """
-    task_dependency_imports: Optional[Tuple[Import, ...]] = (
-        tuple(dependency_imports) if dependency_imports else None
-    )
+    task_dependency_imports: Optional[Tuple[Import, ...]]
+
+    if dependency_imports is None:
+        task_dependency_imports = None
+    elif isinstance(dependency_imports, ImportTypes):
+        task_dependency_imports = (dependency_imports,)
+    elif dependency_imports is not None:
+        task_dependency_imports = tuple(dependency_imports)
 
     if n_outputs is not None:
         if n_outputs <= 0:

--- a/tests/sdk/v2/test_packaging.py
+++ b/tests/sdk/v2/test_packaging.py
@@ -42,8 +42,8 @@ class TestInstalledImport:
         imp = packaging.InstalledImport(package_name="some-package")
         # Then
         assert isinstance(imp, sdk.PythonImports)
-        assert len(imp.packages) == 1
-        assert imp.packages[0] == "some-package==1.2.3"
+        assert len(imp._packages) == 1
+        assert imp._packages[0] == "some-package==1.2.3"
 
     @staticmethod
     def test_package_not_found(monkeypatch):
@@ -78,8 +78,8 @@ class TestInstalledImport:
         )
         # Then
         assert isinstance(imp, sdk.PythonImports)
-        assert len(imp.packages) == 1
-        assert imp.packages[0] == "some-package==1.2.3"
+        assert len(imp._packages) == 1
+        assert imp._packages[0] == "some-package==1.2.3"
 
     @staticmethod
     def test_package_version_does_not_match(monkeypatch):


### PR DESCRIPTION
# The problem

Some folks would like to pass a single import to `dependency_imports`.
Currently, this would cause an issue with `NamedTuple` objects.

# This PR's solution

* Allows passing a single import to `@task`'s `dependency_imports`.
* Switches out imports from using `NamedTuple` to using `dataclass` to prevent `Iterable`/`NamedTuple` issues in the future.
* Makes `PythonImports` comparable with `==`.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
