### PR TITLE
fix: Retry getting results from CE after a workflow has succeeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Setting workflow_id and project_id is now available on workflow Python API start() and prepare() functions
 
 🐛 *Bug Fixes*
+* Add a better error message when attempting to get the results of a succeeded workflow, before the results are available from Compute Engine.
 
 💅 *Improvements*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 * Setting workflow_id and project_id is now available on workflow Python API start() and prepare() functions
 
 🐛 *Bug Fixes*
-* Add a better error message when attempting to get the results of a succeeded workflow, before the results are available from Compute Engine.
+* Retry getting results from CE if the results were not ready but the workflow succeeded.
 
 💅 *Improvements*
 

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -210,10 +210,19 @@ class CERuntime(RuntimeInterface):
 
         if len(result_ids) == 0:
             wf_run = self.get_workflow_run_status(workflow_run_id)
-            raise exceptions.WorkflowRunNotSucceeded(
-                f"Workflow run `{workflow_run_id}` is in state {wf_run.status.state}",
-                wf_run.status.state,
-            )
+            if wf_run.status.state == State.SUCCEEDED:
+                raise exceptions.WorkflowResultsNotReadyError(
+                    f"Workflow run `{workflow_run_id}` has succeded, but the results "
+                    "are not ready yet.\n"
+                    "After a workflow completes, there may be a short delay before the "
+                    "results are ready to download. Please try again!"
+                )
+            else:
+                raise exceptions.WorkflowRunNotSucceeded(
+                    f"Workflow run `{workflow_run_id}` is in state "
+                    f"{wf_run.status.state}",
+                    wf_run.status.state,
+                )
 
         assert len(result_ids) == 1, "We're currently expecting a single result."
 

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import serde
+from orquestra.sdk._base import _retry, serde
 from orquestra.sdk._base._db import WorkflowDB
 from orquestra.sdk._base.abc import ArtifactValue, RuntimeInterface
 from orquestra.sdk.kubernetes.quantity import parse_quantity
@@ -177,6 +177,11 @@ class CERuntime(RuntimeInterface):
                 "- the authorization token was rejected by the remote cluster."
             ) from e
 
+    @_retry.retry(
+        attempts=5,
+        delay=0.2,
+        allowed_exceptions=(exceptions.WorkflowResultsNotReadyError,),
+    )
     def get_workflow_run_outputs_non_blocking(
         self, workflow_run_id: WorkflowRunId
     ) -> Sequence[Any]:
@@ -195,9 +200,13 @@ class CERuntime(RuntimeInterface):
         Returns:
             the outputs associated with the workflow run
         """
+
         try:
             result_ids = self._client.get_workflow_run_results(workflow_run_id)
-        except (_exceptions.InvalidWorkflowRunID, _exceptions.WorkflowRunNotFound) as e:
+        except (
+            _exceptions.InvalidWorkflowRunID,
+            _exceptions.WorkflowRunNotFound,
+        ) as e:
             raise exceptions.WorkflowRunNotFoundError(
                 f"Workflow run with id `{workflow_run_id}` not found"
             ) from e

--- a/src/orquestra/sdk/_base/_retry.py
+++ b/src/orquestra/sdk/_base/_retry.py
@@ -1,0 +1,28 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+import time
+from typing import Optional, Sequence
+
+
+def retry(
+    *,
+    attempts: int,
+    delay: Optional[float] = None,
+    allowed_exceptions: Sequence[Exception]
+):
+    def _inner(fn):
+        def _retried(*args, **kwargs):
+            for i in range(attempts):
+                try:
+                    return fn(*args, **kwargs)
+                except Exception as e:
+                    if i < (attempts - 1) and isinstance(e, allowed_exceptions):
+                        if delay is not None:
+                            time.sleep(delay)
+                        continue
+                    raise
+
+        return _retried
+
+    return _inner

--- a/src/orquestra/sdk/_base/_retry.py
+++ b/src/orquestra/sdk/_base/_retry.py
@@ -11,6 +11,20 @@ def retry(
     allowed_exceptions: Tuple[Type[Exception]],
     delay: Optional[float] = None,
 ):
+    """
+    A decorator useful for when a function should be retried.
+
+    Usage:
+        @retry(attempts=2, allowed_exceptions=(RuntimeError, ConnectionError))
+        def my_function_that_can_fail():
+            ...
+
+    Args:
+        attempts: the maximum number of times to try the function before raising
+        allowed_exceptions: the exceptions that are allowed to be retried.
+            All other exceptions will not cause the function to be retried.
+        delay: if set, there will be a short pause (sleep) before retrying
+    """
     def _inner(fn):
         def _retried(*args, **kwargs):
             for i in range(attempts):

--- a/src/orquestra/sdk/_base/_retry.py
+++ b/src/orquestra/sdk/_base/_retry.py
@@ -2,14 +2,14 @@
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
 import time
-from typing import Optional, Sequence
+from typing import Optional, Tuple, Type
 
 
 def retry(
     *,
     attempts: int,
+    allowed_exceptions: Tuple[Type[Exception]],
     delay: Optional[float] = None,
-    allowed_exceptions: Sequence[Exception]
 ):
     def _inner(fn):
         def _retried(*args, **kwargs):

--- a/src/orquestra/sdk/_base/_retry.py
+++ b/src/orquestra/sdk/_base/_retry.py
@@ -25,6 +25,7 @@ def retry(
             All other exceptions will not cause the function to be retried.
         delay: if set, there will be a short pause (sleep) before retrying
     """
