### PR TITLE
fix: Back compat for older CE workflow results

### DIFF
--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -4,12 +4,11 @@
 import warnings
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Dict, List, Optional, Sequence, Union
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import serde
 from orquestra.sdk._base._db import WorkflowDB
-from orquestra.sdk._base.abc import ArtifactValue, RuntimeInterface
+from orquestra.sdk._base.abc import RuntimeInterface
 from orquestra.sdk.kubernetes.quantity import parse_quantity
 from orquestra.sdk.schema.configs import RuntimeConfiguration
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
@@ -216,11 +215,10 @@ class CERuntime(RuntimeInterface):
                 wf_run.status.state,
             )
 
+        assert len(result_ids) == 1, "Assuming a single output"
+
         try:
-            return tuple(
-                self._client.get_workflow_run_result(result_id)
-                for result_id in result_ids
-            )
+            return self._client.get_workflow_run_result(result_ids[0])
         except (_exceptions.InvalidTokenError, _exceptions.ForbiddenError) as e:
             raise exceptions.UnauthorizedError(
                 "Could not get the outputs for workflow run with id "

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -557,7 +557,7 @@ class DriverClient:
 
     def get_workflow_run_result(
         self, result_id: _models.WorkflowRunResultID
-    ) -> Tuple[WorkflowResult]:
+    ) -> Tuple[WorkflowResult, ...]:
         """
         Gets workflow run results from the workflow driver
 
@@ -601,7 +601,10 @@ class DriverClient:
             )
         except pydantic.ValidationError:
             # If we fail, try parsing each part of a list separately
-            return tuple(pydantic.parse_obj_as(WorkflowResult, r) for r in json_response)  # type: ignore[arg-type]
+            return tuple(
+                pydantic.parse_obj_as(WorkflowResult, r)  # type: ignore[arg-type]
+                for r in json_response
+            )
 
     # --- Workflow Logs ---
 

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -12,7 +12,7 @@ import io
 import json
 import zlib
 from tarfile import TarFile
-from typing import Generic, List, Mapping, Optional, TypeVar
+from typing import Generic, List, Mapping, Optional, Tuple, TypeVar
 from urllib.parse import urljoin
 
 import pydantic
@@ -557,7 +557,7 @@ class DriverClient:
 
     def get_workflow_run_result(
         self, result_id: _models.WorkflowRunResultID
-    ) -> WorkflowResult:
+    ) -> Tuple[WorkflowResult]:
         """
         Gets workflow run results from the workflow driver
 
@@ -580,11 +580,28 @@ class DriverClient:
 
         _handle_common_errors(resp)
 
+        # To ensure the correct ordering of results, we serialize the results on CE as:
+        # [
+        #    (JSONResult | PickleResult).json(),
+        #    (JSONResult | PickleResult).json(),
+        #    ...
+        # ]
+        # For older workflows, we respond with:
+        # (JSONResult | PickleResult).json()
+
+        json_response = resp.json()
         # Bug with mypy and Pydantic:
         #   Unions cannot be passed to parse_obj_as: pydantic/pydantic#1847
-        return pydantic.parse_obj_as(
-            WorkflowResult, resp.json()  # type: ignore[arg-type]
-        )
+        try:
+            # Try an older response
+            return (
+                pydantic.parse_obj_as(
+                    WorkflowResult, json_response  # type: ignore[arg-type]
+                ),
+            )
+        except pydantic.ValidationError:
+            # If we fail, try parsing each part of a list separately
+            return tuple(pydantic.parse_obj_as(WorkflowResult, r) for r in json_response)  # type: ignore[arg-type]
 
     # --- Workflow Logs ---
 

--- a/tests/sdk/v2/driver/resp_mocks.py
+++ b/tests/sdk/v2/driver/resp_mocks.py
@@ -240,7 +240,19 @@ def make_get_wf_run_results_response():
     }
 
 
