### PR TITLE
Feat!: Remove env variable that disabled setting resources for local ray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Workflow definitions now require at least one task in order to be submitted. This check is performed during traversal, and raises a WorkflowSyntaxError if no tasks are required to be executed.
 - Remove TaskDef.model and TaskDef.import_models interfaces
 - Public API classes `sdk.GitImport`, `sdk.GithubImport`, `sdk.LocalImport`, `sdk.InlineImport` now use `dataclasses.dataclass` instead of `typing.NamedTuple`.
+- Local Ray will now always pass resources to underlying ray.remote functions. 
 
 🔥 *Features*
 - Sort WF runs by start date in `list wf` command. Show start date as one of the columns

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -10,4 +10,4 @@ Guides
     runtime-configuration
     workflow-syntax
     dependency-installation
-    ce-resource-management
+    resource-management

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -1,10 +1,10 @@
-Compute Engine Resource Management
+Resource Management
 =======================
 
-Workflows submitted to run on Compute Engine can specify the computational resources they require, enabling precise management of resources and costs.
+Workflows submitted to run on Compute Engine and Local Ray can specify the computational resources they require, enabling precise management of resources and costs.
 
 .. note::
-    Resource management is supported only when executing on Compute Engine runtimes. Tasks and workflows defined with these parameters may still be executed on other runtimes, however the resource specification will be ignored.
+    Resource management is supported only when executing on Compute Engine and local-ray runtimes. Tasks and workflows defined with these parameters may still be executed on other runtimes, however the resource specification will be ignored.
 
 Setting Task Resources
 ----------------------
@@ -107,3 +107,10 @@ In these cases, additional resources should be specified in the workflow decorat
         results = []                            # resources for the additional
         for _ in range(5):                      # actors.
             results.append(task())
+
+Local vs remote resource management
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Resources are specified for a given task regardless of runtime.
+This might lead up to the issue, that tasks with large resources declared are run locally, where such resources are not available.
+In such case those tasks will not be scheduled by a local Ray instance due to the lack of resources.
+To work-around this problem, please lower the resources to the numbers available for the local node.

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -4,7 +4,7 @@ Resource Management
 Workflows submitted to run on Compute Engine and Local Ray can specify the computational resources they require, enabling precise management of resources and costs.
 
 .. note::
-    Resource management is supported only when executing on Compute Engine and local-ray runtimes. Tasks and workflows defined with these parameters may still be executed on other runtimes, however the resource specification will be ignored.
+    Resource management is supported only when executing on Compute Engine and Local Ray runtimes. Tasks and workflows defined with these parameters may still be executed on other runtimes, however the resource specification will be ignored.
 
 Setting Task Resources
 ----------------------
@@ -88,6 +88,9 @@ Tweaking the resource request may be required when your tasks spawn additional a
 Troubleshooting Common Resource Issues
 --------------------------------------
 
+My RLLib task fails
+^^^^^^^^^^^^^^^^^^^
+
 Due to the way Ray's RLLib works, a deadlock can be created on Compute Engine if a task attempts to spawn additional actors or remote functions via the DNQ ``rollouts`` facility. Resources requested in a task definition are bound to the task process, so additional actors can rapidly exhaust the provisioned resources.
 
 In these cases, additional resources should be specified in the workflow decorator.
@@ -108,9 +111,35 @@ In these cases, additional resources should be specified in the workflow decorat
         for _ in range(5):                      # actors.
             results.append(task())
 
