### PR TITLE
internal: Fix CUDA image publishing workflow failure when no Docker tag is given

### DIFF
--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -15,9 +15,9 @@ on:
         type: string
         description: |
           Optional parameter to tag the Docker image. If provided,
-          the published image will be tagged with the given tag.
+          the published image will be tagged with the given tag plus -cuda.
           For e.g. if foo-123 is given, the final image will be named
-          hub.stage.nexus.orquestra.io/zapatacomputing/orquestra-sdk-base:foo-123
+          hub.stage.nexus.orquestra.io/zapatacomputing/orquestra-sdk-base:foo-123-cuda
 jobs:
   trigger-build-and-push:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -66,7 +66,7 @@ jobs:
           # See https://github.com/docker/metadata-action#tags-input for the
           # format this should take.
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
-          additional_image_tags: ${{ inputs.docker_tag && 'type=raw,value=${{ inputs.docker_tag }}' || ''}}
+          additional_image_tags: ${{ inputs.docker_tag && format('type=raw,value={0}', inputs.docker_tag) || ''}}
           # For changing `latest` tag behavior, as well as global prefix/suffixes
           # See https://github.com/docker/metadata-action#flavor-input
           # for details on how to use the `flavor` input.

--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -71,7 +71,7 @@ jobs:
           # See https://github.com/docker/metadata-action#flavor-input
           # for details on how to use the `flavor` input.
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
-          image_tag_flavor: 'suffix=-cuda'
+          image_tag_flavor: ${{ inputs.sdk_requirement && 'suffix=-cuda' || ''}}
           # pass any OCI labels you want to add to the final image
           # https://github.com/opencontainers/image-spec/blob/main/annotations.md
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n

--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -71,7 +71,7 @@ jobs:
           # See https://github.com/docker/metadata-action#flavor-input
           # for details on how to use the `flavor` input.
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
-          image_tag_flavor: ${{ inputs.sdk_requirement && 'suffix=-cuda' || ''}}
+          image_tag_flavor: ${{ inputs.docker_tag && 'suffix=-cuda' || ''}}
           # pass any OCI labels you want to add to the final image
           # https://github.com/opencontainers/image-spec/blob/main/annotations.md
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n

--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -66,12 +66,12 @@ jobs:
           # See https://github.com/docker/metadata-action#tags-input for the
           # format this should take.
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
-          additional_image_tags: 'type=raw,value=${{ inputs.docker_tag }}'
+          additional_image_tags: ${{ inputs.docker_tag && 'type=raw,value=${{ inputs.docker_tag }}' || ''}}
           # For changing `latest` tag behavior, as well as global prefix/suffixes
           # See https://github.com/docker/metadata-action#flavor-input
           # for details on how to use the `flavor` input.
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
-          image_tag_flavor: ${{ inputs.docker_tag && 'suffix=-cuda' || ''}}
+          image_tag_flavor: 'suffix=-cuda'
           # pass any OCI labels you want to add to the final image
           # https://github.com/opencontainers/image-spec/blob/main/annotations.md
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n


### PR DESCRIPTION
# The problem

When no Docker tag is given as an input parameter, the GitHub Actions workflow that builds CUDA images fails. However, it needs to be an optional input parameter and the image should be tagged with prefix `dev-build` instead.

# This PR's solution

Modify GitHub Actions workflow code to add the additional tags only when they're provided.

# Checklist

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
