### PR TITLE
docs: fix formatting in the Resource Management guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 🥷 *Internal*
 
 📃 *Docs*
+* _Resource Management_ guide should render properly now.
 
 ## v0.46.0
 

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -1,9 +1,10 @@
 Resource Management
-=======================
+===================
 
 Workflows submitted to run on Compute Engine and Local Ray can specify the computational resources they require, enabling precise management of resources and costs.
 
 .. note::
+
     Resource management is supported only when executing on Compute Engine and Local Ray runtimes. Tasks and workflows defined with these parameters may still be executed on other runtimes, however the resource specification will be ignored.
 
 Setting Task Resources
@@ -12,7 +13,7 @@ Setting Task Resources
 Required hardware resources are configured on a per-task basis by setting the ``resources`` field of the task decorator:
 
 .. code-block::
-   :caption: task resource request example
+    :caption: Task resource request example
 
     @sdk.task(
         resources=sdk.Resources(cpu="100m", memory="1Gi", disk="10Gi", gpu="1")
@@ -28,7 +29,7 @@ Required hardware resources are configured on a per-task basis by setting the ``
 
 Amounts of cpu and memory resources are specified by a string comprising a floating point value, and, optionally, a modifier to the base unit ('byte' in the case of ``memory`` and ``disk`` requests, 'cores' in the case of ``cpu`` requests). The modifier can be a SI (metric), or IEC (binary) multiplier as detailed in the table below. So ``disk="10k"`` will be interpreted as '10 kilobytes', while ``cpu="10k"`` would request 10^7 cores.
 
-.. table:: unit multipliers
+.. table:: Unit multipliers
     :widths: auto
 
     +---------+-------+--------+-------+
@@ -54,7 +55,8 @@ Amounts of cpu and memory resources are specified by a string comprising a float
 
 Convention is to use binary prefixes for memory resource requests (``disk`` and ``memory``), and decimal prefixes to specify the number of cores. The task resource request example above specifies a task that requires 100 milicores (or 0.1 cores), 1 gibibyte of RAM (2^30 bytes), 10 gibibytes of disk space(1.25*2^33 bytes), and access to a GPU.
 
-.. note:: mixing unit prefixes
+.. note::
+
     Binary and decimal units can be used interchangeably, however this can occasionally cause confusion, and care must be taken when specifying these parameters. For example, a memory request of ``100m`` specifies not 100 megabytes, but 100 millibytes, or 0.1 bytes.
 
 Setting Workflow Resources
@@ -68,7 +70,7 @@ Resources can also be configured at the workflow definition level using the same
 * ``nodes``: the number of nodes requested.
 
 .. code-block::
-    :caption: workflow resource request example
+    :caption: Workflow resource request example
 
     @sdk.workflow(
         resources=sdk.Resources(cpu="100m", memory="1Gi", disk="10Gi", gpu="1", nodes=5)
@@ -77,7 +79,8 @@ Resources can also be configured at the workflow definition level using the same
         ...
 
 
-.. note:: nodes
+.. note::
+
     Note that unlike the other parameters, ``nodes`` must be an integer rather than a string.
 
 Currently, the workflow resource request is only utilised by Compute Engine.
@@ -96,12 +99,13 @@ Due to the way Ray's RLLib works, a deadlock can be created on Compute Engine if
 In these cases, additional resources should be specified in the workflow decorator.
 
 .. code-block::
-    :caption: Example: override workflow resources.
-    @sdk.task(resources=...)                    # task resources requested.
+    :caption: Example: override workflow resources
+
+    @sdk.task(resources=...)                    # Task resources requested.
     def task():
         config = DQNConfig()
         ...
-        config.rollouts(num_rollout_workers=2)  # additional actors do not have
+        config.rollouts(num_rollout_workers=2)  # Additional actors do not have
         ...                                     # access to task resources.
         return results
 

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -27,7 +27,7 @@ Required hardware resources are configured on a per-task basis by setting the ``
 * ``disk``: disk space (bytes).
 * ``gpu``: whether access to a gpu unit is required (``1`` if a GPU is required, ``0`` otherwise).
 
-Amounts of cpu and memory resources are specified by a string comprising a floating point value, and, optionally, a modifier to the base unit ('byte' in the case of ``memory`` and ``disk`` requests, 'cores' in the case of ``cpu`` requests). The modifier can be a SI (metric), or IEC (binary) multiplier as detailed in the table below. So ``disk="10k"`` will be interpreted as '10 kilobytes', while ``cpu="10k"`` would request 10^7 cores.
+Amounts of CPU and memory resources are specified by a string comprising a floating point value, and, optionally, a modifier to the base unit ('byte' in the case of ``memory`` and ``disk`` requests, 'cores' in the case of ``cpu`` requests). The modifier can be a SI (metric), or IEC (binary) multiplier as detailed in the table below. So ``disk="10k"`` will be interpreted as '10 kilobytes', while ``cpu="10k"`` would request 10^7 cores.
 
 .. table:: Unit multipliers
     :widths: auto
@@ -53,7 +53,7 @@ Amounts of cpu and memory resources are specified by a string comprising a float
     |         | exa   | E      | 10^18 |
     +---------+-------+--------+-------+
 
-Convention is to use binary prefixes for memory resource requests (``disk`` and ``memory``), and decimal prefixes to specify the number of cores. The task resource request example above specifies a task that requires 100 milicores (or 0.1 cores), 1 gibibyte of RAM (2^30 bytes), 10 gibibytes of disk space(1.25*2^33 bytes), and access to a GPU.
+Convention is to use binary prefixes for memory resource requests (``disk`` and ``memory``), and decimal prefixes to specify the number of cores. The task resource request example above specifies a task that requires 100 millicores (or 0.1 cores), 1 gibibyte of RAM (2^30 bytes), 10 gibibytes of disk space(1.25*2^33 bytes), and access to a GPU.
 
 .. note::
 
@@ -122,12 +122,12 @@ This might lead to issues when running tasks locally if they require resources t
 
 For example, you have a task that requires:
 
-1. a GPU but during development you run the workflow on your laptop without a GPU.
-2. 32GB of memory, but your Studio notebook only has 8GB available.
+1. A GPU but during development you run the workflow on your laptop without a GPU.
+2. 32 GB of memory, but your Studio notebook only has 8 GB available.
 3. 16 CPU cores but your desktop only has 8 available.
 
 In these examples, those tasks will not be scheduled by a local Ray instance due to the lack of resources.
-To workaround this problem, you should reduce the resources to match what is available. This can be done in the decorator:
+To work around this problem, you should reduce the resources to match what is available. This can be done in the decorator:
 
 .. code-block::
 

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -125,14 +125,16 @@ For example, you have a task that requires:
 In these examples, those tasks will not be scheduled by a local Ray instance due to the lack of resources.
 To workaround this problem, you should reduce the resources to match what is available. This can be done in the decorator:
 
-.. code-block:
+.. code-block::
+
     @sdk.task(resources=sdk.Resources(gpu="0"))
     def my_task():
         ...
 
 or when the task is invoked, with the ``.with_resources()`` method:
 
-.. code-block:
+.. code-block::
+
     # Usual request
     @sdk.task(resources=sdk.Resources(gpu="1"))
     def my_task():


### PR DESCRIPTION
# The problem

After we made the last release, @jamesclark-Zapata [noticed](https://github.com/zapatacomputing/orquestra-docs/pull/66) one of our guides doesn't render properly.

# This PR's solution

Applies few language-tool's spelling suggestions. But also:

## Makes all the code snippets show up

Before:
![image](https://user-images.githubusercontent.com/6004040/232572850-4cc2c638-e6e0-4b11-b5e0-8dce38f715ec.png)


## Fixes directive labels being put inside the rendered boxes

Before:
![image](https://user-images.githubusercontent.com/6004040/232573092-0295ccc4-80b9-4115-af98-bde7a4236785.png)

After:
![image](https://user-images.githubusercontent.com/6004040/232573363-55c35810-d971-481a-aced-3f6ac0ad8021.png)



# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