-Local vs remote resource management
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Resources are specified for a given task regardless of runtime.
-This might lead up to the issue, that tasks with large resources declared are run locally, where such resources are not available.
-In such case those tasks will not be scheduled by a local Ray instance due to the lack of resources.
-To work-around this problem, please lower the resources to the numbers available for the local node.
+My Local Tasks Aren't Running
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Task resources are used to schedule tasks both locally and on remote runtimes.
+This might lead to issues when running tasks locally if they require resources that are unavailable.
+
+For example, you have a task that requires:
+
+1. a GPU but during development you run the workflow on your laptop without a GPU.
+2. 32GB of memory, but your Studio notebook only has 8GB available.
+3. 16 CPU cores but your desktop only has 8 available.
+
+In these examples, those tasks will not be scheduled by a local Ray instance due to the lack of resources.
+To workaround this problem, you should reduce the resources to match what is available. This can be done in the decorator:
+
+.. code-block:
+    @sdk.task(resources=sdk.Resources(gpu="0"))
+    def my_task():
+        ...
+
+or when the task is invoked, with the ``.with_resources()`` method:
+
+.. code-block:
+    # Usual request
+    @sdk.task(resources=sdk.Resources(gpu="1"))
+    def my_task():
+        ...
+
+    @sdk.workflow
+    def my_workflow():
+        # The resources are overridden for this one invocation
+        result = my_task().with_resources(gpu="0")
+        return result

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -40,13 +40,6 @@ Example:
     ORQ_RAY_DOWNLOAD_GIT_IMPORTS=1
 """
 
-RAY_SET_TASK_RESOURCES_ENV = "ORQ_RAY_SET_TASK_RESOURCES"
-"""
-Used to configure if Ray uses a task invocation's resources
-Example:
-    ORQ_RAY_SET_TASK_RESOURCES=1
-"""
-
 PASSPORT_FILE_ENV = "ORQUESTRA_PASSPORT_FILE"
 """
 Consumed by the Workflow SDK to set auth in remote contexts

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -62,12 +62,6 @@ Example:
     ORQ_RAY_DOWNLOAD_GIT_IMPORTS=1
 """
 
-
-PASSPORT_FILE_ENV = "ORQUESTRA_PASSPORT_FILE"
-"""
-Consumed by the Workflow SDK to set auth in remote contexts
-"""
-
 RAY_GLOBAL_WF_RUN_ID_ENV = "GLOBAL_WF_RUN_ID"
 """
 Used to set the workflow run ID in a Ray workflow

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -31,11 +31,7 @@ from .._base import (
     serde,
 )
 from .._base._db import WorkflowDB
-from .._base._env import (
-    RAY_DOWNLOAD_GIT_IMPORTS_ENV,
-    RAY_GLOBAL_WF_RUN_ID_ENV,
-    RAY_SET_TASK_RESOURCES_ENV,
-)
+from .._base._env import RAY_DOWNLOAD_GIT_IMPORTS_ENV, RAY_GLOBAL_WF_RUN_ID_ENV
 from .._base.abc import ArtifactValue, LogReader, RuntimeInterface
 from ..kubernetes.quantity import parse_quantity
 from ..schema import ir
@@ -393,10 +389,6 @@ def _make_ray_dag(
     # a mapping of "artifact ID" <-> "the ray Future needed to get the value"
     ray_futures: t.Dict[ir.ArtifactNodeId, t.Any] = {}
 
-    # Environment variable is used to configure if we apply task invocation resources
-    # to a Ray remote's options
-    add_resources = os.getenv(RAY_SET_TASK_RESOURCES_ENV) == "1"
-
     for ir_invocation in _graphs.iter_invocations_topologically(wf):
         # Prep args, kwargs, and the specs required to unpack tuples
         ray_args, pos_unpack_specs, pos_arg_indices_to_deserialize = _gather_args(
@@ -435,7 +427,7 @@ def _make_ray_dag(
         }
 
         # Task resources
-        if add_resources and ir_invocation.resources is not None:
+        if ir_invocation.resources is not None:
             if ir_invocation.resources.cpu is not None:
                 cpu = parse_quantity(ir_invocation.resources.cpu)
                 cpu_int = cpu.to_integral_value()


### PR DESCRIPTION
# The problem

It was confusing for users why task resources were not used in local ray

# This PR's solution

Always set resources on local ray runtime

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
