### PR TITLE
fix: Do not modify arg when building Ray workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Setting workflow_id and project_id is now available on workflow Python API start() and prepare() functions
 
 🐛 *Bug Fixes*
+* Using secrets inside the workflow function will now work correctly on Ray
 
 💅 *Improvements*
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -383,7 +383,11 @@ def _make_ray_dag(
     client: RayClient, wf: ir.WorkflowDef, wf_run_id: str, project_dir: t.Optional[Path]
 ):
     # We need to modify the dictionary, by adding new key-values.
-    # A shallow copy is OK, as long as we don't modify the _values_ in the dict.
+    # We will need to make a copy to prevent mutating the argument.
+    # Note: this is a *shallow copy* and the values in the dict are not copied but still
+    #       reference the original values. This only works with the assumption that we
+    #       DO NOT MUTATE values in the dictionary.
+    #       When this was implemented, we did not mutate values and only added new keys.
     ray_consts: t.Dict[ir.ConstantNodeId, t.Any] = wf.constant_nodes.copy()
 
     for id, secret in wf.secret_nodes.items():

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -382,7 +382,9 @@ def _gather_kwargs(
 def _make_ray_dag(
     client: RayClient, wf: ir.WorkflowDef, wf_run_id: str, project_dir: t.Optional[Path]
 ):
-    ray_consts: t.Dict[ir.ConstantNodeId, t.Any] = wf.constant_nodes
+    # We need to modify the dictionary, by adding new key-values.
+    # A shallow copy is OK, as long as we don't modify the _values_ in the dict.
+    ray_consts: t.Dict[ir.ConstantNodeId, t.Any] = wf.constant_nodes.copy()
 
     for id, secret in wf.secret_nodes.items():
         ray_consts[id] = secrets.get(


### PR DESCRIPTION
# The problem

We modified the workflow def's constants when building Ray workflows. Python passes args by ref and this mutated the original workflow def, breaking workflow parsing later.

# This PR's solution

* Copies the requires constants instead of mutating

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
