### PR TITLE
feat: add sdk.get_backend_ids() function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New API functions: list_workspaces() and list_projects(). Usable only on CE runtime
 * Setting workflow_id and project_id is now available using "orq wf submit" command
 * All CLI commands that prompted for wf_run_id will now first prompt for workspace and project if wf_run_ID is not provided
+* `sdk.current_run_ids()` can now be used within task code to access the workflow run ID, task invocation ID, and task run ID.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/__init__.py
+++ b/src/orquestra/sdk/__init__.py
@@ -8,6 +8,7 @@ from ._base._api import (
     RuntimeConfig,
     TaskRun,
     WorkflowRun,
+    get_backend_ids,
     list_workflow_runs,
     migrate_config_file,
 )
@@ -33,6 +34,7 @@ from ._base._workflow import NotATaskWarning, WorkflowDef, WorkflowTemplate, wor
 __all__ = [
     "ArtifactFuture",
     "DataAggregation",
+    "get_backend_ids",
     "GithubImport",
     "GitImport",
     "Import",

--- a/src/orquestra/sdk/__init__.py
+++ b/src/orquestra/sdk/__init__.py
@@ -8,7 +8,7 @@ from ._base._api import (
     RuntimeConfig,
     TaskRun,
     WorkflowRun,
-    get_backend_ids,
+    current_run_ids,
     list_workflow_runs,
     migrate_config_file,
 )
@@ -34,7 +34,7 @@ from ._base._workflow import NotATaskWarning, WorkflowDef, WorkflowTemplate, wor
 __all__ = [
     "ArtifactFuture",
     "DataAggregation",
-    "get_backend_ids",
+    "current_run_ids",
     "GithubImport",
     "GitImport",
     "Import",

--- a/src/orquestra/sdk/_base/_api/__init__.py
+++ b/src/orquestra/sdk/_base/_api/__init__.py
@@ -9,13 +9,13 @@ We re-export symbols here for grouping concepts under the "api" umbrella, e.g.
 """
 
 from ._config import RuntimeConfig, migrate_config_file
-from ._task_run import TaskRun, get_backend_ids
+from ._task_run import TaskRun, current_run_ids
 from ._wf_run import WorkflowRun, list_workflow_runs
 
 __all__ = [
     "RuntimeConfig",
     "TaskRun",
-    "get_backend_ids",
+    "current_run_ids",
     "WorkflowRun",
     "list_workflow_runs",
     "migrate_config_file",

--- a/src/orquestra/sdk/_base/_api/__init__.py
+++ b/src/orquestra/sdk/_base/_api/__init__.py
@@ -9,12 +9,13 @@ We re-export symbols here for grouping concepts under the "api" umbrella, e.g.
 """
 
 from ._config import RuntimeConfig, migrate_config_file
-from ._task_run import TaskRun
+from ._task_run import TaskRun, get_backend_ids
 from ._wf_run import WorkflowRun, list_workflow_runs
 
 __all__ = [
     "RuntimeConfig",
     "TaskRun",
+    "get_backend_ids",
     "WorkflowRun",
     "list_workflow_runs",
     "migrate_config_file",

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -341,7 +341,13 @@ def get_backend_ids() -> (
     ]
 ):
     """
-    Get the workflow run, task invocation, and task run IDs for the current task.
+    Get the workflow run, task invocation, and task run IDs related to current execution context. 
+    
+    Workflow run ID is a globally unique identifier generated whenever a workflow is submitted for running. Single workflow definition can be run multiple times resulting in multiple workflow run IDs. Analog of PID for a standard program.
+    
+    Task invocation ID is related to using a task in your workflow definition, analogous to a function invocation in a standard program. Scoped to a workflow definition. Isn't globally unique. If you run the same workflow definition multiple times, you'll end up with the same task invocation IDs across runs.
+    
+    Task run ID is a globally unique identifier of executing an invocation exactly once.
 
     This function is intended to be used within the task code in the following way:
     ```

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -262,7 +262,9 @@ class TaskRun:
         return set(parents)
 
 
-def _get_argo_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId]:
+def _get_argo_backend_ids() -> (
+    t.Tuple[WorkflowRunId, t.Optional[TaskInvocationId], t.Optional[TaskRunId]]
+):
     """
     Get the workflow run, task invocation, and task run IDs from Argo.
 
@@ -291,7 +293,9 @@ def _get_argo_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunI
     return wf_run_id, task_inv_id, task_run_id
 
 
-def _get_ray_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId]:
+def _get_ray_backend_ids() -> (
+    t.Tuple[WorkflowRunId, t.Optional[TaskInvocationId], t.Optional[TaskRunId]]
+):
     """
     Get the workflow run, task invocation, and task run IDs from Ray.
 
@@ -311,7 +315,7 @@ def _get_ray_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId
 
 
 def _get_in_process_backend_ids() -> (
-    t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId]
+    t.Tuple[WorkflowRunId, t.Optional[TaskInvocationId], t.Optional[TaskRunId]]
 ):
     """
     Get the workflow run, task invocation, and task run IDs from the In-process runtime.
@@ -335,9 +339,7 @@ def _get_in_process_backend_ids() -> (
 
 
 def current_run_ids() -> (
-    t.Tuple[
-        t.Optional[WorkflowRunId], t.Optional[TaskInvocationId], t.Optional[TaskRunId]
-    ]
+    t.Tuple[WorkflowRunId, t.Optional[TaskInvocationId], t.Optional[TaskRunId]]
 ):
     """
     Get the workflow run, task invocation, and task run IDs related to current

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -325,12 +325,18 @@ def current_run_ids() -> (
     ]
 ):
     """
-    Get the workflow run, task invocation, and task run IDs related to current execution context. 
-    
-    Workflow run ID is a globally unique identifier generated whenever a workflow is submitted for running. Single workflow definition can be run multiple times resulting in multiple workflow run IDs. Analog of PID for a standard program.
-    
-    Task invocation ID is related to using a task in your workflow definition, analogous to a function invocation in a standard program. Scoped to a workflow definition. Isn't globally unique. If you run the same workflow definition multiple times, you'll end up with the same task invocation IDs across runs.
-    
+    Get the workflow run, task invocation, and task run IDs related to current
+    execution context.
+
+    Workflow run ID is a globally unique identifier generated whenever a workflow is
+    submitted for running. Single workflow definition can be run multiple times
+    resulting in multiple workflow run IDs. Analog of PID for a standard program.
+
+    Task invocation ID is related to using a task in your workflow definition,
+    analogous to a function invocation in a standard program. Scoped to a workflow
+    definition. Isn't globally unique. If you run the same workflow definition multiple
+    times, you'll end up with the same task invocation IDs across runs.
+
     Task run ID is a globally unique identifier of executing an invocation exactly once.
 
     This function is intended to be used within the task code in the following way:

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -343,7 +343,7 @@ def get_backend_ids() -> (
     """
     Get the workflow run, task invocation, and task run IDs for the current task.
 
-    This method is intended to be used within the task code in the following way:
+    This function is intended to be used within the task code in the following way:
     ```
     @sdk.task
     def t():

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -332,7 +332,7 @@ def _get_in_process_backend_ids() -> (
         raise WorkflowRunIDNotFoundError(
             "current_run_ids global was imported with value None."
         )
-    if global_current_run_ids[0] is None or len(global_current_run_ids[0]) == 0:
+    if global_current_run_ids[0] is None:
         raise WorkflowRunIDNotFoundError("Could not recover Workflow Run ID")
 
     return global_current_run_ids

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -299,7 +299,11 @@ def _get_argo_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunI
     return wf_run_id, task_inv_id, task_run_id
 
 
-def _get_ray_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId]:
+def _get_ray_backend_ids() -> (
+    t.Tuple[
+        t.Optional[WorkflowRunId], t.Optional[TaskInvocationId], t.Optional[TaskRunId]
+    ]
+):
     """
     Get the workflow run, task invocation, and task run IDs from Ray.
 
@@ -319,6 +323,8 @@ def _get_in_process_backend_ids() -> (
     Get the workflow run, task invocation, and task run IDs from the In-process runtime.
     """
 
+    # Deferred import so that we get the value of IDS as set by the context manager for
+    # this task.
     from orquestra.sdk._base._in_process_runtime import IDS
 
     assert IDS is not None, (
@@ -329,12 +335,24 @@ def _get_in_process_backend_ids() -> (
     return IDS
 
 
-def get_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId]:
+def get_backend_ids() -> (
+    t.Tuple[
+        t.Optional[WorkflowRunId], t.Optional[TaskInvocationId], t.Optional[TaskRunId]
+    ]
+):
     """
-    _summary_
+    Get the workflow run, task invocation, and task run IDs for the current task.
+
+    This method is intended to be used within the task code in the following way:
+    ```
+    @sdk.task
+    def t():
+        wf_run_id, task_inv_id, task_run_id =  sdk.get_backend_ids()
+        ...
+    ```
 
     Returns:
-        _description_
+        WorkflowRunId, TaskInvocationId, TaskRunId
     """
 
     if _is_argo_backend():

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -287,7 +287,7 @@ def _get_argo_backend_ids() -> (
     # good this assumption is.
     task_inv_id = argo_template["name"]
 
-    if wf_run_id is None:
+    if len(wf_run_id) == 0:
         raise WorkflowRunIDNotFoundError("Could not recover Workflow Run ID")
 
     return wf_run_id, task_inv_id, task_run_id
@@ -332,7 +332,7 @@ def _get_in_process_backend_ids() -> (
         raise WorkflowRunIDNotFoundError(
             "current_run_ids global was imported with value None."
         )
-    if global_current_run_ids[0] is None:
+    if global_current_run_ids[0] is None or len(global_current_run_ids[0]) == 0:
         raise WorkflowRunIDNotFoundError("Could not recover Workflow Run ID")
 
     return global_current_run_ids

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -366,6 +366,10 @@ def current_run_ids() -> (
 
     Returns:
         WorkflowRunId, TaskInvocationId, TaskRunId
+
+    Raises:
+        ModuleNotFoundError: raised from _get_ray_backend_ids when ray is not installed.
+        WorkflowRunIDNotFoundError: When the workflow run ID cannot be recovered.
     """
 
     if _exec_ctx.global_context == _exec_ctx.ExecContext.PLATFORM_QE:

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -295,11 +295,13 @@ def _get_ray_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId
     # Deferred import because Ray isn't installed when running on QE.
     import orquestra.sdk._ray._dag
 
-    ids = orquestra.sdk._ray._dag.get_current_ids()
+    wf_run_id, task_inv_id, task_run_id = orquestra.sdk._ray._dag.get_current_ids()
 
-    assert ids[0] is not None, "Could not get the workflow run id from ray."
+    assert wf_run_id is not None, "Could not get the workflow run ID from ray."
+    assert task_inv_id is not None, "Could not get the task invocation ID from ray."
+    assert task_run_id is not None, "Could not get the task run ID from ray."
 
-    return ids
+    return wf_run_id, task_inv_id, task_run_id
 
 
 def _get_in_process_backend_ids() -> (
@@ -311,12 +313,12 @@ def _get_in_process_backend_ids() -> (
 
     # Deferred import so that we get the value of current_run_ids as set by the context
     # manager for this task.
-    from orquestra.sdk._base._in_process_runtime import current_run_ids
+    from orquestra.sdk._base._in_process_runtime import global_current_run_ids
 
     assert (
-        current_run_ids is not None
+        global_current_run_ids is not None
     ), "current_run_ids global was imported with value None."
-    return current_run_ids
+    return global_current_run_ids
 
 
 def current_run_ids() -> (

--- a/src/orquestra/sdk/_base/_exec_ctx.py
+++ b/src/orquestra/sdk/_base/_exec_ctx.py
@@ -79,3 +79,8 @@ def platform_qe():
     """
     with _set_context(ExecContext.PLATFORM_QE):
         yield
+
+
+def get_current_exec_context() -> ExecContext:
+    """Getter for the current execution context."""
+    return global_context

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -33,7 +33,7 @@ WfRunId = str
 ArtifactValue = t.Any
 TaskOutputs = t.Tuple[ArtifactValue, ...]
 
-current_run_ids: t.Optional[
+global_current_run_ids: t.Optional[
     t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]
 ] = None
 """
@@ -47,17 +47,17 @@ None at all other times.
 @contextmanager
 def set_ids(ids: t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]):
     """
-    Temporarily set the current_run_ids global variable.
+    Temporarily set the global_current_run_ids global variable.
 
-    current_run_ids will be set to a tuple of the current WorkflowRunID,
+    global_current_run_ids will be set to a tuple of the current WorkflowRunID,
     TaskInvocationID, and TaskRunID.
     """
 
-    global current_run_ids
-    old_ids = current_run_ids
-    current_run_ids = ids
+    global global_current_run_ids
+    old_ids = global_current_run_ids
+    global_current_run_ids = ids
     yield
-    current_run_ids = old_ids
+    global_current_run_ids = old_ids
 
 
 def _make_completed_task_run(workflow_run_id, start_time, end_time, task_inv):

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -1,15 +1,28 @@
 ################################################################################
 # © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
+
+"""
+In-process implementation of the runtime interface.
+"""
+
 import typing as t
 import warnings
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 from orquestra.sdk import ProjectRef, exceptions
 from orquestra.sdk._base import abc
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.responses import WorkflowResult
-from orquestra.sdk.schema.workflow_run import RunStatus, State, TaskRun, WorkflowRun
+from orquestra.sdk.schema.workflow_run import (
+    RunStatus,
+    State,
+    TaskRun,
+    TaskRunId,
+    WorkflowRun,
+    WorkflowRunId,
+)
 
 from .. import secrets
 from . import serde
@@ -19,6 +32,30 @@ from .dispatch import locate_fn_ref
 WfRunId = str
 ArtifactValue = t.Any
 TaskOutputs = t.Tuple[ArtifactValue, ...]
+
+IDS: t.Optional[t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]] = None
+"""
+Global variable to store the current workflow, task inv, and task run IDs.
+
+This should _only_ be used in the context of the set_ids context manager, and should be
+None at all other times.
+"""
+
+
+@contextmanager
+def set_ids(ids: t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]):
+    """
+    Temporarily set the IDS global variable.
+
+    IDS will be set to a tuple of the current WorkflowRunID, TaskInvocationID, and
+    TaskRunID.
+    """
+
+    global IDS
+    old_ids = IDS
+    IDS = ids
+    yield
+    IDS = old_ids
 
 
 def _make_completed_task_run(workflow_run_id, start_time, end_time, task_inv):
@@ -122,7 +159,9 @@ class InProcessRuntime(abc.RuntimeInterface):
                 fn = task_fn._TaskDef__sdk_task_body
             except AttributeError:
                 fn = task_fn
-            fn_output = fn(*args, **kwargs)
+
+            with set_ids((run_id, task_inv.id, task_inv.task_id)):
+                fn_output = fn(*args, **kwargs)
 
             # Finally, we need to dereference the output IDs
             for artifact_id in task_inv.output_ids:
@@ -168,9 +207,10 @@ class InProcessRuntime(abc.RuntimeInterface):
 
             artifact_nodes = [wf_def.artifact_nodes[id] for id in inv.output_ids]
             packed_nodes = [n for n in artifact_nodes if n.artifact_index is None]
-            assert (
-                len(packed_nodes) == 1
-            ), f"Task invocation should have exactly 1 packed output. {inv.id} has {len(packed_nodes)}: {packed_nodes}"  # noqa: E501
+            assert len(packed_nodes) == 1, (
+                "Task invocation should have exactly 1 packed output. "
+                f"{inv.id} has {len(packed_nodes)}: {packed_nodes}"
+            )
             packed_artifact = packed_nodes[0]
 
             task_result = self._artifact_store[workflow_run_id][packed_artifact.id]

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -33,7 +33,9 @@ WfRunId = str
 ArtifactValue = t.Any
 TaskOutputs = t.Tuple[ArtifactValue, ...]
 
-IDS: t.Optional[t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]] = None
+current_run_ids: t.Optional[
+    t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]
+] = None
 """
 Global variable to store the current workflow, task inv, and task run IDs.
 
@@ -45,17 +47,17 @@ None at all other times.
 @contextmanager
 def set_ids(ids: t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]):
     """
-    Temporarily set the IDS global variable.
+    Temporarily set the current_run_ids global variable.
 
-    IDS will be set to a tuple of the current WorkflowRunID, TaskInvocationID, and
-    TaskRunID.
+    current_run_ids will be set to a tuple of the current WorkflowRunID,
+    TaskInvocationID, and TaskRunID.
     """
 
-    global IDS
-    old_ids = IDS
-    IDS = ids
+    global current_run_ids
+    old_ids = current_run_ids
+    current_run_ids = ids
     yield
-    IDS = old_ids
+    current_run_ids = old_ids
 
 
 def _make_completed_task_run(workflow_run_id, start_time, end_time, task_inv):

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -39,8 +39,8 @@ global_current_run_ids: t.Optional[
 """
 Global variable to store the current workflow, task inv, and task run IDs.
 
-This should _only_ be used in the context of the set_ids context manager, and should be
-None at all other times.
+This should _only_ be used in the context of the set_ids context manager or the
+`get_current_in_process_ids` function, and should be None at all other times.
 """
 
 
@@ -58,6 +58,15 @@ def set_ids(ids: t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]):
     global_current_run_ids = ids
     yield
     global_current_run_ids = old_ids
+
+
+def get_current_in_process_ids() -> (
+    t.Optional[t.Tuple[WorkflowRunId, ir.TaskInvocationId, TaskRunId]]
+):
+    """
+    Getter for the current In process run IDs.
+    """
+    return global_current_run_ids
 
 
 def _make_completed_task_run(workflow_run_id, start_time, end_time, task_inv):

--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -10,7 +10,7 @@ import logging
 import typing as t
 from datetime import datetime, timezone
 
-from orquestra.sdk._base._api._task_run import get_backend_ids
+from orquestra.sdk._base._api._task_run import current_run_ids
 from orquestra.sdk.schema.ir import TaskInvocationId
 from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRunId
 
@@ -125,7 +125,7 @@ def workflow_logger() -> logging.LoggerAdapter:
     task_inv_id: t.Optional[TaskInvocationId]
     task_run_id: t.Optional[TaskRunId]
     try:
-        wf_run_id, task_inv_id, task_run_id = get_backend_ids()
+        wf_run_id, task_inv_id, task_run_id = current_run_ids()
     except ModuleNotFoundError:
         # Ray is not installed
         wf_run_id, task_inv_id, task_run_id = None, None, None

--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -7,10 +7,10 @@ Log adapter adds a workflow context to logs, Workflow ID and Task ID.
 
 import json
 import logging
-import os
 import typing as t
 from datetime import datetime, timezone
 
+from orquestra.sdk._base._api._task_run import get_backend_ids
 from orquestra.sdk.schema.ir import TaskInvocationId
 from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRunId
 
@@ -50,46 +50,6 @@ class TaggedWorkflowTaskLogger(logging.LoggerAdapter):
         # extras.
         new_kwargs = {**kwargs, "extra": new_extra}
         return new_msg, new_kwargs
-
-
-def is_argo_backend():
-    """
-    Quantum Engine backend test.
-    Argo Workflows are executed in pods, where ARGO_NODE_ID corresponds
-    to the workflow step ID.
-    """
-    return "ARGO_NODE_ID" in os.environ
-
-
-def get_argo_backend_ids() -> t.Tuple[WorkflowRunId, TaskInvocationId, TaskRunId]:
-    node_id = os.environ["ARGO_NODE_ID"]
-    # Argo Workflow ID is the left part of the step ID
-    # [wf-id]-[retry-number]-[step-number]
-    wf_run_id = "-".join(node_id.split("-")[:-2])
-    task_run_id = node_id
-
-    argo_template = json.loads(os.environ["ARGO_TEMPLATE"])
-    # Looks like the template name on Argo matches our task invocation ID. Not sure how
-    # good this assumption is.
-    task_inv_id = argo_template["name"]
-
-    return wf_run_id, task_inv_id, task_run_id
-
-
-def get_ray_backend_ids() -> (
-    t.Tuple[
-        t.Optional[WorkflowRunId], t.Optional[TaskInvocationId], t.Optional[TaskRunId]
-    ]
-):
-    try:
-        # Deferred import because Ray isn't installed when running on QE.
-        import orquestra.sdk._ray._dag
-
-    except ModuleNotFoundError:
-        # Ray is not installed
-        return None, None, None
-
-    return orquestra.sdk._ray._dag.get_current_ids()
 
 
 class ISOFormatter(logging.Formatter):
@@ -164,12 +124,11 @@ def workflow_logger() -> logging.LoggerAdapter:
     wf_run_id: t.Optional[WorkflowRunId]
     task_inv_id: t.Optional[TaskInvocationId]
     task_run_id: t.Optional[TaskRunId]
-    if is_argo_backend():
-        # Workflow is running in the Orquestra QE environment
-        wf_run_id, task_inv_id, task_run_id = get_argo_backend_ids()
-    else:
-        # We assume the workflow is running on Ray
-        wf_run_id, task_inv_id, task_run_id = get_ray_backend_ids()
+    try:
+        wf_run_id, task_inv_id, task_run_id = get_backend_ids()
+    except ModuleNotFoundError:
+        # Ray is not installed
+        wf_run_id, task_inv_id, task_run_id = None, None, None
 
     logger = _make_logger(
         wf_run_id=wf_run_id, task_inv_id=task_inv_id, task_run_id=task_run_id

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -1,3 +1,7 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+
 import os
 import traceback
 import typing as t
@@ -188,9 +192,9 @@ def _make_ray_dag_node(
             deserialize=serialization,
         )
 
-        logger = _log_adapter.workflow_logger()
-        try:
-            with _exec_ctx.ray():
+        with _exec_ctx.ray():
+            logger = _log_adapter.workflow_logger()
+            try:
                 wrapped_return = wrapped(*inner_args, **inner_kwargs)
 
                 packed: responses.WorkflowResult = (
@@ -216,13 +220,13 @@ def _make_ray_dag_node(
                     packed=packed,
                     unpacked=unpacked,
                 )
-        except Exception as e:
-            # Log the stacktrace as a single log line.
-            logger.exception(traceback.format_exc())
+            except Exception as e:
+                # Log the stacktrace as a single log line.
+                logger.exception(traceback.format_exc())
 
-            # We need to stop further execution of this workflow. If we don't raise, Ray
-            # will think the task succeeded with a return value `None`.
-            raise e
+                # We need to stop further execution of this workflow. If we don't
+                # raise, Ray will think the task succeeded with a return value `None`.
+                raise e
 
     named_remote = client.add_options(_ray_remote, **ray_options)
     dag_node = named_remote.bind(*ray_args, **ray_kwargs)

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -204,6 +204,12 @@ class WorkflowResultsNotReadyError(NotFoundError):
     """
 
 
+class WorkflowRunIDNotFoundError(NotFoundError):
+    """Raised when we can't recover the ID for this Workflow Run."""
+
+    # Note that this is different to the WorkflowRunNotFoundError.
+
+
 # Auth Errors
 class UnauthorizedError(BaseRuntimeError):
     """Raised when the remote cluster rejects the auth token."""

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -208,6 +208,8 @@ class WorkflowRunIDNotFoundError(NotFoundError):
     """Raised when we can't recover the ID for this Workflow Run."""
 
     # Note that this is different to the WorkflowRunNotFoundError.
+    # We have an ID but can't find the workflow: WorkflowRunNotFoundError
+    # We have a workflow but can't recover the ID: WorkflowRunIDNotFoundError
 
 
 # Auth Errors

--- a/tests/runtime/test_log_adapter.py
+++ b/tests/runtime/test_log_adapter.py
@@ -4,64 +4,10 @@
 import subprocess
 import sys
 import typing as t
-from unittest.mock import Mock
 
 import pytest
 
-from orquestra.sdk._base import _log_adapter
-from orquestra.sdk._ray import _dag, _ray_logs
-
-TEST_ARGO_NODE_ID = "hello-orquestra-nk148-r000-4219834842"
-TEST_ARGO_TEMPLATE = """{
-    "name": "hello",
-    "inputs": "",
-    "outputs": ""
-}"""
-
-
-def test_is_argo_backend(monkeypatch):
-    monkeypatch.setenv("ARGO_NODE_ID", TEST_ARGO_NODE_ID)
-
-    assert _log_adapter.is_argo_backend()
-
-
-def test_not_argo_backend():
-    assert not _log_adapter.is_argo_backend()
-
-
-def test_get_argo_backend_ids(monkeypatch):
-    monkeypatch.setenv("ARGO_NODE_ID", TEST_ARGO_NODE_ID)
-    monkeypatch.setenv("ARGO_TEMPLATE", TEST_ARGO_TEMPLATE)
-
-    wf_run_id, task_inv_id, task_run_id = _log_adapter.get_argo_backend_ids()
-
-    assert wf_run_id == "hello-orquestra-nk148"
-    assert task_inv_id == "hello"
-    assert task_run_id == TEST_ARGO_NODE_ID
-
-
-def test_get_ray_backend_ids(monkeypatch):
-    """
-    Test boundary::
-        [_dag.get_current_ids]
-
-    The Ray underlying machinery is tested in integration tests for RayRuntime.
-    """
-    # Given
-    wf_run_id = "wf.1"
-    task_inv_id = "inv-1-generate-data"
-    task_run_id = f"{wf_run_id}@{task_inv_id}"
-    monkeypatch.setattr(
-        _dag,
-        "get_current_ids",
-        Mock(return_value=(wf_run_id, task_inv_id, task_run_id)),
-    )
-
-    # When
-    ids = _log_adapter.get_ray_backend_ids()
-
-    # Then
-    assert ids == (wf_run_id, task_inv_id, task_run_id)
+from orquestra.sdk._ray import _ray_logs
 
 
 class TestMakeLogger:

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -577,7 +577,7 @@ def mock_in_process_context(monkeypatch):
     )
     monkeypatch.setattr(
         sdk._base._in_process_runtime,
-        "current_run_ids",
+        "global_current_run_ids",
         (wf_run_id, task_inv_id, task_run_id),
     )
 

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -10,8 +10,10 @@ from unittest.mock import MagicMock, Mock, create_autospec
 
 import pytest
 
+import orquestra.sdk as sdk
 from orquestra.sdk._base import _api, _workflow, serde
 from orquestra.sdk._base.abc import RuntimeInterface
+from orquestra.sdk._ray import _dag
 from orquestra.sdk.exceptions import TaskRunNotFound
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.workflow_run import RunStatus, State
@@ -522,3 +524,162 @@ class TestTaskRun:
             # then
             assert task_input.args == [21]
             assert task_input.kwargs == {}
+
+
+# region: fixtures
+@pytest.fixture
+def mock_argo_context(monkeypatch):
+    wf_run_id = "hello-orquestra-nk148"
+    task_inv_id = "hello"
+    argo_node_id = f"{wf_run_id}-r000-4219834842"
+    argo_template = (
+        "{\n"
+        f'    "name": "{task_inv_id}",\n'
+        '    "inputs": "",\n'
+        '    "outputs": ""\n'
+        "}"
+    )
+    monkeypatch.setenv("ARGO_NODE_ID", argo_node_id)
+    monkeypatch.setenv("ARGO_TEMPLATE", argo_template)
+    return wf_run_id, task_inv_id, argo_node_id
+
+
+@pytest.fixture
+def mock_ray_context(monkeypatch):
+    wf_run_id = "wf.1"
+    task_inv_id = "inv-1-generate-data"
+    task_run_id = f"{wf_run_id}@{task_inv_id}"
+    monkeypatch.setattr(
+        _dag,
+        "get_current_ids",
+        Mock(return_value=(wf_run_id, task_inv_id, task_run_id)),
+    )
+    monkeypatch.setattr("inspect.stack", Mock(return_value="{function='_ray_remote'}"))
+    return wf_run_id, task_inv_id, task_run_id
+
+
+@pytest.fixture
+def mock_in_process_context(monkeypatch):
+    pass
+
+    # monkeypatch.setattr("sys.modules['_in_process_runtime.IDS']", "BLAH")
+
+
+# endregion
+
+
+class TestGetBackendIDs:
+    class TestBackendDetection:
+        @staticmethod
+        def test_is_argo_backend(mock_argo_context):
+            assert _api._task_run._is_argo_backend()
+
+        @staticmethod
+        def test_not_argo_backend():
+            assert not _api._task_run._is_argo_backend()
+
+        @staticmethod
+        def test_is_ray_backend(mock_ray_context):
+            assert _api._task_run._is_ray_backend()
+
+        @staticmethod
+        def test_not_ray_backend():
+            assert not _api._task_run._is_ray_backend()
+
+    class TestRuntimeSpecificGetIDs:
+        @staticmethod
+        def test_get_argo_backend_ids(mock_argo_context):
+            assert _api._task_run._get_argo_backend_ids() == mock_argo_context
+
+        @staticmethod
+        def test_get_ray_backend_ids(mock_ray_context):
+            """
+            Test boundary::
+                [_dag.get_current_ids]
+
+            The Ray underlying machinery is tested in integration tests for RayRuntime.
+            """
+            assert _api._task_run._get_ray_backend_ids() == mock_ray_context
+
+        @staticmethod
+        @pytest.mark.xfail(reason="I do not know how to mock the IDS import yet.")
+        def test_get_in_process_backend_ids(mock_in_process_context):
+            assert (
+                _api._task_run._get_in_process_backend_ids() == mock_in_process_context
+            )
+
+    class TestRuntimeDependentBehaviour:
+        @staticmethod
+        def test_raises_assertionerror_if_multiple_runtimes(
+            mock_argo_context, mock_ray_context
+        ):
+            with pytest.raises(AssertionError):
+                sdk.get_backend_ids()
+
+        @staticmethod
+        def test_gets_ray_ids_for_ray_runtimes(mock_ray_context, monkeypatch):
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_argo_backend_ids",
+                mock_get_argo_ids := Mock(return_value="<argo ids sentinel>"),
+            )
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_ray_backend_ids",
+                mock_get_ray_ids := Mock(return_value="<ray ids sentinel>"),
+            )
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_in_process_backend_ids",
+                mock_get_in_process_ids := Mock(
+                    return_value="<in_process ids sentinel>"
+                ),
+            )
+
+            assert sdk.get_backend_ids() == "<ray ids sentinel>"
+            mock_get_argo_ids.assert_not_called()
+            mock_get_ray_ids.assert_called_once()
+            mock_get_in_process_ids.assert_not_called()
+
+        @staticmethod
+        def test_gets_qe_ids_for_qe_runtimes(mock_argo_context, monkeypatch):
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_argo_backend_ids",
+                mock_get_argo_ids := Mock(return_value="<argo ids sentinel>"),
+            )
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_ray_backend_ids",
+                mock_get_ray_ids := Mock(return_value="<ray ids sentinel>"),
+            )
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_in_process_backend_ids",
+                mock_get_in_process_ids := Mock(
+                    return_value="<in_process ids sentinel>"
+                ),
+            )
+
+            assert sdk.get_backend_ids() == "<argo ids sentinel>"
+            mock_get_argo_ids.assert_called_once()
+            mock_get_ray_ids.assert_not_called()
+            mock_get_in_process_ids.assert_not_called()
+
+        @staticmethod
+        def test_gets_in_process_ids_for_in_process_runtimes(
+            mock_in_process_context, monkeypatch
+        ):
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_argo_backend_ids",
+                mock_get_argo_ids := Mock(return_value="<argo ids sentinel>"),
+            )
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_ray_backend_ids",
+                mock_get_ray_ids := Mock(return_value="<ray ids sentinel>"),
+            )
+            monkeypatch.setattr(
+                "orquestra.sdk._base._api._task_run._get_in_process_backend_ids",
+                mock_get_in_process_ids := Mock(
+                    return_value="<in_process ids sentinel>"
+                ),
+            )
+
+            assert sdk.get_backend_ids() == "<in_process ids sentinel>"
+            mock_get_argo_ids.assert_not_called()
+            mock_get_ray_ids.assert_not_called()
+            mock_get_in_process_ids.assert_called_once()


