### PR TITLE
chore: add reminder about linking JIRA tickets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,3 +13,4 @@ _Check that this PR satisfies the following items:_
 - [ ] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
 - [ ] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
 - [ ] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
+- [ ] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


### PR DESCRIPTION
# The problem

We correlate JIRA tickets with PRs. This helps figuring out what was released/what still needs to be released. It was easy to forget to link a PR with a ticket.

# This PR's solution

Adds an item to the PR checklist

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).