-def make_get_wf_run_result_response(result_obj: Any):
+def make_get_wf_run_result_response(result_list: List[Any]):
+    """
+    Based on:
+        https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/resources/run-result.yaml#L13
+    """
+
+    return [
+        result_from_artifact(result_obj, ArtifactFormat.AUTO).dict()
+        for result_obj in result_list
+    ]
+
+
+def make_get_wf_run_result_legacy_response(result_obj: Any):
     """
     Based on:
         https://github.com/zapatacomputing/workflow-driver/blob/main/openapi/src/resources/run-result.yaml#L13

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -424,7 +424,7 @@ class TestGetWorkflowRunResultsNonBlocking:
     ):
         # Given
         mocked_client.get_workflow_run_results.return_value = ["result_id"]
-        mocked_client.get_workflow_run_result.return_value = JSONResult(value="[1]")
+        mocked_client.get_workflow_run_result.return_value = (JSONResult(value="[1]"),)
 
         # When
         results = runtime.get_workflow_run_outputs_non_blocking(workflow_run_id)
@@ -443,11 +443,10 @@ class TestGetWorkflowRunResultsNonBlocking:
         # Given
         mocked_client.get_workflow_run_results.return_value = [
             "result_id",
-            "result_id2",
         ]
         mocked_client.get_workflow_run_result.side_effect = [
-            JSONResult(value="1"),
-            JSONResult(value="2"),
+            (JSONResult(value="1"),
+            JSONResult(value="2"),)
         ]
 
         # When

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -445,8 +445,10 @@ class TestGetWorkflowRunResultsNonBlocking:
             "result_id",
         ]
         mocked_client.get_workflow_run_result.side_effect = [
-            (JSONResult(value="1"),
-            JSONResult(value="2"),)
+            (
+                JSONResult(value="1"),
+                JSONResult(value="2"),
+            )
         ]
 
         # When

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -1497,13 +1497,15 @@ class TestClient:
                     default_status_code=200,
                 )
 
+            # This test relates to artifacts stored post 0.45.1
             @staticmethod
-            @pytest.mark.parametrize("obj", [None, 100, "hello", np.eye(10)])
-            def test_objects(
+            @pytest.mark.parametrize("obj, length", [([None], 1), ([100, 200], 2)])
+            def test_multiple_objects(
                 endpoint_mocker,
                 client: DriverClient,
                 workflow_run_result_id: str,
                 obj: Any,
+                length: int,
             ):
                 endpoint_mocker(
                     json=resp_mocks.make_get_wf_run_result_response(obj),
@@ -1511,7 +1513,29 @@ class TestClient:
 
                 result = client.get_workflow_run_result(workflow_run_result_id)
 
-                assert isinstance(result, (JSONResult, PickleResult))
+                assert len(result) == length
+
+                for vals in result:
+                    assert isinstance(vals, (JSONResult, PickleResult))
+
+            # This test relates to artifacts stored in 0.45.1 and prior
+            @staticmethod
+            @pytest.mark.parametrize("obj", [None, 100, "hello", np.eye(10)])
+            def test_single_objects(
+                endpoint_mocker,
+                client: DriverClient,
+                workflow_run_result_id: str,
+                obj: Any,
+            ):
+                endpoint_mocker(
+                    json=resp_mocks.make_get_wf_run_result_legacy_response(obj),
+                )
+
+                result = client.get_workflow_run_result(workflow_run_result_id)
+
+                assert len(result) == 1
+
+                assert isinstance(result[0], (JSONResult, PickleResult))
 
             @staticmethod
             def test_sets_auth(
@@ -1521,7 +1545,7 @@ class TestClient:
                 workflow_run_result_id: str,
             ):
                 endpoint_mocker(
-                    json=resp_mocks.make_get_wf_run_result_response(None),
+                    json=resp_mocks.make_get_wf_run_result_legacy_response(None),
                     match=[
                         responses.matchers.header_matcher(
                             {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
depends on #105 

# The problem


# This PR's solution

* Fixes the storage format for CE workflow results and adds backwards compatibility

Note the shape might not be a 1:1 match, a legacy multiple output workflow will now be deserialised as:
```
(
  (
    1,
    2,
    3,
  ),
)
```
instead of
```
(
  1,
  2,
  3,
),
```

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
