### PR TITLE
Feat: Change "self" config name to "auto". "auto" config acts as "local" if not on studio environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
-* New built-in config name - "auto" - used to submit workflows to CE instance present on the cluster in which Jupiter Notebook is running on.
-* "auto" built-in config name becomes alias to "local" if not on studio environment
+* New built-in config name - "auto" - used to submit workflows to a remote cluster when used inside Orquestra Studio.
+* "auto" built-in config name becomes alias to "local" if not in a Studio environment
 
 👩‍🔬 *Experimental*
 * Setting workflow_id and project_id is now available on workflow Python API start() and prepare() functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
-* New built-in config name - "self" - used to submit workflows to CE instance present on the cluster in which Jupiter Notebook is running on
+* New built-in config name - "auto" - used to submit workflows to CE instance present on the cluster in which Jupiter Notebook is running on.
+* "auto" built-in config name becomes alias to "local" if not on studio environment
 
 👩‍🔬 *Experimental*
 * Setting workflow_id and project_id is now available on workflow Python API start() and prepare() functions

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -324,8 +324,8 @@ class RuntimeConfig:
             list: list of configurations within the save file.
         """
         configs = _config.read_config_names() + list(_config.UNIQUE_CONFIGS)
-        if _config.is_self_config_available():
-            configs.append(_config.SAME_CLUSTER_CONFIG_NAME)
+        if _config.is_passport_file_available():
+            configs.append(_config.AUTO_CONFIG_NAME)
         return configs
 
     @classmethod

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -200,7 +200,7 @@ def _resolve_new_config_file(
 
 
 def _resolve_auto_config(config_name) -> RuntimeConfiguration:
-    # if not on the studio environment, return local-ray as autoconfiguration
+    # if not in the Studio environment, return local Ray as auto configuration
     if PASSPORT_FILE_ENV not in os.environ:
         return LOCAL_RUNTIME_CONFIGURATION
     passport_file = pathlib.Path(os.environ[PASSPORT_FILE_ENV])


### PR DESCRIPTION


# The problem

After discussion on OWG there were some comments on the naming of special case-config related submitting workflows to the same cluster:
https://zapatacomputing.atlassian.net/browse/ORQSDK-822

# This PR's solution

Changes "self" config name to "auto"

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
