### PR TITLE
improvement: read old IRs + raise warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ def my_wf():
 
 
 💅 *Improvements*
+* `VersionMismatch` warning will be presented if we detect accessing a workflow def IR generated with another SDK version.
 
 
 🥷 *Internal*

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -10,3 +10,4 @@ Guides
     runtime-configuration
     workflow-syntax
     dependency-installation
+    version-compatibility

--- a/docs/guides/version-compatibility.rst
+++ b/docs/guides/version-compatibility.rst
@@ -7,17 +7,18 @@ This guide covers the details behind the warning::
     VersionMismatch: Attempting to read a workflow definition generated with a different version of Orquestra Workflow SDK. Please consider re-running your workflow or installing 'orquestra-sdk==...'.
 
 
-Client-Server Coupling
-======================
+Workflow Version Coupling
+=========================
 
-When you're running workflows remotely, you have a local version of Orquestra Workflow SDK on your local machine or the Jupyter environment in Orquestra Portal.
-An Intermediate Representation (IR) is generated from your ``@workflow``-decorated function and sent over the wire to the remote runtime.
+When you write a workflow, the Orquestra Workflow SDK generates an Intermediate Representation (IR) from your ``@workflow``-decorated function.
+When you "run" the workflow, this IR is sent to a runtime for execution.
+Inside the IR, we store the version of the Workflow SDK that generated it.
 
-The remote runtime also comes with its own installation of the Workflow SDK to interpret the workflow IR, execute tasks, and store results.
-The Workflow SDK version installed on the server side is selected to match the client's one.
+When executing the workflow remotely, the remote runtime reads the Workflow SDK version from the IR and uses the same version to interpret the IR, execute tasks, and store results.
+Once a workflow run has been started, you will query its status, peek into its graph of task runs, or access the data it produced.
 
-Finally, you're likely to interact with the workflow run to query its status, peek into the graph of task runs, or access the data they produced.
-This interaction can happen a long time after the workflow was originally executed; the workflow data lives longer than the Workflow SDK code that produced it.
+Sometimes these interactions can happen a long time after the workflow was originally executed; the workflow data lives longer than the Workflow SDK version that produced it.
+In the meantime, the internals of the Workflow SDK may have changed resulting in unexpected behavior.
 
 Recommended Usage
 =================

--- a/docs/guides/version-compatibility.rst
+++ b/docs/guides/version-compatibility.rst
@@ -1,0 +1,44 @@
+=====================
+Version Compatibility
+=====================
+
+This guide covers the details behind the warning::
+
+    VersionMismatch: Attempting to read a workflow definition generated with a different version of Orquestra Workflow SDK. Please consider re-running your workflow or installing 'orquestra-sdk==...'.
+
+
+Client-Server Coupling
+======================
+
+When you're running workflows remotely, you have a local version of Orquestra Workflow SDK on your local machine or the Jupyter environment in Orquestra Portal.
+An Intermediate Representation (IR) is generated from your ``@workflow``-decorated function and sent over the wire to the remote runtime.
+
+The remote runtime also comes with its own installation of the Workflow SDK to interpret the workflow IR, execute tasks, and store results.
+The Workflow SDK version installed on the server side is selected to match the client's one.
+
+Finally, you're likely to interact with the workflow run to query its status, peek into the graph of task runs, or access the data they produced.
+This interaction can happen a long time after the workflow was originally executed; the workflow data lives longer than the Workflow SDK code that produced it.
+
+Recommended Usage
+=================
+
+We do our best to maintain backwards compatibility.
+However, we constantly develop new features and implement bug fixes which change how the Workflow SDK works internally.
+Sometimes it's difficult to predict all consequences, especially across multiple library versions.
+When consuming results of a workflow run it's best to use a version of the Workflow SDK that matches the one used to submit and run the workflow.
+
+Why It's Only a Warning
+=======================
+
+Whenever we detect a SemVer mismatch between the resources we read and the currently installed library version we emit a warning about version mismatch.
+Orquestra Workflow SDK is still in the ``v0.x.x`` stage, so according to the `SemVer rules <https://semver.org/#spec-item-4>`_ every release is breaking.
+As a result, anytime you upgrade your local ``orquestra-sdk`` you're likely to see the ``VersionMismatch`` warning when interacting with previously submitted workflow runs.
+
+Example Failure Scenarios
+=========================
+
+#. To fix a bug in IR generation we've had to change the representation of the task outputs in the workflow graph.
+   After upgrading ``orquestra-sdk``, ``orq task results``/``task_run.get_outputs()`` or ``orq wf results``/``wf_run.get_results()`` show invalid values of the computed artifacts.
+
+#. We've changed the place of artifact serialization to better handle returning values coming from 3rd-party libraries.
+   After upgrading ``orquestra-sdk``, ``orq task results``/``task_run.get_outputs()`` or ``orq wf results``/``wf_run.get_results()`` show serialized byte strings instead of plain artifact values.

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -23,6 +23,7 @@ from orquestra.sdk._base import _config, _db, loader
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._qe import _client
 from orquestra.sdk._base.abc import ArtifactValue
