### PR TITLE
Fix: default_dependency_imports as a single import allowed. Fix __main__ reference issue when default_source_import was Inline

### DIFF
--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -492,6 +492,12 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
             raise InvalidTaskDefinitionError(err)
 
     def validate_task(self):
+        """Validate tasks for possible incompatibilities
+
+        Raises:
+            InvalidTaskDefinitionError: If task is defined in __main__module and is not
+            inlined using source_import==InlineImport()
+        """
         self._validate_task_not_in_main()
 
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R:

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -642,6 +642,9 @@ def flatten_graph(
         invocation.task: _make_task_model(invocation.task, import_models_dict)
         for invocation in graph.invocations.keys()
     }
+    # make sure we can execute tasks
+    for task in task_models_dict:
+        task.validate_task()
 
     dsl_invocations = list(graph.invocations.keys())
 

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -36,12 +36,12 @@ from ._dsl import (
     DataAggregation,
     FunctionRef,
     Import,
+    ImportTypes,
     Secret,
     TaskDef,
     UnknownPlaceholderInCustomNameWarning,
     get_fn_ref,
     parse_custom_name,
-    ImportTypes,
 )
 from ._in_process_runtime import InProcessRuntime
 

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -41,6 +41,7 @@ from ._dsl import (
     UnknownPlaceholderInCustomNameWarning,
     get_fn_ref,
     parse_custom_name,
+    ImportTypes,
 )
 from ._in_process_runtime import InProcessRuntime
 
