### PR TITLE
feat: support for custom images on CE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@
 * Removed deprecated save() method from RuntimeConfig class
 * Removed is_saved() method and "name" setter from RuntimeConfig class
 * WorkflowRun.get_results() returns values consistent with vanilla python - single results are returned as-as, multiple results are returned as a tuple.
+* If you set a custom task image (`@sdk.task(custom_image=...)`), the local Ray runtime won't execute the task unless the local Ray cluster was started with custom resources.
 
 🔥 *Features*
 * New API functions: list_workspaces() and list_projects(). Usable only on CE runtime
 * Setting workflow_id and project_id is now available using "orq wf submit" command
+* Support for running tasks in Docker containers with custom images on Compute Engine.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -988,26 +988,31 @@ def task(
     custom_image: Optional[str] = None,
     custom_name: Optional[str] = None,
 ) -> Union[TaskDef[_P, _R], Callable[[Callable[_P, _R]], TaskDef[_P, _R]]]:
-    """Wraps a function into an SDK Task.
+    """
+    Wraps a function into an Orquestra Task.
+
+    The result is something you can use inside your `@sdk.workflow` function. If you
+    need to call the task's underlying function directly, see
+    ``orquestra.sdk.packaging.execute_task()``.
 
     Args:
         fn: A function definition to expose to Orquestra.
-        source_import: Tells Orquestra what git repo to clone to run this task
-            Only matters when running workflows remotely (on Quantum Engine).
-        dependency_imports: Tells Orquestra what other git repos need to be
-            cloned and installed before running this task. Use it only when
-            your dependencies aren't installable from PyPI. Only matters when
-            running workflows remotely (on Quantum Engine).
+        source_import: Tells Orquestra what "import" needs to be installed to access
+            this task's code. For more information see the ``Import``'s union definition
+            and the guide:
+            https://docs.orquestra.io/docs/core/sdk/guides/dependency-installation.html
+        dependency_imports: Tells Orquestra what other "imports" need to be
+            installed before running this task. For more information see:
+            https://docs.orquestra.io/docs/core/sdk/guides/dependency-installation.html
         resources: hints Orquestra what computational resources are required to
-            run this task. Only matters when running workflows remotely (on Quantum
-            Engine).
+            run this task. For more information see:
+            https://docs.orquestra.io/docs/core/sdk/guides/resource-management.html
         n_outputs: tells Orquestra how many outputs this task produces. If omitted,
             the SDK magically infers this information from the task function's source
             code by analyzing the Abstract Syntax Tree (AST).
         custom_image: tell the runtime to run this task in a docker container
-            preloaded with a custom docker image. If the runtime doesn't support
-            it, this field is ignored. Currently, this field only has effect
-            when running the workflow using QERuntime.
+            preloaded with a custom docker image. Only supported with remote workflows
+            sent to Quantum Engine and Compute Engine.
         custom_name: changes name for invocation of this task. Supports python
             formatting in brackets {} using task parameters. Currently, supports only
             values known at submit time. If parameter is unknown at submit time (e.g.

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -282,8 +282,21 @@ def wf_with_secrets():
 
 
 @sdk.workflow
-def workflow_parametrised_with_resources(cpu=None, memory=None, gpu=None):
-    return add(1, 1).with_invocation_meta(cpu=cpu, memory=memory, gpu=gpu)
+def workflow_parametrised_with_resources(
+    cpu=None, memory=None, gpu=None, custom_image=None
+):
+    future = add(1, 1)
+
+    if cpu is not None:
+        future = future.with_invocation_meta(cpu=cpu)
+    if memory is not None:
+        future = future.with_invocation_meta(memory=memory)
+    if gpu is not None:
+        future = future.with_invocation_meta(gpu=gpu)
+    if custom_image is not None:
+        future = future.with_invocation_meta(custom_image=custom_image)
+
+    return future
 
 
 @sdk.workflow

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -1,3 +1,9 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Translates IR workflow def into a Ray workflow.
+"""
 import os
 import traceback
 import typing as t

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -321,7 +321,8 @@ def _ray_resources_for_custom_image(image_name: str) -> t.Mapping[str, float]:
     Custom Ray resources we set to power running Orquestra tasks on custom Docker
     images. The values are coupled with Compute Engine server-side set up.
     """
-    # TODO: link the ADR where the Ray resource name syntax is specified.
+    # The format for custom image strings is described in the ADR:
+    # https://zapatacomputing.atlassian.net/wiki/spaces/ORQSRUN/pages/688259073/2023-05-05+Ray+resources+syntax+for+custom+images
     return {f"image:{image_name}": 1}
 
 

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -91,6 +91,7 @@ else:
             runtime_env: t.Optional[RuntimeEnv],
             catch_exceptions: t.Optional[bool],
             max_retries: int,
+            resources: t.Optional[t.Mapping[str, float]],
             num_cpus: t.Optional[t.Union[int, float]] = None,
             num_gpus: t.Optional[t.Union[int, float]] = None,
             memory: t.Optional[t.Union[int, float]] = None,
@@ -102,18 +103,22 @@ else:
                 "metadata": metadata,
                 "catch_exceptions": catch_exceptions,
             }