+
     def _inner(fn):
         def _retried(*args, **kwargs):
             for i in range(attempts):

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -138,6 +138,12 @@ class TaskInvocationNotFoundError(NotFoundError):
         self.invocation_id = invocation_id
 
 
+class WorkflowResultsNotReadyError(NotFoundError):
+    """
+    Raised when a workflow has succeeded, but the results are not ready yet
+    """
+
+
 # Auth Errors
 class UnauthorizedError(BaseRuntimeError):
     pass

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -2,7 +2,7 @@
 ################################################################################
 from datetime import timedelta
 from pathlib import Path
-from unittest.mock import DEFAULT, MagicMock, Mock, call
+from unittest.mock import DEFAULT, MagicMock, Mock, call, create_autospec
 
 import pytest
 
@@ -14,8 +14,14 @@ from orquestra.sdk._base._testing._example_wfs import (
     workflow_with_different_resources,
 )
 from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
+from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.responses import JSONResult
-from orquestra.sdk.schema.workflow_run import State, WorkflowRunId
+from orquestra.sdk.schema.workflow_run import (
+    RunStatus,
+    State,
+    WorkflowRun,
+    WorkflowRunId,
+)
 
 
 @pytest.fixture
@@ -96,6 +102,24 @@ def workflow_def_id():
 @pytest.fixture
 def workflow_run_id():
     return "00000000-0000-0000-0000-000000000000"
+
+
+@pytest.fixture
+def workflow_run_status(workflow_run_id: WorkflowRunId):
+    def _workflow_run(state: State):
+        workflow_def_mock = create_autospec(WorkflowDef)
+        return WorkflowRun(
+            id=workflow_run_id,
+            workflow_def=workflow_def_mock,
+            task_runs=[],
+            status=RunStatus(
+                state=state,
+                start_time=None,
+                end_time=None,
+            ),
+        )
+
+    return _workflow_run
 
 
 class TestCreateWorkflowRun:
@@ -481,16 +505,36 @@ class TestGetWorkflowRunResultsNonBlocking:
             with pytest.raises(exceptions.WorkflowRunNotFoundError):
                 _ = runtime.get_workflow_run_outputs_non_blocking(workflow_run_id)
 
-        def test_no_results(
+        def test_no_results_not_succeeded(
             self,
             mocked_client: MagicMock,
             runtime: _ce_runtime.CERuntime,
             workflow_run_id: str,
+            workflow_run_status,
         ):
             # Given
             mocked_client.get_workflow_run_results.return_value = []
+            mocked_client.get_workflow_run.return_value = workflow_run_status(
+                State.RUNNING
+            )
             # When
             with pytest.raises(exceptions.WorkflowRunNotSucceeded):
+                _ = runtime.get_workflow_run_outputs_non_blocking(workflow_run_id)
+
+        def test_no_results_succeeded(
+            self,
+            mocked_client: MagicMock,
+            runtime: _ce_runtime.CERuntime,
+            workflow_run_id: str,
+            workflow_run_status,
+        ):
+            # Given
+            mocked_client.get_workflow_run_results.return_value = []
+            mocked_client.get_workflow_run.return_value = workflow_run_status(
+                State.SUCCEEDED
+            )
+            # When
+            with pytest.raises(exceptions.WorkflowResultsNotReadyError):
                 _ = runtime.get_workflow_run_outputs_non_blocking(workflow_run_id)
 
         def test_unknown_http(

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -523,6 +523,7 @@ class TestGetWorkflowRunResultsNonBlocking:
 
         def test_no_results_succeeded(
             self,
+            monkeypatch: pytest.MonkeyPatch,
             mocked_client: MagicMock,
             runtime: _ce_runtime.CERuntime,
             workflow_run_id: str,
@@ -533,9 +534,34 @@ class TestGetWorkflowRunResultsNonBlocking:
             mocked_client.get_workflow_run.return_value = workflow_run_status(
                 State.SUCCEEDED
             )
+            monkeypatch.setattr(_ce_runtime._retry.time, "sleep", Mock())
             # When
             with pytest.raises(exceptions.WorkflowResultsNotReadyError):
                 _ = runtime.get_workflow_run_outputs_non_blocking(workflow_run_id)
+
+            # We should try a few times if the results were not ready
+            assert mocked_client.get_workflow_run_results.call_count == 5
+
+        def test_eventually_get_results(
+            self,
+            monkeypatch: pytest.MonkeyPatch,
+            mocked_client: MagicMock,
+            runtime: _ce_runtime.CERuntime,
+            workflow_run_id: str,
+            workflow_run_status,
+        ):
+            # Given
+            mocked_client.get_workflow_run_results.side_effect = [[], [], [Mock()]]
+            mocked_client.get_workflow_run.return_value = workflow_run_status(
+                State.SUCCEEDED
+            )
+            monkeypatch.setattr(_ce_runtime.serde, "deserialize", lambda x: x)
+            monkeypatch.setattr(_ce_runtime._retry.time, "sleep", Mock())
+            # When
+            _ = runtime.get_workflow_run_outputs_non_blocking(workflow_run_id)
+
+            # We should have the results after 3 attempts
+            assert mocked_client.get_workflow_run_results.call_count == 3
 
         def test_unknown_http(
             self,


### PR DESCRIPTION
# The problem

There's a short period of time between a workflow succeeding and the results being available from CE.
The leads to a weird error message:

```
WorkflowRunNotSucceeded: Workflow run `wf_sum_numbers-P1SVm-r000` is in state State.SUCCEEDED
```

# This PR's solution

Allows `CERuntime.get_workflow_run_results_non_blocking` to retry when it raises `WorkflowResultsNotReadyError`.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