+from orquestra.sdk.schema import _compat
 from orquestra.sdk.schema.configs import ConfigName, RuntimeName
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
 from orquestra.sdk.schema.workflow_run import (
@@ -245,7 +246,7 @@ class WorkflowRunRepo:
         invocation = wf_def.task_invocations[task_inv_id]
         task_def = wf_def.tasks[invocation.task_id]
 
-        if task_def.output_metadata.is_subscriptable:
+        if _compat.result_is_packed(task_def=task_def):
             # We expect ``task_outputs`` to be an iterable already.
             outputs_tuple = tuple(task_outputs)
         else:

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -10,7 +10,7 @@ from .. import exceptions, secrets
 from .._base import _exec_ctx, _git_url_utils, _graphs, _log_adapter, dispatch, serde
 from .._base._env import RAY_DOWNLOAD_GIT_IMPORTS_ENV, RAY_SET_TASK_RESOURCES_ENV
 from ..kubernetes.quantity import parse_quantity
-from ..schema import ir, responses, workflow_run
+from ..schema import _compat, ir, responses, workflow_run
 from . import _client, _id_gen
 from ._client import RayClient
 from ._wf_metadata import InvUserMetadata, pydatic_to_json_dict
@@ -376,7 +376,7 @@ def make_ray_dag(
             ray_kwargs=kwargs,
             args_artifact_nodes=pos_args_artifact_nodes,
             kwargs_artifact_nodes=kwargs_artifact_nodes,
-            n_outputs=user_task.output_metadata.n_outputs,
+            n_outputs=_compat.n_outputs(task_def=user_task, task_inv=invocation),
             project_dir=project_dir,
             user_fn_ref=user_task.fn_ref,
         )

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -3,7 +3,7 @@
 ################################################################################
 import typing as t
 
-from orquestra.sdk.schema.ir import TaskInvocationId
+from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.workflow_run import State
 
 
@@ -11,6 +11,13 @@ class WorkflowSyntaxError(Exception):
     def __init__(self, msg: str):
         super().__init__(msg)
         self.msg = msg
+
+
+class VersionMismatch(Warning):
+    def __init__(self, msg: str, actual: ir.Version, needed: t.Optional[ir.Version]):
+        super().__init__(msg)
+        self.actual = actual
+        self.needed = needed
 
 
 class DirtyGitRepo(Warning):
@@ -133,7 +140,7 @@ class TaskInvocationNotFoundError(NotFoundError):
     Raised when we can't find a Task Invocation that matches the provided ID.
     """
 
-    def __init__(self, invocation_id: TaskInvocationId):
+    def __init__(self, invocation_id: ir.TaskInvocationId):
         super().__init__()
         self.invocation_id = invocation_id
 

--- a/src/orquestra/sdk/packaging/_versions.py
+++ b/src/orquestra/sdk/packaging/_versions.py
@@ -45,16 +45,20 @@ def get_installed_version(package_name: str) -> str:
         raise PackagingError(f"Package not found: {package_name}") from e
 
 
-def get_installed_version_model(package_name: str) -> ir.Version:
-    sdk_version_str = get_installed_version(package_name)
-    parsed_sdk_version = packaging.version.parse(sdk_version_str)
+def parse_version_str(version_str: str) -> ir.Version:
+    parsed_sdk_version = packaging.version.parse(version_str)
     return ir.Version(
-        original=sdk_version_str,
+        original=version_str,
         major=parsed_sdk_version.major,
         minor=parsed_sdk_version.minor,
         patch=parsed_sdk_version.micro,
         is_prerelease=parsed_sdk_version.is_prerelease,
     )
+
+
+def get_installed_version_model(package_name: str) -> ir.Version:
+    sdk_version_str = get_installed_version(package_name)
+    return parse_version_str(sdk_version_str)
 
 
 def get_current_sdk_version() -> ir.Version:

--- a/src/orquestra/sdk/schema/_compat.py
+++ b/src/orquestra/sdk/schema/_compat.py
@@ -1,0 +1,36 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Backwards-compatibility layer for accessing models generated with previous SDK versions.
+"""
+from . import ir
+
+
+def n_outputs(task_def: ir.TaskDef, task_inv: ir.TaskInvocation) -> int:
+    """
+    Figures out number of task invocation outputs.
+
+    Nowadays, we base this information on the task definition's metadata. With
+    orquestra-sdk<=0.45.1 we relied on the task invocation.
+    """
+    if (meta := task_def.output_metadata) is not None:
+        return meta.n_outputs
+    else:
+        return len(task_inv.output_ids)
+
+
+def result_is_packed(task_def: ir.TaskDef) -> bool:
+    """
+    Tasks can return one or multiple values. We call multi-valued result "packed"
+    because it can be unpacked in the workflow function.
+
+    Nowadays, we base this information on the task definition's metadata. With
+    orquestra-sdk<=0.45.1 the behavior was unreliable.
+    """
+    if (meta := task_def.output_metadata) is not None:
+        return meta.is_subscriptable
+    else:
+        # We can't be sure. It's safer to assume the output is a single value so we
+        # don't attempt to subscript it.
+        return False

--- a/src/orquestra/sdk/schema/_compat.py
+++ b/src/orquestra/sdk/schema/_compat.py
@@ -34,3 +34,21 @@ def result_is_packed(task_def: ir.TaskDef) -> bool:
         # We can't be sure. It's safer to assume the output is a single value so we
         # don't attempt to subscript it.
         return False
+
+
+def versions_are_compatible(generated_at: ir.Version, current: ir.Version) -> bool:
+    """
+    Checks if we can assume that we're okay with consuming the given IR.
+
+    Args:
+        generated_at: version of the Workflow SDK used to generate the IR.
+        current: currently installed version of the Workflow SDK
+    """
+    if current.major == 0:
+        # For v0 we require exact match.
+        return generated_at == current
+
+    if generated_at.major != current.major:
+        return False
+
+    return generated_at.minor <= current.minor

--- a/src/orquestra/sdk/schema/ir.py
+++ b/src/orquestra/sdk/schema/ir.py
@@ -423,6 +423,7 @@ class WorkflowDef(BaseModel):
         # Workaround for circular imports
         from orquestra.sdk import exceptions
         from orquestra.sdk.packaging import _versions
+        from orquestra.sdk.schema import _compat
 
         current_version = _versions.get_current_sdk_version()
 
@@ -440,7 +441,9 @@ class WorkflowDef(BaseModel):
             )
             return v
 
