### PR TITLE
internal: allow Ray 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * In the CLI, where the user would be prompted with a choice but only one option is available, we now prompt for confirmation instead.
 
 🥷 *Internal*
+* Allow using Ray 2.4.0.
 
 📃 *Docs*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,9 @@ where = src
 
 [options.extras_require]
 ray =
-    ray[default]==2.3.0
+    # We need to be strict with Ray version because there's high risk of
+    # breaking stuff even with patch bumps.
+    ray[default]>=2.3.0,<=2.4.0
     # Ray workflows also requires pyarrow but it's missing from their requirements.
     pyarrow
 all =

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -35,8 +35,6 @@ else:
     Storage = ray.workflow.storage.Storage
     RuntimeEnv = ray.runtime_env.RuntimeEnv
     FunctionNode = ray.dag.FunctionNode
-    SessionLatest = ray._private.node.SESSION_LATEST
-    TempDir = ray._private.utils.get_ray_temp_dir()
     LogPrefixActorName = ray._private.ray_constants.LOG_PREFIX_ACTOR_NAME
     LogPrefixTaskName = ray._private.ray_constants.LOG_PREFIX_TASK_NAME
 


### PR DESCRIPTION
# The problem

Ray 2.4.0 was released. We had a strict requirement on 2.3.0. It wasn't possible to use 2.4.0 unless you depend on pip weirdness.

# This PR's solution

Loosens the requirement on Ray so `orquestra-sdk` can be used with both Ray 2.3.0 and 2.4.0. If a user project doesn't work with Ray 2.4.0, it should be added as a project requirement instead of our requirement.

This might also help with hanging Windows tests.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
