### PR TITLE
internal: Tagging Docker images via optional parameter [OP-39]

### DIFF
--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -11,6 +11,11 @@ on:
           orquestra-sdk[ray]==0.47.0 
           Example of using an unpublished version:
           orquestra-sdk[ray] @ git+https://github.com/zapatacomputing/orquestra-workflow-sdk.git@v0.47.0
+      docker_tag:
+        type: string
+        description: |
+          Optional parameter to tag the Docker image. If provided,
+          the published image will be tagged with the given tag.
 jobs:
   trigger-build-and-push:
     runs-on: ubuntu-20.04
@@ -59,7 +64,7 @@ jobs:
           # See https://github.com/docker/metadata-action#tags-input for the
           # format this should take.
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
-          additional_image_tags: ''
+          additional_image_tags: 'type=raw,value=${{ inputs.docker_tag }}'
           # For changing `latest` tag behavior, as well as global prefix/suffixes
           # See https://github.com/docker/metadata-action#flavor-input
           # for details on how to use the `flavor` input.

--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -16,6 +16,8 @@ on:
         description: |
           Optional parameter to tag the Docker image. If provided,
           the published image will be tagged with the given tag.
+          For e.g. if foo-123 is given, the final image will be named
+          hub.stage.nexus.orquestra.io/zapatacomputing/orquestra-sdk-base:foo-123
 jobs:
   trigger-build-and-push:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -11,6 +11,11 @@ on:
           orquestra-sdk[ray]==0.47.0 
           Example of using an unpublished version:
           orquestra-sdk[ray] @ git+https://github.com/zapatacomputing/orquestra-workflow-sdk.git@v0.47.0
+      docker_tag:
+        type: string
+        description: |
+          Optional parameter to tag the Docker image. If provided,
+          the published image will be tagged with the given tag.
 jobs:
   trigger-build-and-push:
     runs-on: ubuntu-20.04
@@ -59,7 +64,7 @@ jobs:
           # See https://github.com/docker/metadata-action#tags-input for the
           # format this should take.
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
-          additional_image_tags: ''
+          additional_image_tags: 'type=raw,value=${{ inputs.docker_tag }}'
           # For changing `latest` tag behavior, as well as global prefix/suffixes
           # See https://github.com/docker/metadata-action#flavor-input
           # for details on how to use the `flavor` input.


### PR DESCRIPTION
# The problem

It's not possible to tag Docker images based on the SDK version with the current version of the GitHub Actions workflow that we have for publishing Docker images.

# This PR's solution

Add an optional parameter to the GitHub Actions workflow that publishes Docker images to optionally tag the published Docker image. This way, when we want to publish a Docker image and also tag it with the version of SDK that it uses, we'll be able to do so.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