-            ray_optional_opts = {}
+
+            ray_optional_kwargs = {}
             if num_cpus is not None:
-                ray_optional_opts["num_cpus"] = num_cpus
+                ray_optional_kwargs["num_cpus"] = num_cpus
             if num_gpus is not None:
-                ray_optional_opts["num_gpus"] = num_gpus
+                ray_optional_kwargs["num_gpus"] = num_gpus
             if memory is not None:
-                ray_optional_opts["memory"] = memory
+                ray_optional_kwargs["memory"] = memory
+            if resources is not None:
+                ray_optional_kwargs["resources"] = resources
+
             return ray_remote_fn.options(
                 **ray.workflow.options(**workflow_opts),
                 runtime_env=runtime_env,
                 max_retries=max_retries,
-                **ray_optional_opts,
+                **ray_optional_kwargs,
             )
 
         # ----- Ray Workflow -----

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -104,7 +104,7 @@ else:
                 "catch_exceptions": catch_exceptions,
             }
 
-            ray_optional_kwargs = {}
+            ray_optional_kwargs: t.Dict[str, t.Any] = {}
             if num_cpus is not None:
                 ray_optional_kwargs["num_cpus"] = num_cpus
             if num_gpus is not None:

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -25,7 +25,7 @@ from .._base import _services, serde
 from .._base._db import WorkflowDB
 from .._base._env import RAY_GLOBAL_WF_RUN_ID_ENV
 from .._base._spaces._structs import ProjectRef
-from .._base.abc import ArtifactValue, LogReader, RuntimeInterface
+from .._base.abc import LogReader, RuntimeInterface
 from ..schema import ir
 from ..schema.configs import RuntimeConfiguration
 from ..schema.local_database import StoredWorkflowRun
@@ -284,8 +284,12 @@ class RayRuntime(RuntimeInterface):
         global_run_id = os.getenv(RAY_GLOBAL_WF_RUN_ID_ENV)
         wf_run_id = global_run_id or _generate_wf_run_id(workflow_def)
 
-        # dag = make_ray_dag(self._client, workflow_def, wf_run_id, self._project_dir)
-        dag = make_ray_dag(self._client, workflow_def, wf_run_id)
+        dag = make_ray_dag(
+            self._client,
+            workflow_def=workflow_def,
+            workflow_run_id=wf_run_id,
+            project_dir=self._project_dir,
+        )
         wf_user_metadata = WfUserMetadata(workflow_def=workflow_def)
 
         # Unfortunately, Ray doesn't validate uniqueness of workflow IDs. Let's
@@ -296,11 +300,9 @@ class RayRuntime(RuntimeInterface):
             metadata=pydatic_to_json_dict(wf_user_metadata),
         )
 
-        config_name: str
-        config_name = self._config.config_name
         wf_run = StoredWorkflowRun(
             workflow_run_id=wf_run_id,
-            config_name=config_name,
+            config_name=self._config.config_name,
             workflow_def=workflow_def,
         )
         with WorkflowDB.open_project_db(self._project_dir) as db:

--- a/tests/runtime/ray/data/python_package/original_workflow.py
+++ b/tests/runtime/ray/data/python_package/original_workflow.py
@@ -22,4 +22,4 @@ def wf():
 
 
 if __name__ == "__main__":
-    print(wf.model.json())
+    print(wf.model.json(exclude_none=True))

--- a/tests/runtime/ray/data/python_package/python_package_dependent_workflow.json
+++ b/tests/runtime/ray/data/python_package/python_package_dependent_workflow.json
@@ -1,114 +1,106 @@
 {
-  "name": "wf",
-  "fn_ref": {
-    "module": "__main__",
-    "function_name": "wf",
-    "file_path": "tests/runtime/ray/data/python_package/original_workflow.py",
-    "line_number": 14,
-    "type": "MODULE_FUNCTION_REF"
-  },
-  "imports": {
-    "inline-import-1": {
-      "id": "inline-import-1",
-      "type": "INLINE_IMPORT"
+    "name": "wf",
+    "fn_ref": {
+        "module": "__main__",
+        "function_name": "wf",
+        "file_path": "tests/runtime/ray/data/python_package/original_workflow.py",
+        "line_number": 18,
+        "type": "MODULE_FUNCTION_REF"
     },
-    "python-import-4b988e935a": {
-      "id": "python-import-4b988e935a",
-      "packages": [
-        {
-          "name": "polars",
-          "extras": [],
-          "version_constraints": [
-            "==0.17.3"
-          ],
-          "environment_markers": ""
+    "imports": {
+        "inline-import-1": {
+            "id": "inline-import-1",
+            "type": "INLINE_IMPORT"
+        },
+        "python-import-dac5d03ef0": {
+            "id": "python-import-dac5d03ef0",
+            "packages": [
+                {
+                    "name": "polars",
+                    "extras": [],
+                    "version_constraints": [
+                        "==0.17.3"
+                    ],
+                    "environment_markers": ""
+                }
+            ],
+            "pip_options": [],
+            "type": "PYTHON_IMPORT"
         }
-      ],
-      "pip_options": [],
-      "type": "PYTHON_IMPORT"
-    }
-  },
-  "tasks": {
-    "task-my-fn-55d017d1e7": {
-      "id": "task-my-fn-55d017d1e7",
-      "fn_ref": {
-        "function_name": "my_fn",
-        "encoded_function": [
-          "gASVQgQAAAAAAACMF2Nsb3VkcGlja2xlLmNsb3VkcGlja2xllIwOX21ha2VfZnVuY3Rpb26Uk5Qo\naACMDV9idWlsdGluX3R5cGWUk5SMCENvZGVUeXBllIWUUpQoSwFLAEsASwFLAktDQwh8AKAAoQBT\nAJROhZSMBGl0ZW2UhZSMAmRmlIWUjDp0ZXN0cy9ydW50aW1lL3JheS9kYXRhL3B5dGhvbl9wYWNr\nYWdlL29yaWdpbmFsX3dvcmtmbG93LnB5lIwFbXlfZm6USwZDAgAFlCkpdJRSlH2UKIwLX19wYWNr\nYWdlX1+UTowIX19uYW1lX1+UjAhfX21haW5fX5SMCF9fZmlsZV9flGgOdU5OTnSUUpSMHGNsb3Vk\ncGlja2xlLmNsb3VkcGlja2xlX2Zhc3SUjBJfZnVuY3Rpb25fc2V0c3RhdGWUk5RoGX2UKIwXX1Rh\nc2tEZWZfX3Nka190YXNrX2JvZHmUaBmMB19mbl9yZWaUjBhvcnF1ZXN0cmEuc2RrLl9iYXNlLl9k\nc2yUjBFJbmxpbmVGdW5jdGlvblJlZpSTlGgPaBmGlIGUjAhfZm5fbmFtZZRoD4wQX291dHB1dF9t\nZXRhZGF0YZRoIIwSVGFza091dHB1dE1ldGFkYXRhlJOUiUsBhpSBlIwLX3BhcmFtZXRlcnOUjAtj\nb2xsZWN0aW9uc5SMC09yZGVyZWREaWN0lJOUKVKUaAxoIIwNVGFza1BhcmFtZXRlcpSTlGgMaCCM\nDVBhcmFtZXRlcktpbmSUk5SMFVBPU0lUSU9OQUxfT1JfS0VZV09SRJSFlFKUhpSBlHOMCl9yZXNv\ndXJjZXOUaCCMCVJlc291cmNlc5STlChOTk5OTnSUgZSMDV9jdXN0b21faW1hZ2WUjCh6YXBhdGFj\nb21wdXRpbmcvb3JxdWVzdHJhLWRlZmF1bHQ6djAuMC4wlIwMX2N1c3RvbV9uYW1llE6ME19kZXBl\nbmRlbmN5X2ltcG9ydHOUaCCMDVB5dGhvbkltcG9ydHOUk5QpgZR9lCiMBV9maWxllE6MCV9wYWNr\nYWdlc5SMDnBvbGFycz09MC4xNy4zlIWUdWKFlIwfX3VzZV9kZWZhdWx0X2RlcGVuZGVuY3lfaW1w\nb3J0c5SJjA5fc291cmNlX2ltcG9ydJRoIIwMSW5saW5lSW1wb3J0lJOUKYGUjBpfdXNlX2RlZmF1\nbHRfc291cmNlX2ltcG9ydJSJdX2UKGgVaA+MDF9fcXVhbG5hbWVfX5RoD4wPX19hbm5vdGF0aW9u\nc19flH2UjA5fX2t3ZGVmYXVsdHNfX5ROjAxfX2RlZmF1bHRzX1+UTowKX19tb2R1bGVfX5RoFowH\nX19kb2NfX5ROjAtfX2Nsb3N1cmVfX5ROjBdfY2xvdWRwaWNrbGVfc3VibW9kdWxlc5RdlIwLX19n\nbG9iYWxzX1+UfZR1hpSGUjAu\n"
-        ],
-        "type": "INLINE_FUNCTION_REF"
-      },
-      "parameters": [
-        {
-          "name": "df",
-          "kind": "POSITIONAL_OR_KEYWORD"
+    },
+    "tasks": {
+        "task-my-fn-6d73c7e55a": {
+            "id": "task-my-fn-6d73c7e55a",
+            "fn_ref": {
+                "function_name": "my_fn",
+                "encoded_function": [
+                    "gASVYwQAAAAAAACMF2Nsb3VkcGlja2xlLmNsb3VkcGlja2xllIwOX21ha2VfZnVuY3Rpb26Uk5Qo\naACMDV9idWlsdGluX3R5cGWUk5SMCENvZGVUeXBllIWUUpQoSwFLAEsASwFLAktDQwh8AKAAoQBT\nAJROhZSMBGl0ZW2UhZSMAmRmlIWUjIUvVXNlcnMvYWxleC9Db2RlL3phcGF0YS9ldmFuZ2VsaXNt\nLXdvcmtmbG93cy92ZW5kb3Ivb3JxdWVzdHJhLXdvcmtmbG93LXNkay90ZXN0cy9ydW50aW1lL3Jh\neS9kYXRhL3B5dGhvbl9wYWNrYWdlL29yaWdpbmFsX3dvcmtmbG93LnB5lIwFbXlfZm6USwpDAgAF\nlCkpdJRSlH2UKIwLX19wYWNrYWdlX1+UTowIX19uYW1lX1+UjAhfX21haW5fX5SMCF9fZmlsZV9f\nlGgOdU5OTnSUUpSMHGNsb3VkcGlja2xlLmNsb3VkcGlja2xlX2Zhc3SUjBJfZnVuY3Rpb25fc2V0\nc3RhdGWUk5RoGX2UKIwXX1Rhc2tEZWZfX3Nka190YXNrX2JvZHmUaBmMB19mbl9yZWaUjBhvcnF1\nZXN0cmEuc2RrLl9iYXNlLl9kc2yUjBFJbmxpbmVGdW5jdGlvblJlZpSTlGgPaBmGlIGUjAhfZm5f\nbmFtZZRoD4wQX291dHB1dF9tZXRhZGF0YZRoIIwSVGFza091dHB1dE1ldGFkYXRhlJOUiUsBhpSB\nlIwLX3BhcmFtZXRlcnOUjAtjb2xsZWN0aW9uc5SMC09yZGVyZWREaWN0lJOUKVKUaAxoIIwNVGFz\na1BhcmFtZXRlcpSTlGgMaCCMDVBhcmFtZXRlcktpbmSUk5SMFVBPU0lUSU9OQUxfT1JfS0VZV09S\nRJSFlFKUhpSBlHOMCl9yZXNvdXJjZXOUaCCMCVJlc291cmNlc5STlChOTk5OTnSUgZSMDV9jdXN0\nb21faW1hZ2WUTowMX2N1c3RvbV9uYW1llE6ME19kZXBlbmRlbmN5X2ltcG9ydHOUaCCMDVB5dGhv\nbkltcG9ydHOUk5QpgZR9lCiMBV9maWxllE6MCV9wYWNrYWdlc5SMDnBvbGFycz09MC4xNy4zlIWU\ndWKFlIwfX3VzZV9kZWZhdWx0X2RlcGVuZGVuY3lfaW1wb3J0c5SJjA5fc291cmNlX2ltcG9ydJRo\nIIwMSW5saW5lSW1wb3J0lJOUKYGUjBpfdXNlX2RlZmF1bHRfc291cmNlX2ltcG9ydJSJdX2UKGgV\naA+MDF9fcXVhbG5hbWVfX5RoD4wPX19hbm5vdGF0aW9uc19flH2UjA5fX2t3ZGVmYXVsdHNfX5RO\njAxfX2RlZmF1bHRzX1+UTowKX19tb2R1bGVfX5RoFowHX19kb2NfX5ROjAtfX2Nsb3N1cmVfX5RO\njBdfY2xvdWRwaWNrbGVfc3VibW9kdWxlc5RdlIwLX19nbG9iYWxzX1+UfZR1hpSGUjAu\n"
+                ],
+                "type": "INLINE_FUNCTION_REF"
+            },
+            "parameters": [
+                {
+                    "name": "df",
+                    "kind": "POSITIONAL_OR_KEYWORD"
+                }
+            ],
+            "output_metadata": {
+                "is_subscriptable": false,
+                "n_outputs": 1
+            },
+            "source_import_id": "inline-import-1",
+            "dependency_import_ids": [
+                "python-import-dac5d03ef0"
+            ]
         }
-      ],
-      "output_metadata": {
-        "is_subscriptable": false,
-        "n_outputs": 1
-      },
-      "source_import_id": "inline-import-1",
-      "dependency_import_ids": [
-        "python-import-4b988e935a"
-      ],
-      "resources": null,
-      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
-    }
-  },
-  "artifact_nodes": {
-    "artifact-0-my-fn": {
-      "id": "artifact-0-my-fn",
-      "custom_name": null,
-      "serialization_format": "AUTO",
-      "artifact_index": null
-    }
-  },
-  "constant_nodes": {
-    "constant-0": {
-      "id": "constant-0",
-      "chunks": [
-        "gASVeAAAAAAAAACMFnBvbGFycy5kYXRhZnJhbWUuZnJhbWWUjAlEYXRhRnJhbWWUk5QpgZRdlIwU\ncG9sYXJzLnNlcmllcy5zZXJpZXOUjAZTZXJpZXOUk5QpgZRDIKNkbmFtZWFhaGRhdGF0eXBlZUlu\ndDY0ZnZhbHVlc4EVlGJhYi4=\n"
-      ],
-      "serialization_format": "ENCODED_PICKLE",
-      "value_preview": "shape: (1, 1"
-    }
-  },
-  "secret_nodes": {},
-  "task_invocations": {
-    "invocation-0-task-my-fn": {
-      "id": "invocation-0-task-my-fn",
-      "task_id": "task-my-fn-55d017d1e7",
-      "args_ids": [
-        "constant-0"
-      ],
-      "kwargs_ids": {},
-      "output_ids": [
+    },
+    "artifact_nodes": {
+        "artifact-0-my-fn": {
+            "id": "artifact-0-my-fn",
+            "serialization_format": "AUTO"
+        }
+    },
+    "constant_nodes": {
+        "constant-0": {
+            "id": "constant-0",
+            "chunks": [
+                "gASVeAAAAAAAAACMFnBvbGFycy5kYXRhZnJhbWUuZnJhbWWUjAlEYXRhRnJhbWWUk5QpgZRdlIwU\ncG9sYXJzLnNlcmllcy5zZXJpZXOUjAZTZXJpZXOUk5QpgZRDIKNkbmFtZWFhaGRhdGF0eXBlZUlu\ndDY0ZnZhbHVlc4EVlGJhYi4=\n"
+            ],
+            "serialization_format": "ENCODED_PICKLE",
+            "value_preview": "shape: (1, 1"
+        }
+    },
+    "secret_nodes": {},
+    "task_invocations": {
+        "invocation-0-task-my-fn": {
+            "id": "invocation-0-task-my-fn",
+            "task_id": "task-my-fn-6d73c7e55a",
+            "args_ids": [
+                "constant-0"
+            ],
+            "kwargs_ids": {},
+            "output_ids": [
+                "artifact-0-my-fn"
+            ]
+        }
+    },
+    "output_ids": [
         "artifact-0-my-fn"
-      ],
-      "resources": null,
-      "custom_image": "zapatacomputing/orquestra-default:v0.0.0"
+    ],
+    "metadata": {
+        "sdk_version": {
+            "original": "0.47.1.dev21+g54ad067",
+            "major": 0,
+            "minor": 47,
+            "patch": 1,
+            "is_prerelease": true
+        },
+        "python_version": {
+            "original": "3.9.16 (main, May  8 2023, 17:01:20) \n[Clang 14.0.3 (clang-1403.0.22.14.1)]",
+            "major": 3,
+            "minor": 9,
+            "patch": 16,
+            "is_prerelease": false
+        }
     }
-  },
-  "output_ids": [
-    "artifact-0-my-fn"
-  ],
-  "data_aggregation": null,
-  "metadata": {
-    "sdk_version": {
-      "original": "0.45.2.dev18+ga73915e.d20230405",
-      "major": 0,
-      "minor": 45,
-      "patch": 2,
-      "is_prerelease": true
-    },
-    "python_version": {
-      "original": "3.8.12 (default, Apr 28 2022, 11:46:59) \n[Clang 12.0.5 (clang-1205.0.22.9)]",
-      "major": 3,
-      "minor": 8,
-      "patch": 12,
-      "is_prerelease": false
-    }
-  },
-  "resources": null
 }

--- a/tests/runtime/ray/regression/test_workflow_outputs.py
+++ b/tests/runtime/ray/regression/test_workflow_outputs.py
@@ -28,6 +28,8 @@ def runtime(tmp_path_factory: pytest.TempPathFactory, change_db_location):
     yield rt
 
 
+# Uses real Ray connection
+@pytest.mark.slow
 # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
 # unraisable exceptions. Last tested with Ray 2.3.0.
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -163,6 +163,7 @@ class TestResourcesInMakeDag:
             runtime_env=ANY,
             catch_exceptions=ANY,
             max_retries=ANY,
+            resources=ANY,
             **expected
         )
         for kwarg_name, type_ in types.items():

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -3,7 +3,6 @@ from unittest.mock import ANY, Mock, call, create_autospec
 
 import pytest
 
-from orquestra.sdk._base import serde
 from orquestra.sdk._base._testing._example_wfs import (
     workflow_parametrised_with_resources,
 )
@@ -145,8 +144,13 @@ class TestResourcesInMakeDag:
         expected: Dict[str, Union[int, float]],
         types: Dict[str, type],
     ):
+        # Given
         workflow = workflow_parametrised_with_resources(**resources).model
+
+        # When
         _ = _build_workflow.make_ray_dag(client, workflow, wf_run_id, None)
+
+        # Then
         calls = client.add_options.call_args_list
 
         # We should only have two calls: our invocation and the aggregation step

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -5,11 +5,9 @@
 Unit tests for orquestra.sdk._ray._dag. If you need a test against a live
 Ray connection, see tests/ray/test_integration.py instead.
 """
-import copy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, Union
-from unittest.mock import ANY, Mock, PropertyMock, call, create_autospec
+from unittest.mock import Mock, PropertyMock, create_autospec
 
 import pytest
 
@@ -17,10 +15,6 @@ from orquestra.sdk import exceptions
 from orquestra.sdk._base._config import RuntimeConfiguration, RuntimeName
 from orquestra.sdk._base._db import WorkflowDB
 from orquestra.sdk._base._spaces._structs import ProjectRef
-from orquestra.sdk._base._testing._example_wfs import (
-    wf_with_secrets,
-    workflow_parametrised_with_resources,
-)
 from orquestra.sdk._ray import _client, _dag, _ray_logs
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
 from orquestra.sdk.schema.workflow_run import State

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -305,6 +305,7 @@ class TestRayRuntimeMethods:
             # cancel changes the state to terminated
             assert status.status.state == State.TERMINATED
 
+    @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
     class TestGetWorkflowRunOutputsNonBlocking:
         """
         Tests that validate get_workflow_run_outputs_non_blocking
@@ -322,7 +323,6 @@ class TestRayRuntimeMethods:
                 JSONResult(value='"yooooo emiliano from zapata computing"'),
             )
 
-        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_failed_workflow(self, runtime: _dag.RayRuntime):
             wf_def = _example_wfs.exception_wf_with_multiple_values().model
             run_id = runtime.create_workflow_run(wf_def, None)
@@ -332,7 +332,6 @@ class TestRayRuntimeMethods:
             with pytest.raises(exceptions.WorkflowRunNotSucceeded):
                 runtime.get_workflow_run_outputs_non_blocking(run_id)
 
-        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
         def test_in_progress_workflow(self, runtime: _dag.RayRuntime, tmp_path):
             """
             Workflow graph in the scenario under test:

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -7,7 +7,6 @@ from unittest.mock import DEFAULT, MagicMock, Mock, call, create_autospec
 import pytest
 
 from orquestra.sdk import Project, Workspace, exceptions
-from orquestra.sdk._base import serde
 from orquestra.sdk._base._driver import _ce_runtime, _client, _exceptions, _models
 from orquestra.sdk._base._testing._example_wfs import (
     my_workflow,
@@ -15,7 +14,7 @@ from orquestra.sdk._base._testing._example_wfs import (
     workflow_with_different_resources,
 )
 from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
-from orquestra.sdk.schema.ir import ArtifactFormat, WorkflowDef
+from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.responses import ComputeEngineWorkflowResult, JSONResult
 from orquestra.sdk.schema.workflow_run import (
     RunStatus,


### PR DESCRIPTION
# The problem

Sometimes users need to provide custom docker images with external deps to run their Orquestra tasks. It was possible with QE but not with CE yet.

# This PR's solution

Makes use of Ray's custom resources to embed the custom image name a user specified either:
* in the task def: `@sdk.task(custom_image="foo/bar:abc")`
* in the task invocation inside the workflow: `future = my_task(...).with_invocation_meta(custom_image="foo/bar:abc")`

## Known limitation

If a task in the workflow IR specifies a custom image and you attempt to run the workflow on a local `orq up`-style Ray cluster, Ray will never schedule task for execution. That's the reason why I needed to update the `Test3rdParty` integration test—it used an IR generated with an old SDK version from a time when we embedded `zapatacomputing/orquestra-default:v0.0.0` to every task def. 

@SebastianMorawiec and I talked a bit to figure out a sensible solution. We couldn't find any obvious one, so I added a separate ticket to discuss our options: https://zapatacomputing.atlassian.net/browse/ORQSDK-838

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