### PR DESCRIPTION
[ORQSDK-823]

# The problem

Users who want to track their metrics in MLflow need to somehow identify MLflow experiments and MLflow runs. “Tagging” MLflow stuff with WorkflowRunID/TaskInvocationID could be used to correlate MLflow entities with Orquestra ones. At the moment there’s no good way to get this contextual information from within the user-written task code.

# This PR's solution

Adds a new function `sdk.get_backend_ids()` to the API. This function does the following:
- Determines the current backend - Argo, Ray, or in-process
    - Argo backends are identified by the presence of "ARGO_NODE_ID" in the environment variables
    - Ray backends are identified by the presence of "function='_ray_remote'" in the call stack (it's there for local ray instances as well)
    - In process backends are identified by the absence of the identifiers for ray and argo.
- Determines the current WFRunID, TaskRunID, and TaskInvID
    - For Argo, these are determined from the componenets of the Node ID
    - For Ray, we use _dag.get_current_ids()
    - For In process, we use the IDS global variable, see below
- returns a tuple of these values.

In order to access the ids from within a task, we add a global variable IDS to the in-process runtime. This is set by a context manager for each task execution. `sdk.get_backend_ids()` then imports this at execution time, and returns its value.

## Example usage:

```python
import sdk

@sdk.task
def t():
    wf_run_id, task_inv_id, task_run_id =  sdk.get_backend_ids()
    ...
```

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


[ORQSDK-823]: https://zapatacomputing.atlassian.net/browse/ORQSDK-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