-        if v.sdk_version != current_version:
+        if not _compat.versions_are_compatible(
+            generated_at=v.sdk_version, current=current_version
+        ):
             warnings.warn(
                 exceptions.VersionMismatch(
                     (

--- a/src/orquestra/sdk/schema/ir.py
+++ b/src/orquestra/sdk/schema/ir.py
@@ -433,7 +433,8 @@ class WorkflowDef(BaseModel):
                     (
                         "Attempting to read a workflow definition generated with an "
                         "old version of Orquestra Workflow SDK. Please consider "
-                        "re-running your workflow or downgrading orquestra-sdk."
+                        "re-running your workflow or downgrading orquestra-sdk. "
+                        "For more information visit: https://docs.orquestra.io/docs/core/sdk/guides/version-compatibility.html"  # noqa: E501
                     ),
                     actual=current_version,
                     needed=None,
@@ -450,7 +451,8 @@ class WorkflowDef(BaseModel):
                         "Attempting to read a workflow definition generated with a "
                         "different version of Orquestra Workflow SDK. "
                         "Please consider re-running your workflow or installing "
-                        f"'orquestra-sdk=={v.sdk_version.original}'"
+                        f"'orquestra-sdk=={v.sdk_version.original}'. "
+                        "For more information visit: https://docs.orquestra.io/docs/core/sdk/guides/version-compatibility.html"  # noqa: E501
                     ),
                     actual=current_version,
                     needed=v.sdk_version,

--- a/tests/runtime/corq/test_format.py
+++ b/tests/runtime/corq/test_format.py
@@ -136,6 +136,7 @@ class TestPrettyPrintResponse:
                 ),
             ],
         )
+        @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
         def test_matches_recorded_output(
             capsys, resp_cls, resp_path: Path, recorded_output_path: Path
         ):

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -595,6 +595,10 @@ def test_run_and_get_output(
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class Test3rdPartyLibraries:
     @staticmethod
+    # We're reading a serialized workflow def. The SDK version inside that JSON is
+    # likely to be different from the one we're using for development. The SDK shows a
+    # warning when deserializing a workflow def like this.
+    @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
     def test_constants_and_inline_imports(runtime: _dag.RayRuntime):
         """
         This test uses already generated workflow def from json file. If necessary, it

--- a/tests/sdk/v2/conversions/test_yaml_exporter.py
+++ b/tests/sdk/v2/conversions/test_yaml_exporter.py
@@ -1017,6 +1017,7 @@ class TestWorkflowToYAML:
             (_make_python_requirements, DATA_PATH / "python_import.yml"),
         ],
     )
+    @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
     def test_matches_ref_file(self, override_semver, workflow, ref_yaml_path):
         wf_model = workflow()
         with ref_yaml_path.open() as f:
@@ -1032,6 +1033,7 @@ class TestWorkflowToYAML:
             _make_workflow_with_pickled_args,
         ],
     )
+    @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
     def test_for_pickled_constants(self, override_semver, workflow):
         """
         This method check if is possible to create the yaml representation of a workflow
@@ -1102,6 +1104,7 @@ def _make_override_workflow():
     )
 
 
+@pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
 def test_workflow_to_yaml_override_git_ref():
     workflow = _make_override_workflow()
     ref_yaml_path = DATA_PATH / "basics.yml"
@@ -1145,6 +1148,7 @@ def test_real_wf_to_yaml(monkeypatch, wf_def, yaml_path):
     assert _model_dict(yaml_converter.workflow_to_yaml(workflow)) == ref_yaml_contents
 
 
+@pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
 def test_main(override_semver, monkeypatch, capsys):
     with (DATA_PATH / "main_test.json").open() as json_f:
         monkeypatch.setattr("sys.stdin", json_f)
@@ -1212,6 +1216,7 @@ def _make_plain_workflow():
     )
 
 
+@pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
 def test_workflow_with_invalid_package_version(monkeypatch):
     wf_model = _make_plain_workflow()
     version_mock = Mock(side_effect=_imports.PackageVersionError("mock", "mocked"))

--- a/tests/sdk/v2/schema/data/unpacking.py
+++ b/tests/sdk/v2/schema/data/unpacking.py
@@ -1,6 +1,15 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
+"""
+This script dumps a workflow IR for regression tests. To regenerate the IR:
+1. Pick the SDK version you want to validate. ``pip install orquestra-sdk==<version>``.
+2. Run this file: ``python tests/sdk/v2/schema/data/unpacking.py``.
+3. Commit in the changes in ``unpacking_wf.json``.
+
+Note: the whole purpose of this fixture is to record old IRs. It probably shouldn't be
+regenerated often.
+"""
 from pathlib import Path
 
 from orquestra import sdk
@@ -27,3 +36,14 @@ def unpacking_wf():
     a3, _ = packed3
 
     return b1, packed1, a3
