### PR TITLE
Feat: Add new config "self" to submit to CE from within a cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
+* New built-in config name - "self" - used to submit workflows to CE instance present on the cluster in which Jupiter Notebook is running on
 
 👩‍🔬 *Experimental*
 * Setting workflow_id and project_id is now available on workflow Python API start() and prepare() functions

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -323,7 +323,10 @@ class RuntimeConfig:
         Returns:
             list: list of configurations within the save file.
         """
-        return _config.read_config_names() + list(_config.UNIQUE_CONFIGS)
+        configs = _config.read_config_names() + list(_config.UNIQUE_CONFIGS)
+        if _config.is_self_config_available():
+            configs += _config.SAME_CLUSTER_CONFIG_NAME
+        return configs
 
     @classmethod
     def load(

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -325,7 +325,7 @@ class RuntimeConfig:
         """
         configs = _config.read_config_names() + list(_config.UNIQUE_CONFIGS)
         if _config.is_self_config_available():
-            configs += _config.SAME_CLUSTER_CONFIG_NAME
+            configs.append(_config.SAME_CLUSTER_CONFIG_NAME)
         return configs
 
     @classmethod

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -22,7 +22,7 @@ from orquestra.sdk.schema.configs import (
     RuntimeName,
 )
 
-from ._env import CONFIG_PATH_ENV
+from ._env import CONFIG_PATH_ENV, PASSPORT_FILE_ENV
 
 # Why JSON?
 #  The Python TOML package is unmaintained as of 2022-02-18.
@@ -35,6 +35,7 @@ LOCK_FILE_NAME = "config.json.lock"
 BUILT_IN_CONFIG_NAME = "local"
 RAY_CONFIG_NAME_ALIAS = "ray"
 IN_PROCESS_CONFIG_NAME = "in_process"
