### PR TITLE
Fix: Fix WorkflowDef.graph function to properly generate graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 🐛 *Bug Fixes*
 * Retry getting results from CE if the results were not ready but the workflow succeeded.
 * Using secrets inside the workflow function will now work correctly on Ray
+* Fix WorkflowDef.graph - honour kwargs of tasks and add aggregate_output to show outputs
 
 💅 *Improvements*
 

--- a/src/orquestra/sdk/_base/_viz.py
+++ b/src/orquestra/sdk/_base/_viz.py
@@ -5,6 +5,7 @@
 Workflow visualization using graphviz.
 """
 
+import itertools
 import typing as t
 from dataclasses import dataclass
 
@@ -87,7 +88,7 @@ def wf_def_graph(wf_def: ir.WorkflowDef) -> BiGraph:
         )
 
         # 2. Connect task with arguments
-        for arg_id in task_inv.args_ids:
+        for arg_id in itertools.chain(task_inv.args_ids, task_inv.kwargs_ids.values()):
             # We don't define a node here, because artifacts are declared with the
             # tasks that produce them (below), and workflow constants are defined
             # totally separately.
@@ -101,6 +102,11 @@ def wf_def_graph(wf_def: ir.WorkflowDef) -> BiGraph:
     # 4. Add workflow constants
     for constant in wf_def.constant_nodes.values():
         artifact_nodes.append(Node(id=constant.id, caption=[constant.value_preview]))
+
+    aggregation_step_id = "aggregation_step"
+    artifact_nodes.append(Node(id=aggregation_step_id, caption=["outputs"]))
+    for wf_output in wf_def.output_ids:
+        edges.append((wf_output, aggregation_step_id))
 
     return BiGraph(nodes1=task_nodes, nodes2=artifact_nodes, edges=edges)
 

--- a/tests/sdk/v2/sample_wfs.py
+++ b/tests/sdk/v2/sample_wfs.py
@@ -32,7 +32,7 @@ def integer_division(a, b):
 @sdk.workflow
 def wf(param: int):
     floor, remainder = integer_division(param, 3)
-    floor_plus_6 = add(floor, 6)
+    floor_plus_6 = add(a=floor, b=6)
     remainder_plus_3 = inc(inc_2(remainder))
 
     return floor_plus_6, remainder_plus_3

--- a/tests/sdk/v2/test_viz.py
+++ b/tests/sdk/v2/test_viz.py
@@ -14,6 +14,7 @@ class TestWfDefGraph:
     @staticmethod
     def test_example_nodes_edges():
         """ """
+        aggregate_step_name = "aggregation_step"
         wf_def = sample_wfs.wf(123).model
         graph = _viz.wf_def_graph(wf_def)
 
@@ -38,6 +39,7 @@ class TestWfDefGraph:
                 caption=["tests.sdk.v2.sample_wfs.add():12", "invocation-3-task-add"],
             ),
         ]
+
         assert graph.nodes2 == [
             _viz.Node(id="artifact-0-inc", caption=[]),
             _viz.Node(id="artifact-1-inc-2", caption=[]),
@@ -47,6 +49,7 @@ class TestWfDefGraph:
             _viz.Node(id="constant-0", caption=["3"]),
             _viz.Node(id="constant-1", caption=["123"]),
             _viz.Node(id="constant-2", caption=["6"]),
+            _viz.Node(id=aggregate_step_name, caption=["outputs"])
         ]
         assert graph.edges == [
             ("artifact-1-inc-2", "invocation-0-task-inc"),
@@ -60,4 +63,6 @@ class TestWfDefGraph:
             ("artifact-4-integer-division", "invocation-3-task-add"),
             ("constant-2", "invocation-3-task-add"),
             ("invocation-3-task-add", "artifact-3-add"),
+            ("artifact-3-add", aggregate_step_name),
+            ("artifact-0-inc", aggregate_step_name),
         ]

--- a/tests/sdk/v2/test_viz.py
+++ b/tests/sdk/v2/test_viz.py
@@ -49,7 +49,7 @@ class TestWfDefGraph:
             _viz.Node(id="constant-0", caption=["3"]),
             _viz.Node(id="constant-1", caption=["123"]),
             _viz.Node(id="constant-2", caption=["6"]),
-            _viz.Node(id=aggregate_step_name, caption=["outputs"])
+            _viz.Node(id=aggregate_step_name, caption=["outputs"]),
         ]
         assert graph.edges == [
             ("artifact-1-inc-2", "invocation-0-task-inc"),


### PR DESCRIPTION
# The problem

WorkflowDef.graph produced weird results - discontinuous graphs that looked wrong:
https://zapatacomputing.atlassian.net/browse/ORQSDK-804

# This PR's solution

Fix consists of 2 minor changes:
- creating edges between graphs did not take into account kwargs, which created discontinuity
- aggregation_step was not created at all so it was difficult to see what step is at what stage

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
