### PR TITLE
refactor: `orquestra.sdk.packaging` module -> package

### DIFF
--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -10,19 +10,17 @@ import collections.abc
 import hashlib
 import inspect
 import re
-import sys
 import typing as t
 import warnings
 from collections import OrderedDict
 from functools import singledispatch
 
-from packaging.version import parse as parse_version
 from pip_api import Requirement
 
 from orquestra.sdk.schema import ir, responses
 
 from .. import exceptions
-from ..packaging import get_installed_version
+from ..packaging._versions import get_current_python_version, get_current_sdk_version
 from . import _dsl, _exec_ctx, _git_url_utils, _workflow, serde
 
 N_BYTES_IN_HASH = 8
@@ -822,26 +820,13 @@ def flatten_graph(
         for dsl_invocation_i, dsl_invocation in enumerate(dsl_invocations)
     }
 
-    sdk_version_str = get_installed_version("orquestra-sdk")
-    parsed_sdk_version = parse_version(sdk_version_str)
-    sdk_version = ir.Version(
-        original=sdk_version_str,
-        major=parsed_sdk_version.major,
-        minor=parsed_sdk_version.minor,
-        patch=parsed_sdk_version.micro,
-        is_prerelease=parsed_sdk_version.is_prerelease,
-    )
+    sdk_version = get_current_sdk_version()
+    python_version = get_current_python_version()
 
     return ir.WorkflowDef(
         metadata=ir.WorkflowMetadata(
             sdk_version=sdk_version,
-            python_version=ir.Version(
-                original=sys.version,
-                major=sys.version_info.major,
-                minor=sys.version_info.minor,
-                patch=sys.version_info.micro,
-                is_prerelease=sys.version_info.releaselevel != "final",
-            ),
+            python_version=python_version,
         ),
         resources=_make_resources_model(workflow_def._resources, is_task=False),
         # At the moment 'orq submit workflow-def <name>' assumes that the <name> is

--- a/src/orquestra/sdk/packaging/__init__.py
+++ b/src/orquestra/sdk/packaging/__init__.py
@@ -1,0 +1,17 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+
+from ._versions import (
+    InstalledImport,
+    PackagingError,
+    execute_task,
+    get_installed_version,
+)
+
+__all__ = [
+    "InstalledImport",
+    "PackagingError",
+    "execute_task",
+    "get_installed_version",
+]

--- a/src/orquestra/sdk/packaging/_versions.py
+++ b/src/orquestra/sdk/packaging/_versions.py
@@ -1,7 +1,8 @@
 ################################################################################
-# © Copyright 2022 Zapata Computing Inc.
+# © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
 import re
+import sys
 from typing import Any, Optional
 
 try:
@@ -9,7 +10,10 @@ try:
 except ModuleNotFoundError:  # pragma: no cover
     import importlib_metadata as metadata  # type: ignore  # pragma: no cover
 
+import packaging.version
+
 from orquestra.sdk import Import, PythonImports, TaskDef, exceptions
+from orquestra.sdk.schema import ir
 
 
 class PackagingError(exceptions.BaseRuntimeError):
@@ -39,6 +43,32 @@ def get_installed_version(package_name: str) -> str:
         return metadata.version(package_name)
     except metadata.PackageNotFoundError as e:
         raise PackagingError(f"Package not found: {package_name}") from e
+
+
+def get_installed_version_model(package_name: str) -> ir.Version:
+    sdk_version_str = get_installed_version(package_name)
+    parsed_sdk_version = packaging.version.parse(sdk_version_str)
+    return ir.Version(
+        original=sdk_version_str,
+        major=parsed_sdk_version.major,
+        minor=parsed_sdk_version.minor,
+        patch=parsed_sdk_version.micro,
+        is_prerelease=parsed_sdk_version.is_prerelease,
+    )
+
+
+def get_current_sdk_version() -> ir.Version:
+    return get_installed_version_model("orquestra-sdk")
+
+
+def get_current_python_version() -> ir.Version:
+    return ir.Version(
+        original=sys.version,
+        major=sys.version_info.major,
+        minor=sys.version_info.minor,
+        patch=sys.version_info.micro,
+        is_prerelease=sys.version_info.releaselevel != "final",
+    )
 
 
 def InstalledImport(

--- a/tests/sdk/v2/test_packaging.py
+++ b/tests/sdk/v2/test_packaging.py
@@ -5,16 +5,21 @@ from unittest.mock import Mock
 
 import pytest
 
-import orquestra.sdk as sdk
-import orquestra.sdk.packaging as packaging
+from orquestra import sdk
+from orquestra.sdk import packaging
+from orquestra.sdk.packaging import _versions
+
+try:
+    import importlib.metadata as metadata  # type: ignore
+except ModuleNotFoundError:
+    import importlib_metadata as metadata  # type: ignore
 
 
 class TestGetInstalledVersion:
     @staticmethod
     def test_successful_call(monkeypatch):
         # Given
-        metadata_version = Mock(return_value="1.2.3")
-        monkeypatch.setattr(packaging.metadata, "version", metadata_version)
+        monkeypatch.setattr(metadata, "version", Mock(return_value="1.2.3"))
         # When
         version = packaging.get_installed_version("some-package")
         # Then
@@ -23,8 +28,9 @@ class TestGetInstalledVersion:
     @staticmethod
     def test_package_not_found(monkeypatch):
         # Given
-        metadata_version = Mock(side_effect=packaging.metadata.PackageNotFoundError)
-        monkeypatch.setattr(packaging.metadata, "version", metadata_version)
+        monkeypatch.setattr(
+            metadata, "version", Mock(side_effect=metadata.PackageNotFoundError)
+        )
         # When
         with pytest.raises(packaging.PackagingError) as exc_info:
             _ = packaging.get_installed_version("some-package")
@@ -36,8 +42,9 @@ class TestInstalledImport:
     @staticmethod
     def test_package_found(monkeypatch):
         # Given
-        get_version = Mock(return_value="1.2.3")
-        monkeypatch.setattr(packaging, "get_installed_version", get_version)
+        monkeypatch.setattr(
+            _versions, "get_installed_version", Mock(return_value="1.2.3")
+        )
         # When
         imp = packaging.InstalledImport(package_name="some-package")
         # Then
@@ -48,8 +55,11 @@ class TestInstalledImport:
     @staticmethod
     def test_package_not_found(monkeypatch):
         # Given
-        get_version = Mock(side_effect=packaging.PackagingError("Package not found:"))
-        monkeypatch.setattr(packaging, "get_installed_version", get_version)
+        monkeypatch.setattr(
+            _versions,
+            "get_installed_version",
+            Mock(side_effect=packaging.PackagingError("Package not found:")),
+        )
         # When
         with pytest.raises(packaging.PackagingError) as exc_info:
             _ = packaging.InstalledImport(package_name="some-package")
@@ -59,8 +69,11 @@ class TestInstalledImport:
     @staticmethod
     def test_package_not_found_fallback(monkeypatch):
         # Given
-        get_version = Mock(side_effect=packaging.PackagingError("Package not found:"))
-        monkeypatch.setattr(packaging, "get_installed_version", get_version)
+        monkeypatch.setattr(
+            _versions,
+            "get_installed_version",
+            Mock(side_effect=packaging.PackagingError("Package not found:")),
+        )
         fallback = sdk.GithubImport("zapatacomputing/orquestra-workflow-sdk")
         # When
         imp = packaging.InstalledImport(package_name="some-package", fallback=fallback)
@@ -70,8 +83,9 @@ class TestInstalledImport:
     @staticmethod
     def test_package_version_matches(monkeypatch):
         # Given
-        get_version = Mock(return_value="1.2.3")
-        monkeypatch.setattr(packaging, "get_installed_version", get_version)
+        monkeypatch.setattr(
+            _versions, "get_installed_version", Mock(return_value="1.2.3")
+        )
         # When
         imp = packaging.InstalledImport(
             package_name="some-package", version_match="[0-9].[0-9].[0-9]"
@@ -84,8 +98,9 @@ class TestInstalledImport:
     @staticmethod
     def test_package_version_does_not_match(monkeypatch):
         # Given
-        get_version = Mock(return_value="1.2.3")
-        monkeypatch.setattr(packaging, "get_installed_version", get_version)
+        monkeypatch.setattr(
+            _versions, "get_installed_version", Mock(return_value="1.2.3")
+        )
         # When
         with pytest.raises(packaging.PackagingError) as exc_info:
             _ = packaging.InstalledImport(
@@ -100,8 +115,9 @@ class TestInstalledImport:
     @staticmethod
     def test_package_version_does_not_match_fallback(monkeypatch):
         # Given
-        get_version = Mock(return_value="1.2.3")
-        monkeypatch.setattr(packaging, "get_installed_version", get_version)
+        monkeypatch.setattr(
+            _versions, "get_installed_version", Mock(return_value="1.2.3")
+        )
         fallback = sdk.GithubImport("zapatacomputing/orquestra-workflow-sdk")
         # When
         imp = packaging.InstalledImport(

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -17,6 +17,7 @@ import pytest
 import orquestra.sdk.schema.ir as ir
 from orquestra.sdk import exceptions, secrets
 from orquestra.sdk._base import _dsl, _traversal, _workflow, dispatch, serde
+from orquestra.sdk.packaging import _versions
 
 from .data.complex_serialization.workflow_defs import (
     generate_object_with_num,
@@ -1169,7 +1170,7 @@ def test_workflow_with_secret():
 def test_metadata_on_release(monkeypatch: pytest.MonkeyPatch):
     # Given
     mocked_installed_version = Mock(return_value="22.42.0")
-    monkeypatch.setattr(_traversal, "get_installed_version", mocked_installed_version)
+    monkeypatch.setattr(_versions, "get_installed_version", mocked_installed_version)
 
     # When
     wf = workflow().model
@@ -1185,7 +1186,7 @@ def test_metadata_on_release(monkeypatch: pytest.MonkeyPatch):
 def test_metadata_on_dev(monkeypatch: pytest.MonkeyPatch):
     # Given
     mocked_installed_version = Mock(return_value="22.42.0.dev1+gitAABBCC.20230101")
-    monkeypatch.setattr(_traversal, "get_installed_version", mocked_installed_version)
+    monkeypatch.setattr(_versions, "get_installed_version", mocked_installed_version)
 
     # When
     wf = workflow().model


### PR DESCRIPTION
# The problem

When working on https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/105 I needed to add some helpers related to fetching version of the SDK. `orquestra.sdk.packaging` seemed like a good place for it. I don't want to expose my helpers in the public API, but `orquestra.sdk.packaging` is a module.

# This PR's solution

~Depends on https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/107.~

Turns `orquestra.sdk.packaging` into a package. This allows separating public-internal APIs.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