+SAME_CLUSTER_CONFIG_NAME = "self"
 
 LOCAL_RUNTIME_CONFIGURATION = RuntimeConfiguration(
     config_name=BUILT_IN_CONFIG_NAME,
@@ -51,6 +52,12 @@ IN_PROCESS_RUNTIME_CONFIGURATION = RuntimeConfiguration(
     config_name=IN_PROCESS_CONFIG_NAME,
     runtime_name=RuntimeName.IN_PROCESS,
     runtime_options={},
+)
+# this runtime config is not ready-to-be-used without runtime options
+SAME_CLUSTER_RUNTIME_CONFIGURATION = RuntimeConfiguration(
+    config_name=SAME_CLUSTER_CONFIG_NAME,
+    runtime_name=RuntimeName.CE_REMOTE,
+    runtime_options={}
 )
 
 SPECIAL_CONFIG_NAME_DICT = {
@@ -109,6 +116,10 @@ def _get_config_file_path() -> Path:
         _config_file_path = Path.home() / ".orquestra" / CONFIG_FILE_NAME
     _ensure_directory(_config_file_path.parent)
     return _config_file_path
+
+
+def is_self_config_available() -> bool:
+    return PASSPORT_FILE_ENV in os.environ
 
 
 def _get_config_directory() -> Path:

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -58,7 +58,7 @@ IN_PROCESS_RUNTIME_CONFIGURATION = RuntimeConfiguration(
 SAME_CLUSTER_RUNTIME_CONFIGURATION = RuntimeConfiguration(
     config_name=SAME_CLUSTER_CONFIG_NAME,
     runtime_name=RuntimeName.CE_REMOTE,
-    runtime_options={}
+    runtime_options={},
 )
 SAME_CLUSTER_URL = "http://workflow-driver.workflow-driver"
 
@@ -66,7 +66,7 @@ SPECIAL_CONFIG_NAME_DICT = {
     IN_PROCESS_CONFIG_NAME: IN_PROCESS_RUNTIME_CONFIGURATION,
     BUILT_IN_CONFIG_NAME: LOCAL_RUNTIME_CONFIGURATION,
     RAY_CONFIG_NAME_ALIAS: LOCAL_RUNTIME_CONFIGURATION,
-    SAME_CLUSTER_CONFIG_NAME: SAME_CLUSTER_RUNTIME_CONFIGURATION
+    SAME_CLUSTER_CONFIG_NAME: SAME_CLUSTER_RUNTIME_CONFIGURATION,
 }
 # Unique config list to prompt to the users. Separate from SPECIAL_CONFIG_NAME_DICT
 # as SPECIAL_CONFIG_NAME_DICT might have duplicate names which could be confusing for
@@ -211,8 +211,10 @@ def _handle_same_cluster_config_case(config_name) -> RuntimeConfiguration:
 
     passport_token = Path(passport_file).read_text()
     runtime_config = SPECIAL_CONFIG_NAME_DICT[config_name]
-    runtime_config.runtime_options = {"uri": SAME_CLUSTER_URL,
-                                      "token": passport_token,}
+    runtime_config.runtime_options = {
+        "uri": SAME_CLUSTER_URL,
+        "token": passport_token,
+    }
     return runtime_config
 
 

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -115,7 +115,7 @@ class DriverClient:
     """
 
     def __init__(self, base_uri: str, session: requests.Session):
-        self._base_uri = "http://workflow-driver.workflow-driver"#base_uri
+        self._base_uri = base_uri
         self._session = session
 
     @classmethod

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -115,7 +115,7 @@ class DriverClient:
     """
 
     def __init__(self, base_uri: str, session: requests.Session):
-        self._base_uri = base_uri
+        self._base_uri = "http://workflow-driver.workflow-driver"#base_uri
         self._session = session
 
     @classmethod

--- a/tests/sdk/v2/api/test_config.py
+++ b/tests/sdk/v2/api/test_config.py
@@ -307,6 +307,8 @@ class TestRuntimeConfiguration:
             assert config_names == [name for name in TEST_CONFIGS_DICT] + list(
                 _config.UNIQUE_CONFIGS
             )
+            # this config name should appear only when proper env var is set
+            assert _config.SAME_CLUSTER_CONFIG_NAME not in config_names
 
         @staticmethod
         def test_custom_file_location(
@@ -337,6 +339,13 @@ class TestRuntimeConfiguration:
             config_names = api_cfg.RuntimeConfig.list_configs()
 
             assert config_names == list(_config.UNIQUE_CONFIGS)
+
+        @staticmethod
+        def test_self_config_name(monkeypatch, tmp_config_json):
+            monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", "some_file_path")
+            config_names = api_cfg.RuntimeConfig.list_configs()
+
+            assert _config.SAME_CLUSTER_CONFIG_NAME in config_names
 
     class TestLoad:
         @pytest.mark.parametrize("config_name", [name for name in TEST_CONFIGS_DICT])
@@ -375,6 +384,32 @@ class TestRuntimeConfiguration:
                 api_cfg.RuntimeConfig.load(
                     "non-existing",
                 )
+
+        class TestLoadOnSameCluster:
+            def test_happy_path(self, monkeypatch, tmp_path):
+                token = "the best token you have ever seen"
+                pass_file = tmp_path / "pass.port"
+                pass_file.write_text(token)
+                monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
+
+                cfg = api_cfg.RuntimeConfig.load(
+                    "self",
+                )
+
+                assert cfg.token == token
+
+            def test_no_env_variable(self):
+                with pytest.raises(NotImplementedError):
+                    api_cfg.RuntimeConfig.load(
+                        "self",
+                    )
+
+            def test_no_file(self, monkeypatch):
+                monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", "non-existing-path")
+                with pytest.raises(FileNotFoundError):
+                    api_cfg.RuntimeConfig.load(
+                        "self",
+                    )
 
     class TestLoadDefault:
         @staticmethod

--- a/tests/sdk/v2/api/test_config.py
+++ b/tests/sdk/v2/api/test_config.py
@@ -399,7 +399,7 @@ class TestRuntimeConfiguration:
                 assert cfg.token == token
 
             def test_no_env_variable(self):
-                with pytest.raises(NotImplementedError):
+                with pytest.raises(ValueError):
                     api_cfg.RuntimeConfig.load(
                         "self",
                     )


### PR DESCRIPTION
https://zapatacomputing.atlassian.net/browse/ORQSDK-772

# The problem

Clusters have embedded passport token to be used from within their internals.
For user convenience they shouldn't have to log-in into the same cluster from within portal studio

# This PR's solution

add new config named <self> which can be used to interact with CE from within portal and studio.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