+
+
+def main():
+    wf_def_model = unpacking_wf().model
+
+    target_path = Path(__file__).parent / "unpacking_wf.json"
+    target_path.write_text(wf_def_model.json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sdk/v2/schema/data/unpacking_wf_0.44.0.json
+++ b/tests/sdk/v2/schema/data/unpacking_wf_0.44.0.json
@@ -1,0 +1,153 @@
+{
+  "name": "unpacking_wf",
+  "fn_ref": {
+    "module": "__main__",
+    "function_name": "unpacking_wf",
+    "file_path": "tests/sdk/v2/schema/data/unpacking.py",
+    "line_number": 28,
+    "type": "MODULE_FUNCTION_REF"
+  },
+  "imports": {
+    "inline-import-1": {
+      "id": "inline-import-1",
+      "type": "INLINE_IMPORT"
+    }
+  },
+  "tasks": {
+    "task-two-outputs-7048e77dbb": {
+      "id": "task-two-outputs-7048e77dbb",
+      "fn_ref": {
+        "function_name": "two_outputs",
+        "encoded_function": [
+          "gANjZGlsbC5fZGlsbApfY3JlYXRlX2Z1bmN0aW9uCnEAKGNkaWxsLl9kaWxsCl9jcmVhdGVfY29k\nZQpxAShDAgACcQJLAksASwBLAksDS0NDEHwAZAEXAHwBZAIXAGYCUwBxA05LAUsCh3EEKVgBAAAA\nYXEFWAEAAABicQaGcQdYcAAAAC9Vc2Vycy9hbGV4L0NvZGUvemFwYXRhL2V2YW5nZWxpc20td29y\na2Zsb3dzL3ZlbmRvci9vcnF1ZXN0cmEtd29ya2Zsb3ctc2RrL3Rlc3RzL3Nkay92Mi9zY2hlbWEv\nZGF0YS91bnBhY2tpbmcucHlxCFgLAAAAdHdvX291dHB1dHNxCUsSQwIQAnEKKSl0cQtScQx9cQ1Y\nCAAAAF9fbmFtZV9fcQ5YCAAAAF9fbWFpbl9fcQ9zaAlOTnRxEFJxEX1xEihYFwAAAF9UYXNrRGVm\nX19zZGtfdGFza19ib2R5cRNoEVgGAAAAZm5fcmVmcRRjZGlsbC5fZGlsbApfY3JlYXRlX25hbWVk\ndHVwbGUKcRVYEQAAAElubGluZUZ1bmN0aW9uUmVmcRZYDQAAAGZ1bmN0aW9uX25hbWVxF1gCAAAA\nZm5xGIZxGVgYAAAAb3JxdWVzdHJhLnNkay5fYmFzZS5fZHNscRqHcRtScRxoCWgRhnEdgXEeWA0A\nAABzb3VyY2VfaW1wb3J0cR9oFVgMAAAASW5saW5lSW1wb3J0cSApaBqHcSFScSIpgXEjWA8AAABv\ndXRwdXRfbWV0YWRhdGFxJGgVWBIAAABUYXNrT3V0cHV0TWV0YWRhdGFxJVgQAAAAaXNfc3Vic2Ny\naXB0YWJsZXEmWAkAAABuX291dHB1dHNxJ4ZxKGgah3EpUnEqiEsChnErgXEsWAoAAABwYXJhbWV0\nZXJzcS1jY29sbGVjdGlvbnMKT3JkZXJlZERpY3QKcS4pUnEvKGgFaBVYDQAAAFRhc2tQYXJhbWV0\nZXJxMFgEAAAAbmFtZXExWAQAAABraW5kcTKGcTNoGodxNFJxNWgFY29ycXVlc3RyYS5zZGsuX2Jh\nc2UuX2RzbApQYXJhbWV0ZXJLaW5kCnE2WBUAAABQT1NJVElPTkFMX09SX0tFWVdPUkRxN4VxOFJx\nOYZxOoFxO2gGaDVoBmg5hnE8gXE9dVgSAAAAZGVwZW5kZW5jeV9pbXBvcnRzcT5OWAkAAAByZXNv\ndXJjZXNxP2gVKFgJAAAAUmVzb3VyY2VzcUAoWAMAAABjcHVxQVgGAAAAbWVtb3J5cUJYBAAAAGRp\nc2txQ1gDAAAAZ3B1cUR0cUVoGl1xRihOTk5OZXRxR1JxSChOTk5OdHFJgXFKWAwAAABjdXN0b21f\naW1hZ2VxS1goAAAAemFwYXRhY29tcHV0aW5nL29ycXVlc3RyYS1kZWZhdWx0OnYwLjAuMHFMWAsA\nAABjdXN0b21fbmFtZXFNTnV9cU5YDwAAAF9fYW5ub3RhdGlvbnNfX3FPfXFQc4ZxUWIu\n"
+        ],
+        "type": "INLINE_FUNCTION_REF"
+      },
+      "parameters": [
+        {
+          "name": "a",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        },
+        {
+          "name": "b",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        }
+      ],
+      "source_import_id": "inline-import-1",
+      "dependency_import_ids": null,
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    },
+    "task-single-output-5e628fa21b": {
+      "id": "task-single-output-5e628fa21b",
+      "fn_ref": {
+        "function_name": "single_output",
+        "encoded_function": [
+          "gANjZGlsbC5fZGlsbApfY3JlYXRlX2Z1bmN0aW9uCnEAKGNkaWxsLl9kaWxsCl9jcmVhdGVfY29k\nZQpxAShDAgACcQJLAUsASwBLAUsCS0NDCHwAZAEXAFMAcQNOSwOGcQQpWAEAAABhcQWFcQZYcAAA\nAC9Vc2Vycy9hbGV4L0NvZGUvemFwYXRhL2V2YW5nZWxpc20td29ya2Zsb3dzL3ZlbmRvci9vcnF1\nZXN0cmEtd29ya2Zsb3ctc2RrL3Rlc3RzL3Nkay92Mi9zY2hlbWEvZGF0YS91bnBhY2tpbmcucHlx\nB1gNAAAAc2luZ2xlX291dHB1dHEISxdDAggCcQkpKXRxClJxC31xDFgIAAAAX19uYW1lX19xDVgI\nAAAAX19tYWluX19xDnNoCE5OdHEPUnEQfXERKFgXAAAAX1Rhc2tEZWZfX3Nka190YXNrX2JvZHlx\nEmgQWAYAAABmbl9yZWZxE2NkaWxsLl9kaWxsCl9jcmVhdGVfbmFtZWR0dXBsZQpxFFgRAAAASW5s\naW5lRnVuY3Rpb25SZWZxFVgNAAAAZnVuY3Rpb25fbmFtZXEWWAIAAABmbnEXhnEYWBgAAABvcnF1\nZXN0cmEuc2RrLl9iYXNlLl9kc2xxGYdxGlJxG2gIaBCGcRyBcR1YDQAAAHNvdXJjZV9pbXBvcnRx\nHmgUWAwAAABJbmxpbmVJbXBvcnRxHyloGYdxIFJxISmBcSJYDwAAAG91dHB1dF9tZXRhZGF0YXEj\naBRYEgAAAFRhc2tPdXRwdXRNZXRhZGF0YXEkWBAAAABpc19zdWJzY3JpcHRhYmxlcSVYCQAAAG5f\nb3V0cHV0c3EmhnEnaBmHcShScSmJSwGGcSqBcStYCgAAAHBhcmFtZXRlcnNxLGNjb2xsZWN0aW9u\ncwpPcmRlcmVkRGljdApxLSlScS5oBWgUWA0AAABUYXNrUGFyYW1ldGVycS9YBAAAAG5hbWVxMFgE\nAAAAa2luZHExhnEyaBmHcTNScTRoBWNvcnF1ZXN0cmEuc2RrLl9iYXNlLl9kc2wKUGFyYW1ldGVy\nS2luZApxNVgVAAAAUE9TSVRJT05BTF9PUl9LRVlXT1JEcTaFcTdScTiGcTmBcTpzWBIAAABkZXBl\nbmRlbmN5X2ltcG9ydHNxO05YCQAAAHJlc291cmNlc3E8aBQoWAkAAABSZXNvdXJjZXNxPShYAwAA\nAGNwdXE+WAYAAABtZW1vcnlxP1gEAAAAZGlza3FAWAMAAABncHVxQXRxQmgZXXFDKE5OTk5ldHFE\nUnFFKE5OTk50cUaBcUdYDAAAAGN1c3RvbV9pbWFnZXFIWCgAAAB6YXBhdGFjb21wdXRpbmcvb3Jx\ndWVzdHJhLWRlZmF1bHQ6djAuMC4wcUlYCwAAAGN1c3RvbV9uYW1lcUpOdX1xS1gPAAAAX19hbm5v\ndGF0aW9uc19fcUx9cU1zhnFOYi4=\n"
+        ],
+        "type": "INLINE_FUNCTION_REF"
+      },
+      "parameters": [
+        {
+          "name": "a",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        }
+      ],
+      "source_import_id": "inline-import-1",
+      "dependency_import_ids": null,
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    }
+  },
+  "artifact_nodes": {
+    "artifact-0-two-outputs": {
+      "id": "artifact-0-two-outputs",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": 0
+    },
+    "artifact-1-single-output": {
+      "id": "artifact-1-single-output",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": null
+    },
+    "artifact-5-two-outputs": {
+      "id": "artifact-5-two-outputs",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": 1
+    },
+    "artifact-4-two-outputs": {
+      "id": "artifact-4-two-outputs",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": null
+    }
+  },
+  "constant_nodes": {
+    "constant-0": {
+      "id": "constant-0",
+      "value": "12",
+      "serialization_format": "JSON",
+      "value_preview": "12"
+    },
+    "constant-1": {
+      "id": "constant-1",
+      "value": "11",
+      "serialization_format": "JSON",
+      "value_preview": "11"
+    }
+  },
+  "secret_nodes": {},
+  "task_invocations": {
+    "invocation-0-task-two-outputs": {
+      "id": "invocation-0-task-two-outputs",
+      "task_id": "task-two-outputs-7048e77dbb",
+      "args_ids": [
+        "artifact-4-two-outputs",
+        "artifact-1-single-output"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-0-two-outputs"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    },
+    "invocation-1-task-single-output": {
+      "id": "invocation-1-task-single-output",
+      "task_id": "task-single-output-5e628fa21b",
+      "args_ids": [
+        "artifact-5-two-outputs"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-1-single-output"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    },
+    "invocation-2-task-two-outputs": {
+      "id": "invocation-2-task-two-outputs",
+      "task_id": "task-two-outputs-7048e77dbb",
+      "args_ids": [
+        "constant-1",
+        "constant-0"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-4-two-outputs",
+        "artifact-5-two-outputs"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    }
+  },
+  "output_ids": [
+    "artifact-5-two-outputs",
+    "artifact-4-two-outputs",
+    "artifact-0-two-outputs"
+  ],
+  "data_aggregation": null
+}

--- a/tests/sdk/v2/schema/data/unpacking_wf_0.45.1.json
+++ b/tests/sdk/v2/schema/data/unpacking_wf_0.45.1.json
@@ -1,0 +1,169 @@
+{
+  "name": "unpacking_wf",
+  "fn_ref": {
+    "module": "__main__",
+    "function_name": "unpacking_wf",
+    "file_path": "tests/sdk/v2/schema/data/unpacking.py",
+    "line_number": 28,
+    "type": "MODULE_FUNCTION_REF"
+  },
+  "imports": {
+    "inline-import-1": {
+      "id": "inline-import-1",
+      "type": "INLINE_IMPORT"
+    }
+  },
+  "tasks": {
+    "task-two-outputs-930acd99d0": {
+      "id": "task-two-outputs-930acd99d0",
+      "fn_ref": {
+        "function_name": "two_outputs",
+        "encoded_function": [
+          "gASV9gMAAAAAAACMF2Nsb3VkcGlja2xlLmNsb3VkcGlja2xllIwOX21ha2VfZnVuY3Rpb26Uk5Qo\naACMDV9idWlsdGluX3R5cGWUk5SMCENvZGVUeXBllIWUUpQoSwJLAEsASwJLA0tDQxB8AGQBFwB8\nAWQCFwBmAlMAlE5LAUsCh5QpjAFhlIwBYpSGlIxwL1VzZXJzL2FsZXgvQ29kZS96YXBhdGEvZXZh\nbmdlbGlzbS13b3JrZmxvd3MvdmVuZG9yL29ycXVlc3RyYS13b3JrZmxvdy1zZGsvdGVzdHMvc2Rr\nL3YyL3NjaGVtYS9kYXRhL3VucGFja2luZy5weZSMC3R3b19vdXRwdXRzlEsSQwIQApQpKXSUUpR9\nlCiMC19fcGFja2FnZV9flE6MCF9fbmFtZV9flIwIX19tYWluX1+UjAhfX2ZpbGVfX5RoDXVOTk50\nlFKUjBxjbG91ZHBpY2tsZS5jbG91ZHBpY2tsZV9mYXN0lIwSX2Z1bmN0aW9uX3NldHN0YXRllJOU\naBh9lCiMF19UYXNrRGVmX19zZGtfdGFza19ib2R5lGgYjAZmbl9yZWaUjBhvcnF1ZXN0cmEuc2Rr\nLl9iYXNlLl9kc2yUjBFJbmxpbmVGdW5jdGlvblJlZpSTlGgOaBiGlIGUjA1zb3VyY2VfaW1wb3J0\nlGgfjAxJbmxpbmVJbXBvcnSUk5QpgZSMD291dHB1dF9tZXRhZGF0YZRoH4wSVGFza091dHB1dE1l\ndGFkYXRhlJOUiEsChpSBlIwKcGFyYW1ldGVyc5SMC2NvbGxlY3Rpb25zlIwLT3JkZXJlZERpY3SU\nk5QpUpQoaApoH4wNVGFza1BhcmFtZXRlcpSTlGgKaB+MDVBhcmFtZXRlcktpbmSUk5SMFVBPU0lU\nSU9OQUxfT1JfS0VZV09SRJSFlFKUhpSBlGgLaDNoC2g4hpSBlHWMEmRlcGVuZGVuY3lfaW1wb3J0\nc5ROjAlyZXNvdXJjZXOUaB+MCVJlc291cmNlc5STlChOTk5OdJSBlIwMY3VzdG9tX2ltYWdllIwo\nemFwYXRhY29tcHV0aW5nL29ycXVlc3RyYS1kZWZhdWx0OnYwLjAuMJSMC2N1c3RvbV9uYW1llE51\nfZQoaBRoDowMX19xdWFsbmFtZV9flGgOjA9fX2Fubm90YXRpb25zX1+UfZSMDl9fa3dkZWZhdWx0\nc19flE6MDF9fZGVmYXVsdHNfX5ROjApfX21vZHVsZV9flGgVjAdfX2RvY19flE6MC19fY2xvc3Vy\nZV9flE6MF19jbG91ZHBpY2tsZV9zdWJtb2R1bGVzlF2UjAtfX2dsb2JhbHNfX5R9lHWGlIZSMC4=\n"
+        ],
+        "type": "INLINE_FUNCTION_REF"
+      },
+      "parameters": [
+        {
+          "name": "a",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        },
+        {
+          "name": "b",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        }
+      ],
+      "source_import_id": "inline-import-1",
+      "dependency_import_ids": null,
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    },
+    "task-single-output-ca697364e3": {
+      "id": "task-single-output-ca697364e3",
+      "fn_ref": {
+        "function_name": "single_output",
+        "encoded_function": [
+          "gASV3QMAAAAAAACMF2Nsb3VkcGlja2xlLmNsb3VkcGlja2xllIwOX21ha2VfZnVuY3Rpb26Uk5Qo\naACMDV9idWlsdGluX3R5cGWUk5SMCENvZGVUeXBllIWUUpQoSwFLAEsASwFLAktDQwh8AGQBFwBT\nAJROSwOGlCmMAWGUhZSMcC9Vc2Vycy9hbGV4L0NvZGUvemFwYXRhL2V2YW5nZWxpc20td29ya2Zs\nb3dzL3ZlbmRvci9vcnF1ZXN0cmEtd29ya2Zsb3ctc2RrL3Rlc3RzL3Nkay92Mi9zY2hlbWEvZGF0\nYS91bnBhY2tpbmcucHmUjA1zaW5nbGVfb3V0cHV0lEsXQwIIApQpKXSUUpR9lCiMC19fcGFja2Fn\nZV9flE6MCF9fbmFtZV9flIwIX19tYWluX1+UjAhfX2ZpbGVfX5RoDHVOTk50lFKUjBxjbG91ZHBp\nY2tsZS5jbG91ZHBpY2tsZV9mYXN0lIwSX2Z1bmN0aW9uX3NldHN0YXRllJOUaBd9lCiMF19UYXNr\nRGVmX19zZGtfdGFza19ib2R5lGgXjAZmbl9yZWaUjBhvcnF1ZXN0cmEuc2RrLl9iYXNlLl9kc2yU\njBFJbmxpbmVGdW5jdGlvblJlZpSTlGgNaBeGlIGUjA1zb3VyY2VfaW1wb3J0lGgejAxJbmxpbmVJ\nbXBvcnSUk5QpgZSMD291dHB1dF9tZXRhZGF0YZRoHowSVGFza091dHB1dE1ldGFkYXRhlJOUiUsB\nhpSBlIwKcGFyYW1ldGVyc5SMC2NvbGxlY3Rpb25zlIwLT3JkZXJlZERpY3SUk5QpUpRoCmgejA1U\nYXNrUGFyYW1ldGVylJOUaApoHowNUGFyYW1ldGVyS2luZJSTlIwVUE9TSVRJT05BTF9PUl9LRVlX\nT1JElIWUUpSGlIGUc4wSZGVwZW5kZW5jeV9pbXBvcnRzlE6MCXJlc291cmNlc5RoHowJUmVzb3Vy\nY2VzlJOUKE5OTk50lIGUjAxjdXN0b21faW1hZ2WUjCh6YXBhdGFjb21wdXRpbmcvb3JxdWVzdHJh\nLWRlZmF1bHQ6djAuMC4wlIwLY3VzdG9tX25hbWWUTnV9lChoE2gNjAxfX3F1YWxuYW1lX1+UaA2M\nD19fYW5ub3RhdGlvbnNfX5R9lIwOX19rd2RlZmF1bHRzX1+UTowMX19kZWZhdWx0c19flE6MCl9f\nbW9kdWxlX1+UaBSMB19fZG9jX1+UTowLX19jbG9zdXJlX1+UTowXX2Nsb3VkcGlja2xlX3N1Ym1v\nZHVsZXOUXZSMC19fZ2xvYmFsc19flH2UdYaUhlIwLg==\n"
+        ],
+        "type": "INLINE_FUNCTION_REF"
+      },
+      "parameters": [
+        {
+          "name": "a",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        }
+      ],
+      "source_import_id": "inline-import-1",
+      "dependency_import_ids": null,
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    }
+  },
+  "artifact_nodes": {
+    "artifact-0-two-outputs": {
+      "id": "artifact-0-two-outputs",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": 0
+    },
+    "artifact-1-single-output": {
+      "id": "artifact-1-single-output",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": null
+    },
+    "artifact-5-two-outputs": {
+      "id": "artifact-5-two-outputs",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": 1
+    },
+    "artifact-4-two-outputs": {
+      "id": "artifact-4-two-outputs",
+      "custom_name": null,
+      "serialization_format": "AUTO",
+      "artifact_index": null
+    }
+  },
+  "constant_nodes": {
+    "constant-0": {
+      "id": "constant-0",
+      "value": "12",
+      "serialization_format": "JSON",
+      "value_preview": "12"
+    },
+    "constant-1": {
+      "id": "constant-1",
+      "value": "11",
+      "serialization_format": "JSON",
+      "value_preview": "11"
+    }
+  },
+  "secret_nodes": {},
+  "task_invocations": {
+    "invocation-0-task-two-outputs": {
+      "id": "invocation-0-task-two-outputs",
+      "task_id": "task-two-outputs-930acd99d0",
+      "args_ids": [
+        "artifact-4-two-outputs",
+        "artifact-1-single-output"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-0-two-outputs"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    },
+    "invocation-1-task-single-output": {
+      "id": "invocation-1-task-single-output",
+      "task_id": "task-single-output-ca697364e3",
+      "args_ids": [
+        "artifact-5-two-outputs"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-1-single-output"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    },
+    "invocation-2-task-two-outputs": {
+      "id": "invocation-2-task-two-outputs",
+      "task_id": "task-two-outputs-930acd99d0",
+      "args_ids": [
+        "constant-1",
+        "constant-0"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-4-two-outputs",
+        "artifact-5-two-outputs"
+      ],
+      "resources": null,
+      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    }
+  },
+  "output_ids": [
+    "artifact-5-two-outputs",
+    "artifact-4-two-outputs",
+    "artifact-0-two-outputs"
+  ],
+  "data_aggregation": null,
+  "metadata": {
+    "sdk_version": {
+      "original": "0.45.1",
+      "major": 0,
+      "minor": 45,
+      "patch": 1,
+      "is_prerelease": false
+    },
+    "python_version": {
+      "original": "3.10.2 (main, Oct 28 2022, 11:58:19) [Clang 14.0.0 (clang-1400.0.29.102)]",
+      "major": 3,
+      "minor": 10,
+      "patch": 2,
+      "is_prerelease": false
+    }
+  }
+}

--- a/tests/sdk/v2/schema/test_compat.py
+++ b/tests/sdk/v2/schema/test_compat.py
@@ -6,10 +6,10 @@ Tests for ``orquestra.sdk.schema._compat``.
 """
 import typing as t
 from pathlib import Path
-from unittest.mock import create_autospec
 
 import pytest
 
+from orquestra.sdk.packaging import _versions
 from orquestra.sdk.schema import _compat, ir
 
 from .data import unpacking
@@ -174,3 +174,42 @@ class TestResultIsPacked:
 
                 # Then
                 assert packed is False
+
+
+class TestVersionsAreCompatible:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "generated_at,current,expected",
+        [
+            # Major version bump since the generation.
+            ("0.2.3", "1.2.3", False),
+            # We're at v0 -> not compatible with any other version.
+            ("1.2.3", "0.2.3", False),
+            # Exact version.
+            ("0.2.3", "0.2.3", True),
+            # We're at v0 -> not compatible with any other version.
+            ("0.2.3", "0.2.4", False),
+            # We're at v0 -> not compatible with any other version.
+            ("0.2.3", "0.3.0", False),
+            # Exact version.
+            ("1.2.3", "1.2.3", True),
+            # Exact version.
+            ("2.2.3", "2.2.3", True),
+            # Same major, bigger feature set.
+            ("2.2.3", "2.3.3", True),
+            # Same major, smaller feature set.
+            ("2.2.3", "2.1.3", False),
+            # Different majors.
+            ("2.2.3", "3.1.3", False),
+        ],
+    )
+    def test_examples(generated_at, current, expected):
+        # Given
+        generated_at_version = _versions.parse_version_str(generated_at)
+        current_version = _versions.parse_version_str(current)
+
+        # When
+        result = _compat.versions_are_compatible(generated_at_version, current_version)
+
+        # Then
+        assert result == expected

--- a/tests/sdk/v2/schema/test_compat.py
+++ b/tests/sdk/v2/schema/test_compat.py
@@ -46,7 +46,7 @@ SNAPSHOT_VERSIONS = [
 
 
 class TestNOutputs:
-    class TestModernIR:
+    class TestCurrentIR:
         @staticmethod
         @pytest.fixture
         def wf_def():
@@ -106,7 +106,7 @@ class TestNOutputs:
 
 
 class TestResultIsPacked:
-    class TestModernIR:
+    class TestCurrentIR:
         @staticmethod
         def test_single_output_task():
             # Given

--- a/tests/sdk/v2/schema/test_compat.py
+++ b/tests/sdk/v2/schema/test_compat.py
@@ -1,0 +1,176 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Tests for ``orquestra.sdk.schema._compat``.
+"""
+import typing as t
+from pathlib import Path
+from unittest.mock import create_autospec
+
+import pytest
+
+from orquestra.sdk.schema import _compat, ir
+
+from .data import unpacking
+
+
+def _get_task_by_name(
+    wf_def: ir.WorkflowDef, task_name: str
+) -> t.Sequence[t.Tuple[ir.TaskDef, ir.TaskInvocation]]:
+    task_defs = [
+        task_def
+        for task_def in wf_def.tasks.values()
+        if task_def.fn_ref.function_name == task_name
+    ]
+    task_def_ids = {task_def.id for task_def in task_defs}
+
+    pairs = []
+    for task_def in task_defs:
+        invs = [
+            inv
+            for inv in wf_def.task_invocations.values()
+            if inv.task_id in task_def_ids
+        ]
+        pairs.extend([(task_def, inv) for inv in invs])
+    return pairs
+
+
+DATA_PATH = Path(__file__).parent / "data"
+SNAPSHOT_VERSIONS = [
+    # Last version without ``ir.WorkflowDef.metadata``
+    "0.44.0",
+    # Last version without ``ir.TaskDef.output_metadata``
+    "0.45.1",
+]
+
+
+class TestNOutputs:
+    class TestModernIR:
+        @staticmethod
+        @pytest.fixture
+        def wf_def():
+            return unpacking.unpacking_wf().model
+
+        @staticmethod
+        def test_single_output_task(wf_def: ir.WorkflowDef):
+            # Given
+            pairs = _get_task_by_name(wf_def=wf_def, task_name="single_output")
+            assert len(pairs) == 1
+            task_def, task_inv = pairs[0]
+
+            # When
+            n_outputs = _compat.n_outputs(task_def, task_inv)
+
+            # Then
+            assert n_outputs == 1
+
+        @staticmethod
+        def test_multi_output(wf_def: ir.WorkflowDef):
+            # Given
+            pairs = _get_task_by_name(wf_def=wf_def, task_name="two_outputs")
+            assert (
+                len(pairs) == 2
+            ), "There should be two invocations in the test workflow"
+
+            for task_def, task_inv in pairs:
+                # When
+                n_outputs = _compat.n_outputs(task_def, task_inv)
+
+                # Then
+                assert n_outputs == 2
+
+    @pytest.mark.parametrize("snapshot_version", SNAPSHOT_VERSIONS)
+    class TestOldIR:
+        @staticmethod
+        @pytest.fixture
+        def wf_def(snapshot_version: str):
+            path = DATA_PATH / f"unpacking_wf_{snapshot_version}.json"
+            return ir.WorkflowDef.parse_file(path)
+
+        @staticmethod
+        @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
+        def test_single_output_task(wf_def: ir.WorkflowDef):
+            # Given
+            pairs = _get_task_by_name(wf_def=wf_def, task_name="single_output")
+            assert len(pairs) == 1
+            task_def, task_inv = pairs[0]
+
+            # When
+            n_outputs = _compat.n_outputs(task_def, task_inv)
+
+            # Then
+            assert n_outputs == 1
+
+        # No test for "multi_output" because "n_outputs" isn't reliable with old IRs.
+
+
+class TestResultIsPacked:
+    class TestModernIR:
+        @staticmethod
+        def test_single_output_task():
+            # Given
+            wf_def = unpacking.unpacking_wf().model
+            pairs = _get_task_by_name(wf_def=wf_def, task_name="single_output")
+            assert len(pairs) == 1
+            task_def, _ = pairs[0]
+
+            # When
+            packed = _compat.result_is_packed(task_def)
+
+            # Then
+            assert packed is False
+
+        @staticmethod
+        def test_multi_output():
+            # Given
+            wf_def = unpacking.unpacking_wf().model
+            pairs = _get_task_by_name(wf_def=wf_def, task_name="two_outputs")
+            assert (
+                len(pairs) == 2
+            ), "There should be two invocations in the test workflow"
+
+            for task_def, _ in pairs:
+                # When
+                packed = _compat.result_is_packed(task_def)
+
+                # Then
+                assert packed is True
+
+    @pytest.mark.parametrize("snapshot_version", SNAPSHOT_VERSIONS)
+    class TestOldIR:
+        @staticmethod
+        @pytest.fixture
+        def wf_def(snapshot_version: str):
+            path = DATA_PATH / f"unpacking_wf_{snapshot_version}.json"
+            return ir.WorkflowDef.parse_file(path)
+
+        @staticmethod
+        @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
+        def test_single_output_task(wf_def: ir.WorkflowDef):
+            # Given
+            pairs = _get_task_by_name(wf_def=wf_def, task_name="single_output")
+            assert len(pairs) == 1
+            task_def, _ = pairs[0]
+
+            # When
+            packed = _compat.result_is_packed(task_def)
+
+            # Then
+            assert packed is False
+
+        @staticmethod
+        @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
+        def test_multi_output_task(wf_def: ir.WorkflowDef):
+            # Given
+            pairs = _get_task_by_name(wf_def=wf_def, task_name="two_outputs")
+            assert (
+                len(pairs) == 2
+            ), "There should be two invocations in the test workflow"
+
+            for task_def, _ in pairs:
+                # When
+                packed = _compat.result_is_packed(task_def)
+
+                # Then
+                assert packed is False

--- a/tests/sdk/v2/schema/test_ir.py
+++ b/tests/sdk/v2/schema/test_ir.py
@@ -33,3 +33,30 @@ class TestWorkflowDef:
 
             # Then
             assert wf_def2 == wf_def
+
+    class TestRegression:
+        """
+        Validates we're able to deserialize workflow defs generated with old versions
+        of the SDK. We should be careful about the assertions; probably we should never
+        change them to test for regressions.
+        """
+
+        @staticmethod
+        def test_new_ir():
+            # Given
+            wf = unpacking.unpacking_wf()
+
+            # When
+            _ = wf.model
+
+            # Then
+            # No warning: we're good
+
+        @staticmethod
+        @pytest.mark.parametrize("snapshot_version", ["0.44.0", "0.45.1"])
+        def test_old_ir(snapshot_version: str):
+            path = DATA_PATH / f"unpacking_wf_{snapshot_version}.json"
+            # Then
+            with pytest.warns(exceptions.VersionMismatch):
+                # When
+                _ = ir.WorkflowDef.parse_file(path)

--- a/tests/sdk/v2/schema/test_ir.py
+++ b/tests/sdk/v2/schema/test_ir.py
@@ -42,7 +42,7 @@ class TestWorkflowDef:
         """
 
         @staticmethod
-        def test_new_ir():
+        def test_current_ir():
             # Given
             wf = unpacking.unpacking_wf()
 


### PR DESCRIPTION
# The problem

_Please describe the motivation for this PR. Bonus points for code examples, error messages, and screenshots._

# This PR's solution

Blocked on ~https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/107~, ~https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/108~.

1. Make `TaskDef.output_metadata` optional. This allows deserializing IRs from `orquestra-sdk<=v0.45.1`
2. Add `_compat` module for a single place where we handle cases where the task def is `None`.
3. Add regression test in form of a workflow def IR serialized from `orquestra-sdk==0.45.1` and `0.44.0`.
4. Add validator on `ir.WorkflowDef` that raises warnings when deserializing an IR generated with a different version of the SDK.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
