### PR TITLE
fix: Set max retries in Ray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
+* Tasks will no longer be retried on Ray and Compute Engine when the process crashes, preventing duplicated MLflow errors.
 
 💅 *Improvements*
 

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -402,6 +402,8 @@ def make_ray_dag(
             "metadata": None,
             "runtime_env": None,
             "catch_exceptions": True,
+            # Set to avoid retrying when the worker crashes.
+            # See the comment with the invocation's options for more details.
             "max_retries": 0,
         },
         ray_args=pos_args,

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -348,6 +348,13 @@ def make_ray_dag(
             # If there are any python packages to install for step - set runtime env
             "runtime_env": (_client.RuntimeEnv(pip=pip) if len(pip) > 0 else None),
             "catch_exceptions": False,
+            # We only want to execute workflow tasks once. This is so there is only one
+            # task run ID per task, for scenarios where this is used (like in MLFlow).
+            # By default, Ray will only retry tasks that fail due to a "system error".
+            # For example, if the worker process crashes or exits early.
+            # Normal Python exceptions are NOT retried.
+            # So, we turn max_retries down to 0.
+            "max_retries": 0,
         }
 
         # Task resources
@@ -395,6 +402,7 @@ def make_ray_dag(
             "metadata": None,
             "runtime_env": None,
             "catch_exceptions": True,
+            "max_retries": 0,
         },
         ray_args=pos_args,
         ray_kwargs={},

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -85,10 +85,12 @@ else:
         def add_options(
             self,
             ray_remote_fn,
+            *,
             name: str,
             metadata: t.Dict[str, t.Any],
             runtime_env: t.Optional[RuntimeEnv],
             catch_exceptions: t.Optional[bool],
+            max_retries: int,
             num_cpus: t.Optional[t.Union[int, float]] = None,
             num_gpus: t.Optional[t.Union[int, float]] = None,
             memory: t.Optional[t.Union[int, float]] = None,
@@ -110,6 +112,7 @@ else:
             return ray_remote_fn.options(
                 **ray.workflow.options(**workflow_opts),
                 runtime_env=runtime_env,
+                max_retries=max_retries,
                 **ray_optional_opts,
             )
 

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -158,6 +158,7 @@ class TestResourcesInMakeDag:
             metadata=ANY,
             runtime_env=ANY,
             catch_exceptions=ANY,
+            max_retries=ANY,
             **expected
         )
         for kwarg_name, type_ in types.items():

--- a/tests/runtime/ray/test_client.py
+++ b/tests/runtime/ray/test_client.py
@@ -26,6 +26,7 @@ class TestClient:
                 "metadata": {},
                 "catch_exceptions": False,
                 "runtime_env": None,
+                "max_retries": 0,
             }
 
         def test_required_args(self, client: RayClient, remote_fn, required_kwargs):
@@ -39,6 +40,7 @@ class TestClient:
                     }
                 },
                 runtime_env=required_kwargs["runtime_env"],
+                max_retries=required_kwargs["max_retries"],
             )
 
         @pytest.mark.parametrize(
@@ -65,5 +67,6 @@ class TestClient:
                     }
                 },
                 runtime_env=required_kwargs["runtime_env"],
+                max_retries=required_kwargs["max_retries"],
                 **expected,
             )


### PR DESCRIPTION
# The problem

When a Ray worker crashes, it will try to run the task again. This causes issues when using things that assume a single execution of a task.

# This PR's solution

* Set `max_retries` to 0.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