@@ -600,7 +601,7 @@ def workflow(
     data_aggregation: Optional[Union[DataAggregation, bool]] = None,
     custom_name: Optional[str] = None,
     default_source_import: Optional[Import] = None,
-    default_dependency_imports: Optional[Iterable[Import]] = None,
+    default_dependency_imports: Union[Iterable[Import], Import, None] = None,
 ) -> Union[
     WorkflowTemplate[_P, _R],
     Callable[[Callable[_P, _R]], WorkflowTemplate[_P, _R]],
@@ -658,6 +659,14 @@ def workflow(
 
     will raise a NotATaskWarning on the `np.ones` call, but not for the `my_task` call.
     """
+    workflow_default_dependency_imports: Optional[Tuple[Import, ...]]
+
+    if default_dependency_imports is None:
+        workflow_default_dependency_imports = None
+    elif isinstance(default_dependency_imports, ImportTypes):
+        workflow_default_dependency_imports = (default_dependency_imports,)
+    elif default_dependency_imports is not None:
+        workflow_default_dependency_imports = tuple(default_dependency_imports)
 
     def _inner(fn: Callable[_P, _R]):
         signature = inspect.signature(fn)
@@ -671,7 +680,7 @@ def workflow(
             is_parametrized=len(signature.parameters) > 0,
             data_aggregation=data_aggregation,
             default_source_import=default_source_import,
-            default_dependency_imports=default_dependency_imports,
+            default_dependency_imports=workflow_default_dependency_imports,
         )
         functools.update_wrapper(template, fn)
         return template

--- a/tests/sdk/v2/data/sample_project/workflow_defs_no_raise.py
+++ b/tests/sdk/v2/data/sample_project/workflow_defs_no_raise.py
@@ -1,0 +1,20 @@
+################################################################################
+# © Copyright 2022 Zapata Computing Inc.
+################################################################################
+import helpers  # type: ignore
+
+import orquestra.sdk as sdk
+
+
+@sdk.task()
+def capitalize_task(text):
+    return helpers.capitalize_helper(text)
+
+
+@sdk.workflow(default_source_import=sdk.InlineImport())
+def sample_workflow():
+    return [capitalize_task("sample")]
+
+
+if __name__ == "__main__":
+    model = sample_workflow.model

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -641,7 +641,7 @@ class TestRefToMain:
                 "workflow_defs.py",
                 pytest.raises(sdk.exceptions.InvalidTaskDefinitionError),
             ),
-            ("wokrflow_defs_no_raise", do_not_raise()),
+            ("workflow_defs_no_raise.py", do_not_raise()),
         ],
     )
     def test_ref_to_main_in_task(self, workflow_defs_file, raises):

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -633,22 +633,33 @@ def test_python_imports_deps(python_imports, expected_req, raises):
         assert list(parsed) == expected_req
 
 
-def test_ref_to_main_in_task_error():
-    path_to_workflows = (
-        os.path.dirname(os.path.abspath(__file__)) + "/data/sample_project/"
+class TestRefToMain:
+    @pytest.mark.parametrize(
+        "workflow_defs_file, raises",
+        [
+            (
+                "workflow_defs.py",
+                pytest.raises(sdk.exceptions.InvalidTaskDefinitionError),
+            ),
+            ("wokrflow_defs_no_raise", do_not_raise()),
+        ],
     )
-    # add path to locate helper imports
-    sys.path.append(path_to_workflows)
-    # prepare file to be executed as __main__
-    loader = importlib.machinery.SourceFileLoader(
-        "__main__", path_to_workflows + "workflow_defs.py"
-    )
-    spec = importlib.util.spec_from_loader(loader.name, loader)
-    assert spec is not None
-    mod = importlib.util.module_from_spec(spec)
+    def test_ref_to_main_in_task(self, workflow_defs_file, raises):
+        path_to_workflows = (
+            os.path.dirname(os.path.abspath(__file__)) + "/data/sample_project/"
+        )
+        # add path to locate helper imports
+        sys.path.append(path_to_workflows)
+        # prepare file to be executed as __main__
+        loader = importlib.machinery.SourceFileLoader(
+            "__main__", path_to_workflows + workflow_defs_file
+        )
+        spec = importlib.util.spec_from_loader(loader.name, loader)
+        assert spec is not None
+        mod = importlib.util.module_from_spec(spec)
 
-    with pytest.raises(sdk.exceptions.InvalidTaskDefinitionError):
-        loader.exec_module(mod)
+        with raises:
+            loader.exec_module(mod)
 
 
 def test_python_310_importlib_abc_bug():

--- a/tests/sdk/v2/test_workflow.py
+++ b/tests/sdk/v2/test_workflow.py
@@ -369,3 +369,31 @@ class TestResources:
         )
 
         assert wf.resources == expected_resources
+
+
+@pytest.mark.parametrize(
+    "dependency_imports, expected_imports",
+    [
+        (None, None),
+        (sdk.InlineImport(), (sdk.InlineImport(),)),
+        (sdk.LocalImport("mod"), (sdk.LocalImport("mod"),)),
+        (
+            sdk.GitImport(repo_url="abc", git_ref="xyz"),
+            (sdk.GitImport(repo_url="abc", git_ref="xyz"),),
+        ),
+        (
+            sdk.GithubImport("abc"),
+            (sdk.GithubImport("abc"),),
+        ),
+        (
+            sdk.PythonImports("abc"),
+            (sdk.PythonImports("abc"),),
+        ),
+    ],
+)
+def test_default_dependency_imports(dependency_imports, expected_imports):
+    @sdk.workflow(default_dependency_imports=dependency_imports)
+    def my_workflow():
+        pass
+
+    assert my_workflow._default_dependency_imports == expected_imports


### PR DESCRIPTION
# The problem
look solution - 2 minor changes to 2 recently delivered PRs

# This PR's solution

https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/104 - introduces single import as dependency import.
This PR adds single import as dependency import also for workflow-scoped default dependency imports making it consistent

https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/102 - introduces default_source_import. It wasnt taken into account when task was defined in __main__.
E.g.
Having such workflow
```
@sdk.workflow(default_source_import=sdk.InlineImport())
def sample_workflow():
    return [capitalize_task("sample")]
```

if capitalize_task was defined in __main__ - it shouldnt raise an error (as inlineImport was used).

This PR fixes it by moving __main__ check into graph traversal stage when WF source import is taken into consideration.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
