### PR TITLE
Internal, Fix: rewrite tests to use sockets instead of FS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 🥷 *Internal*
 * Switch the login URL endpoint
+* Rewrite tests to avoid hangs on Windows CI
 
 📃 *Docs*
 

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -8,6 +8,7 @@ from typing import Optional, Sequence
 import orquestra.sdk as sdk
 import orquestra.sdk._base._testing._ipc as ipc
 
+
 @sdk.task
 def make_greeting(name, company_name):
     return f"yooooo {name} from {company_name}"

--- a/src/orquestra/sdk/_base/_testing/_ipc.py
+++ b/src/orquestra/sdk/_base/_testing/_ipc.py
@@ -1,7 +1,7 @@
-import socket
 import select
-import typing as t
+import socket
 import time
+import typing as t
 
 TRIGGER_MSG = "t".encode()
 

--- a/src/orquestra/sdk/_base/_testing/_ipc.py
+++ b/src/orquestra/sdk/_base/_testing/_ipc.py
@@ -1,0 +1,56 @@
+import socket
+import select
+import typing as t
+import time
+
+TRIGGER_MSG = "t".encode()
+
+
+class TriggerServer:
+    def __init__(self):
+        self._trigger_msg: bytes = TRIGGER_MSG
+        self._socket: t.Optional[socket.socket] = None
+        self._port: t.Optional[int] = None
+
+        self.start()
+
+    @property
+    def port(self) -> int:
+        assert self._port is not None
+        return self._port
+
+    def start(self):
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.bind(("127.0.0.1", 0))
+        self._socket.listen()
+        self._port = self._socket.getsockname()[1]
+
+    def trigger(self):
+        assert self._socket is not None
+
+        client_socket, _ = self._socket.accept()
+        client_socket.send(self._trigger_msg)
+
+    def close(self):
+        self._socket.close()
+
+
+class TriggerClient:
+    def __init__(self, port: int):
+        self._port = port
+        self._trigger_msg = TRIGGER_MSG
+
+    def wait_on_trigger(self, timeout):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect(("127.0.0.1", self._port))
+        start_time = time.time()
+
+        while True:
+            input, _, _ = select.select([sock], [], [], 0.1)
+            if input:
+                incoming_data = sock.recv(1024)
+                assert incoming_data == self._trigger_msg
+                break
+            ts = time.time()
+            if ts - start_time > timeout:
+                raise TimeoutError()

--- a/src/orquestra/sdk/_base/_testing/_ipc.py
+++ b/src/orquestra/sdk/_base/_testing/_ipc.py
@@ -32,6 +32,8 @@ class TriggerServer:
         client_socket.send(self._trigger_msg)
 
     def close(self):
+        assert self._socket is not None
+
         self._socket.close()
 
 

--- a/src/orquestra/sdk/_base/_testing/_ipc.py
+++ b/src/orquestra/sdk/_base/_testing/_ipc.py
@@ -1,3 +1,6 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
 import select
 import socket
 import time
@@ -37,7 +40,7 @@ class TriggerServer:
         self._socket.close()
 
 
-class TriggerClient:
+class TriggerClient:  # pragma: no cover
     def __init__(self, port: int):
         self._port = port
         self._trigger_msg = TRIGGER_MSG

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -460,6 +460,7 @@ class TestRayRuntimeMethods:
             for trigger in triggers:
                 trigger.close()
 
+
 @pytest.mark.slow
 # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
 # unraisable exceptions. Last tested with Ray 2.3.0.

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -291,6 +291,7 @@ class TestRayRuntimeMethods:
             wf_run = runtime.get_workflow_run_status(wf_run_id)
             assert wf_run.status.state == State.TERMINATED
 
+        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_on_finished_workflow(self, runtime: _dag.RayRuntime, tmp_path):
             wf = _example_wfs.multioutput_task_wf.model
             wf_run_id = runtime.create_workflow_run(wf, None)

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -322,6 +322,7 @@ class TestRayRuntimeMethods:
                 JSONResult(value='"yooooo emiliano from zapata computing"'),
             )
 
+        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_failed_workflow(self, runtime: _dag.RayRuntime):
             wf_def = _example_wfs.exception_wf_with_multiple_values().model
             run_id = runtime.create_workflow_run(wf_def, None)


### PR DESCRIPTION
# The problem

Some of our tests were stuck for some reason.

# This PR's solution

 Rewriting IPC to sockets to see if this makes them more reliable

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
