### PR TITLE
Feat: cli easy re login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 🔥 *Features*
 * Login CLI command now accepts the name of a stored config as an alternative to the uri.
+* Choice and Checklist CLI prompts present an informative error message when there are no options rather than prompting the user to select from an empty list.
 * All CLI commands that prompted for `wf_run_id` will now first prompt for workspace and project if `wf_run_id` is not provided.
 
 👩‍🔬 *Experimental*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * New API functions: list_workspaces() and list_projects(). Usable only on CE runtime
 * Setting workflow_id and project_id is now available using "orq wf submit" command
 * All CLI commands that prompted for wf_run_id will now first prompt for workspace and project if wf_run_ID is not provided
+* Login CLI command now accepts the name of a stored config as an alternative to the uri.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -386,10 +386,17 @@ dorq.section(
     status,
 )
 
+server_config_group = cloup.OptionGroup(
+    "Server configuration", constraint=cloup.constraints.RequireExactly(1)
+)
+
 
 @dorq.command()
-@cloup.option(
-    "-s", "--server", required=True, help="server URI that you want to log into"
+@server_config_group.option(
+    "-c", "--config", required=False, help="The name of an existing configureation."
+)
+@server_config_group.option(
+    "-s", "--server", required=False, help="server URI that you want to log into"
 )
 @cloup.option(
     "-t",
@@ -404,14 +411,14 @@ dorq.section(
     default=False,
     help="Log in to Compute Engine. If not passed, will log in to Quantum Engine",
 )
-def login(server: str, token: t.Optional[str], ce: bool):
+def login(config: str, server: str, token: t.Optional[str], ce: bool):
     """
     Login in to remote cluster
     """
     from ._login._login import Action
 
     action = Action()
-    action.on_cmd_call(server, token, ce)
+    action.on_cmd_call(config, server, token, ce)
 
 
 def main():

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -79,7 +79,6 @@ class Action:
 
         _url: str
         if config:
-            # _config =
             loaded_config = self._config_repo.read_config(
                 self._config_resolver.resolve_stored_config_for_login(config)
             )
@@ -98,7 +97,7 @@ class Action:
             # TODO: This can be reworked once we have a --qe flag.
             if ce != (loaded_config.runtime_name == RuntimeName.CE_REMOTE):
                 if not self._prompter.confirm(
-                    f"Config '{config}' will be changed from "
+                    f"Config '{loaded_config.config_name}' will be changed from "
                     f"{loaded_config.runtime_name} to "
                     f"{RuntimeName.CE_REMOTE if ce else RuntimeName.QE_REMOTE}. "
                     "Continue?",

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -76,6 +76,7 @@ class Action:
             "should have been handled at CLI entry. Please report this as a bug."
         )
 
+        _url: str
         if config:
             loaded_config = self._config_repo.read_config(
                 self._config_resolver.resolve(config)
@@ -94,12 +95,14 @@ class Action:
                 )
 
             ce = loaded_config.runtime_name == RuntimeName.CE_REMOTE
-            url = loaded_config.runtime_options["uri"]
+            _url = loaded_config.runtime_options["uri"]
+
+        _url = url or _url
 
         if token is None:
-            self._prompt_for_login(url, ce)
+            self._prompt_for_login(_url, ce)
         else:
-            self._save_token(url, token, ce)
+            self._save_token(_url, token, ce)
 
     def _prompt_for_login(self, url: str, ce: bool):
         try:

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -29,7 +29,7 @@ class Action:
         config_repo=_repos.ConfigRepo(),
         runtime_repo=_repos.RuntimeRepo(),
         login_server=LoginServer(),
-        config_resolver: t.Optional[_arg_resolvers.ConfigResolver] = None,
+        config_resolver=_arg_resolvers.ConfigResolver(),
         prompter=_prompts.Prompter(),
     ):
         # presenters
@@ -42,9 +42,7 @@ class Action:
         self._config_repo: _repos.ConfigRepo = config_repo
         self._runtime_repo: _repos.RuntimeRepo = runtime_repo
         self._login_server: LoginServer = login_server
-        self._config_resolver = config_resolver or _arg_resolvers.ConfigResolver(
-            prompter=prompter
-        )
+        self._config_resolver: _arg_resolvers.ConfigResolver = config_resolver
 
     def on_cmd_call(
         self,
@@ -53,6 +51,9 @@ class Action:
         token: t.Optional[str],
         ce: bool,
     ):
+        """
+        Call the login command action, catching any exceptions that arise.
+        """
         try:
             self._on_cmd_call_with_exceptions(config, url, token, ce)
         except Exception as e:

--- a/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_login/_login.py
@@ -73,7 +73,7 @@ class Action:
             "orq login action was called with arguments "
             f"'config = {config}, url = {url}'. "
             "Exactly one of these arguments must be provided, but this constraint "
-            "should have been handled at CLI entry. Please report this as a bug."
+            "should have been handled at CLI entry."
         )
 
         _url: str

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -509,6 +509,9 @@ class ConfigRepo:
         return config_name
 
     def read_config(self, config: ConfigName) -> RuntimeConfiguration:
+        """
+        Read a stored config.
+        """
         return _config.read_config(config)
 
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -25,7 +25,7 @@ from orquestra.sdk._base._qe import _client
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base.abc import ArtifactValue
 from orquestra.sdk.schema import _compat
-from orquestra.sdk.schema.configs import ConfigName, RuntimeName
+from orquestra.sdk.schema.configs import ConfigName, RuntimeConfiguration, RuntimeName
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
 from orquestra.sdk.schema.workflow_run import (
     ProjectId,
@@ -507,6 +507,9 @@ class ConfigRepo:
         _config.save_or_update(config_name, runtime_name, config._get_runtime_options())
 
         return config_name
+
+    def read_config(self, config: ConfigName) -> RuntimeConfiguration:
+        return _config.read_config(config)
 
 
 class SpacesRepo:

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -134,7 +134,7 @@ def _(e: exceptions.ConfigNameNotFoundError) -> ResponseStatusCode:
 @pretty_print_exception.register
 def _(e: exceptions.NoOptionsAvailableError) -> ResponseStatusCode:
     _print_traceback(e)
-    click.echo(e.message)
+    click.echo(f"{e.message}:\nNo options are available.")
     return ResponseStatusCode.NOT_FOUND
 
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -132,6 +132,13 @@ def _(e: exceptions.ConfigNameNotFoundError) -> ResponseStatusCode:
 
 
 @pretty_print_exception.register
+def _(e: exceptions.NoOptionsAvailableError) -> ResponseStatusCode:
+    _print_traceback(e)
+    click.echo(e.message)
+    return ResponseStatusCode.NOT_FOUND
+
+
+@pretty_print_exception.register
 def _(e: exceptions.LocalConfigLoginError) -> ResponseStatusCode:
     click.echo(e.message)
     return ResponseStatusCode.INVALID_CLI_COMMAND_ERROR

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -122,3 +122,16 @@ def _(_: exceptions.InProcessFromCLIError) -> ResponseStatusCode:
         ).format(IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_ALIAS),
     )
     return ResponseStatusCode.USER_CANCELLED
+
+
+@pretty_print_exception.register
+def _(e: exceptions.ConfigNameNotFoundError) -> ResponseStatusCode:
+    _print_traceback(e)
+    click.echo(e.message)
+    return ResponseStatusCode.NOT_FOUND
+
+
+@pretty_print_exception.register
+def _(e: exceptions.LocalConfigLoginError) -> ResponseStatusCode:
+    click.echo(e.message)
+    return ResponseStatusCode.INVALID_CLI_COMMAND_ERROR

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
@@ -77,6 +77,11 @@ class Prompter:
         Raises:
             UserCancelledPrompt if the user cancels the prompt
         """
+        # If there are no choices, report it to the user and exit.
+        if len(choices) == 0:
+            raise exceptions.NoOptionsAvailableError(
+                f"{message} - no options are available."
+            )
 
         # If there's only one choice, select it automatically and confirm with the user
         # that that's what they want to do.
@@ -182,6 +187,33 @@ class Prompter:
         Raises:
             UserCancelledPrompt if the user cancels the prompt
         """
+        # If there are no choices, report it to the user and exit.
+        if len(choices) == 0:
+            raise exceptions.NoOptionsAvailableError(
+                f"{message} - no options are available."
+            )
+
+        # If there's only one choice, select it automatically and confirm with the user
+        # that that's what they want to do.
+        if len(choices) == 1:
+            name: ChoiceID
+            value: t.Union[ChoiceID, T]
+            # When the choice is a tuple, we unpack the display
+            # name and the returned value.
+            # Otherwise, the choice is a ChoiceID and should be
+            # used as both the display name and the returned
+            # value.
+            if isinstance(choices[0], tuple):
+                name, value = choices[0]
+            else:
+                name, value = choices[0], choices[0]
+
+            if not self.confirm(
+                f"{message} - only one option is available. Proceed with {name}?",
+                default=True,
+            ):
+                raise exceptions.UserCancelledPrompt(f"User cancelled {message} prompt")
+            return value
 
         question = inquirer.Checkbox(
             SINGLE_INPUT,

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_prompts.py
@@ -79,9 +79,7 @@ class Prompter:
         """
         # If there are no choices, report it to the user and exit.
         if len(choices) == 0:
-            raise exceptions.NoOptionsAvailableError(
-                f"{message} - no options are available."
-            )
+            raise exceptions.NoOptionsAvailableError(message)
 
         # If there's only one choice, select it automatically and confirm with the user
         # that that's what they want to do.
@@ -172,9 +170,7 @@ class Prompter:
         """
         # If there are no choices, report it to the user and exit.
         if len(choices) == 0:
-            raise exceptions.NoOptionsAvailableError(
-                f"{message} - no options are available."
-            )
+            raise exceptions.NoOptionsAvailableError(message)
 
         # If there's only one choice, select it automatically and confirm with the user
         # that that's what they want to do.

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -73,6 +73,12 @@ class UnsavedConfigChangesError(BaseRuntimeError):
     pass
 
 
+class LocalConfigLoginError(BaseRuntimeError):
+    """Raised when trying to log in using a config that relates to local execution."""
+
+    pass
+
+
 # Workflow Definition Errors
 class WorkflowDefinitionModuleNotFound(NotFoundError):
     """

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -238,6 +238,12 @@ class LoginURLUnavailableError(BaseRuntimeError):
         self.base_uri = base_uri
 
 
+class NoOptionsAvailableError(NotFoundError):
+    """Raised when the user would choose options, but no options are available"""
+
+    pass
+
+
 class InProcessFromCLIError(NotFoundError):
     """Raised when the user requests the in-process runtime when using the CLI"""
 

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -11,6 +11,7 @@ from orquestra.sdk import exceptions
 from orquestra.sdk._base._spaces._structs import Project, ProjectRef, Workspace
 from orquestra.sdk._base.cli._dorq import _arg_resolvers, _repos
 from orquestra.sdk._base.cli._dorq._ui import _presenters, _prompts
+from orquestra.sdk.schema.configs import RuntimeConfiguration
 from orquestra.sdk.schema.workflow_run import RunStatus, State
 
 
@@ -21,62 +22,67 @@ class TestConfigResolver:
                         ->[prompter]
     """
 
-    @staticmethod
-    def test_passing_config_directly():
-        """
-        User passed `config` value directly as CLI arg.
-        """
-        # Given
-        config = "<config sentinel>"
+    class TestResolveSingular:
+        @staticmethod
+        def test_passing_config_directly():
+            """
+            User passed `config` value directly as CLI arg.
+            """
+            # Given
+            config = "<config sentinel>"
 
-        resolver = _arg_resolvers.ConfigResolver(
-            config_repo=Mock(),
-            prompter=Mock(),
-        )
+            resolver = _arg_resolvers.ConfigResolver(
+                config_repo=Mock(),
+                prompter=Mock(),
+            )
 
-        # When
-        resolved_config = resolver.resolve(config=config)
+            # When
+            resolved_config = resolver.resolve(config=config)
 
-        # Then
-        assert resolved_config == config
+            # Then
+            assert resolved_config == config
 
-    @staticmethod
-    def test_no_config():
-        # Given
-        config = None
+        @staticmethod
+        def test_no_config():
+            # Given
+            config = None
 
-        config_repo = Mock()
-        local_config_names = ["cfg1", "cfg2"]
-        config_repo.list_config_names.return_value = local_config_names
+            config_repo = Mock()
+            local_config_names = ["cfg1", "cfg2"]
+            config_repo.list_config_names.return_value = local_config_names
 
-        prompter = Mock()
-        selected_config = local_config_names[1]
-        prompter.choice.return_value = selected_config
+            prompter = Mock()
+            selected_config = local_config_names[1]
+            prompter.choice.return_value = selected_config
 
-        resolver = _arg_resolvers.ConfigResolver(
-            config_repo=config_repo,
-            prompter=prompter,
-        )
+            resolver = _arg_resolvers.ConfigResolver(
+                config_repo=config_repo,
+                prompter=prompter,
+            )
 
-        # When
-        resolved_config = resolver.resolve(config=config)
+            # When
+            resolved_config = resolver.resolve(config=config)
 
-        # Then
-        # We expect prompt for selecting config.
-        prompter.choice.assert_called_with(local_config_names, message="Runtime config")
+            # Then
+            # We expect prompt for selecting config.
+            prompter.choice.assert_called_with(
+                local_config_names, message="Runtime config"
+            )
 
-        # Resolver should return the user's choice.
-        assert resolved_config == selected_config
+            # Resolver should return the user's choice.
+            assert resolved_config == selected_config
 
-    @staticmethod
-    def test_with_in_process():
-        # Given
-        config = "in_process"
-        resolver = _arg_resolvers.ConfigResolver(config_repo=Mock(), prompter=Mock())
+        @staticmethod
+        def test_with_in_process():
+            # Given
+            config = "in_process"
+            resolver = _arg_resolvers.ConfigResolver(
+                config_repo=Mock(), prompter=Mock()
+            )
 
-        # When/Then
-        with pytest.raises(exceptions.InProcessFromCLIError):
-            resolver.resolve(config)
+            # When/Then
+            with pytest.raises(exceptions.InProcessFromCLIError):
+                resolver.resolve(config)
 
     class TestResolveMultiple:
         @staticmethod
@@ -155,6 +161,120 @@ class TestConfigResolver:
 
             # Resolver should return the user's choice.
             assert resolved_config == selected_config
+
+    class TestResolveStoredForLogin:
+        @staticmethod
+        def test_passing_valid_config_name():
+            # GIVEN
+            # cli inputs
+            config = "<config sentinel>"
+
+            # Stored configs
+            stored_config = create_autospec(RuntimeConfiguration)
+            stored_config.config_name = config
+            stored_config.runtime_options = {"uri": "<stored uri sentinel>"}
+            stored_configs = [stored_config]
+
+            # test boundaries
+            config_repo = create_autospec(_repos.ConfigRepo)
+            config_repo.list_config_names.return_value = [
+                config.config_name for config in stored_configs
+            ]
+            config_repo.read_config.side_effect = stored_configs
+            prompter = create_autospec(_prompts.Prompter)
+
+            resolver = _arg_resolvers.ConfigResolver(
+                config_repo=config_repo,
+                prompter=prompter,
+            )
+
+            # WHEN
+            resolved_config = resolver.resolve_stored_config_for_login(config)
+
+            # THEN
+            assert resolved_config == config
+            prompter.choice.assert_not_called()
+
+        @staticmethod
+        def test_passing_non_existant_config_name():
+            # GIVEN
+            # cli inputs
+            config = "<config sentinel>"
+
+            # Stored configs
+            stored_config = create_autospec(RuntimeConfiguration)
+            stored_config.config_name = "<stored config name sentinel>"
+            stored_config.runtime_options = {"uri": "<stored uri sentinel>"}
+            stored_configs = [stored_config]
+
+            # test boundaries
+            config_repo = create_autospec(_repos.ConfigRepo)
+            config_repo.list_config_names.return_value = [
+                config.config_name for config in stored_configs
+            ]
+            config_repo.read_config.side_effect = stored_configs
+            prompter = create_autospec(_prompts.Prompter)
+            prompter.choice.return_value = "<chosen config sentinel>"
+
+            resolver = _arg_resolvers.ConfigResolver(
+                config_repo=config_repo,
+                prompter=prompter,
+            )
+
+            # WHEN
+            resolved_config = resolver.resolve_stored_config_for_login(config)
+
+            # THEN
+            assert resolved_config == "<chosen config sentinel>"
+            prompter.choice.assert_called_once_with(
+                ["<stored config name sentinel>"],
+                message=(
+                    "No config '<config sentinel>' found in file. "
+                    "Please select a valid config"
+                ),
+            )
+
+        @staticmethod
+        def test_passing_local_config_name():
+            # GIVEN
+            # cli inputs
+            config = "<config sentinel>"
+
+            # Stored configs
+            stored_config = create_autospec(RuntimeConfiguration)
+            stored_config.config_name = "<stored config name sentinel>"
+            stored_config.runtime_options = {"uri": "<stored uri sentinel>"}
+            stored_local_config = create_autospec(RuntimeConfiguration)
+            stored_local_config.config_name = config
+            stored_local_config.runtime_options = {}
+            stored_configs = [stored_config, stored_local_config]
+
+            # test boundaries
+            config_repo = create_autospec(_repos.ConfigRepo)
+            config_repo.list_config_names.return_value = [
+                config.config_name for config in stored_configs
+            ]
+            config_repo.read_config.side_effect = stored_configs
+            prompter = create_autospec(_prompts.Prompter)
+            prompter.choice.return_value = "<chosen config sentinel>"
+
+            resolver = _arg_resolvers.ConfigResolver(
+                config_repo=config_repo,
+                prompter=prompter,
+            )
+
+            # WHEN
+            resolved_config = resolver.resolve_stored_config_for_login(config)
+
+            # THEN
+            assert resolved_config == "<chosen config sentinel>"
+            prompter.choice.assert_called_once_with(
+                ["<stored config name sentinel>"],
+                message=(
+                    "Cannot log in with '<config sentinel>' as it relates to local "
+                    "runs. Please select a valid config"
+                ),
+            )
 
 
 class TestWFConfigResolver:

--- a/tests/cli/dorq/test_login.py
+++ b/tests/cli/dorq/test_login.py
@@ -123,7 +123,7 @@ class TestAction:
         action.on_cmd_call(config=config, url=url, token=token, ce=ce)
 
         # Then
-        config_resolver.resolve.assert_not_called()
+        config_resolver.resolve_stored_config_for_login.assert_not_called()
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_called_once_with(
             url, retrieved_token, ce
@@ -168,7 +168,7 @@ class TestAction:
 
         # Then
         async_sleep.assert_not_called()
-        config_resolver.resolve.assert_not_called()
+        config_resolver.resolve_stored_config_for_login.assert_not_called()
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_not_called()
         login_presenter.prompt_config_saved.assert_not_called()
@@ -211,7 +211,7 @@ class TestAction:
         # Then
         # We should get the login url from QE
         async_sleep.assert_not_called()
-        config_resolver.resolve.assert_not_called()
+        config_resolver.resolve_stored_config_for_login.assert_not_called()
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_called_once_with(url, token, ce)
         login_presenter.prompt_config_saved.assert_called_once_with(url, config_name)
@@ -239,7 +239,7 @@ class TestAction:
 
         loaded_runtime_config.runtime_options = {"uri": login_url}
         loaded_runtime_config.runtime_name = "CE_REMOTE" if ce else "QE_REMOTE"
-        config_resolver.resolve.return_value = config_name
+        config_resolver.resolve_stored_config_for_login.return_value = config_name
         config_repo.read_config.return_value = loaded_runtime_config
         config_repo.store_token_in_config.return_value = config_name
         type(login_server).token = PropertyMock(return_value=retrieved_token)
@@ -258,7 +258,7 @@ class TestAction:
 
         # THEN
         async_sleep.assert_called_once()
-        config_resolver.resolve.assert_called_once_with(config)
+        config_resolver.resolve_stored_config_for_login.assert_called_once_with(config)
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_called_once_with(
             login_url, retrieved_token, ce
@@ -289,7 +289,7 @@ class TestAction:
 
         loaded_runtime_config.runtime_options = {"uri": login_url}
         loaded_runtime_config.runtime_name = "CE_REMOTE" if ce else "QE_REMOTE"
-        config_resolver.resolve.return_value = config_name
+        config_resolver.resolve_stored_config_for_login.return_value = config_name
         config_repo.read_config.return_value = loaded_runtime_config
         config_repo.store_token_in_config.return_value = config_name
 
@@ -307,7 +307,7 @@ class TestAction:
 
         # THEN
         async_sleep.assert_not_called()
-        config_resolver.resolve.assert_called_once_with(config)
+        config_resolver.resolve_stored_config_for_login.assert_called_once_with(config)
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_called_once_with(login_url, token, ce)
         login_presenter.prompt_config_saved.assert_called_once_with(
@@ -336,7 +336,7 @@ class TestAction:
 
         loaded_runtime_config.runtime_options = {"uri": login_url}
         loaded_runtime_config.runtime_name = "CE_REMOTE" if ce else "QE_REMOTE"
-        config_resolver.resolve.return_value = config_name
+        config_resolver.resolve_stored_config_for_login.return_value = config_name
         config_repo.read_config.return_value = loaded_runtime_config
         config_repo.store_token_in_config.return_value = config_name
 
@@ -354,7 +354,7 @@ class TestAction:
 
         # THEN
         async_sleep.assert_not_called()
-        config_resolver.resolve.assert_not_called()
+        config_resolver.resolve_stored_config_for_login.assert_not_called()
         exception_presenter.show_error.assert_called_once()
         config_repo.store_token_in_config.assert_not_called()
         login_presenter.prompt_config_saved.assert_not_called()
@@ -384,7 +384,7 @@ class TestAction:
         loaded_runtime_config = create_autospec(RuntimeConfiguration)
         loaded_runtime_config.runtime_options = {"uri": login_url}
         loaded_runtime_config.runtime_name = "QE_REMOTE" if ce else "CE_REMOTE"
-        config_resolver.resolve.return_value = config_name
+        config_resolver.resolve_stored_config_for_login.return_value = config_name
         config_repo.read_config.return_value = loaded_runtime_config
         config_repo.store_token_in_config.return_value = config_name
 
@@ -410,7 +410,7 @@ class TestAction:
             True,
         )
         async_sleep.assert_called_once()
-        config_resolver.resolve.assert_called_once_with(config)
+        config_resolver.resolve_stored_config_for_login.assert_called_once_with(config)
         login_presenter.prompt_config_saved.assert_called_once_with(
             login_url, config_name
         )
@@ -464,7 +464,7 @@ class TestAction:
 
         # THEN
         # called
-        config_resolver.resolve.assert_called_once_with(config)
+        config_resolver.resolve_stored_config_for_login.assert_called_once_with(config)
         prompter.confirm.assert_called_once_with(
             f"Config '{config}' will be changed from "
             f"{loaded_runtime_config.runtime_name} to "

--- a/tests/cli/dorq/test_login.py
+++ b/tests/cli/dorq/test_login.py
@@ -384,6 +384,7 @@ class TestAction:
         loaded_runtime_config = create_autospec(RuntimeConfiguration)
         loaded_runtime_config.runtime_options = {"uri": login_url}
         loaded_runtime_config.runtime_name = "QE_REMOTE" if ce else "CE_REMOTE"
+        loaded_runtime_config.config_name = config_name
         config_resolver.resolve_stored_config_for_login.return_value = config_name
         config_repo.read_config.return_value = loaded_runtime_config
         config_repo.store_token_in_config.return_value = config_name
@@ -404,7 +405,7 @@ class TestAction:
         # THEN
         # called
         prompter.confirm.assert_called_once_with(
-            f"Config '{config}' will be changed from "
+            f"Config '{config_name}' will be changed from "
             f"{loaded_runtime_config.runtime_name} to "
             f"{'CE_REMOTE' if ce else 'QE_REMOTE'}. Continue?",
             True,
@@ -445,6 +446,7 @@ class TestAction:
         loaded_runtime_config = create_autospec(RuntimeConfiguration)
         loaded_runtime_config.runtime_options = {"uri": login_url}
         loaded_runtime_config.runtime_name = "QE_REMOTE" if ce else "CE_REMOTE"
+        loaded_runtime_config.config_name = config_name
         config_resolver.resolve.return_value = config_name
         config_repo.read_config.return_value = loaded_runtime_config
         config_repo.store_token_in_config.return_value = config_name
@@ -466,7 +468,7 @@ class TestAction:
         # called
         config_resolver.resolve_stored_config_for_login.assert_called_once_with(config)
         prompter.confirm.assert_called_once_with(
-            f"Config '{config}' will be changed from "
+            f"Config '{config_name}' will be changed from "
             f"{loaded_runtime_config.runtime_name} to "
             f"{'CE_REMOTE' if ce else 'QE_REMOTE'}. Continue?",
             True,

--- a/tests/cli/dorq/test_login.py
+++ b/tests/cli/dorq/test_login.py
@@ -8,12 +8,14 @@ from unittest.mock import Mock, PropertyMock, create_autospec
 import pytest
 from aiohttp import web
 
+from orquestra.sdk._base.cli._dorq._arg_resolvers import ConfigResolver
 from orquestra.sdk._base.cli._dorq._login import _login, _login_server
 from orquestra.sdk._base.cli._dorq._repos import ConfigRepo, RuntimeRepo
 from orquestra.sdk._base.cli._dorq._ui._presenters import (
     LoginPresenter,
     WrappedCorqOutputPresenter,
 )
+from orquestra.sdk.schema.configs import RuntimeConfiguration
 
 
 @pytest.mark.parametrize("ce", [True, False])
@@ -42,6 +44,7 @@ class TestAction:
         config_name = "cfg"
         token = None
         retrieved_token = "mocked_token"
+        config = None
 
         # Mocks
         exception_presenter = create_autospec(WrappedCorqOutputPresenter)
@@ -49,6 +52,7 @@ class TestAction:
         runtime_repo = create_autospec(RuntimeRepo)
         config_repo = create_autospec(ConfigRepo)
         login_server = create_autospec(_login_server.LoginServer)
+        config_resolver = create_autospec(ConfigResolver)
 
         config_repo.store_token_in_config.return_value = config_name
         runtime_repo.get_login_url.return_value = login_url
@@ -60,13 +64,15 @@ class TestAction:
             runtime_repo=runtime_repo,
             config_repo=config_repo,
             login_server=login_server,
+            config_resolver=config_resolver,
         )
 
         # When
-        action.on_cmd_call(url=url, token=token, ce=ce)
+        action.on_cmd_call(config=config, url=url, token=token, ce=ce)
 
         # Then
         async_sleep.assert_called_once()
+        config_resolver.resolve.assert_not_called()
         exception_presenter.show_error.assert_not_called()
         login_presenter.open_url_in_browser.assert_called_once_with(login_url)
         login_presenter.print_login_help.assert_called_once()
@@ -86,6 +92,7 @@ class TestAction:
         config_name = "cfg"
         token = None
         retrieved_token = "mocked_token"
+        config = None
 
         # Mocks
         exception_presenter = create_autospec(WrappedCorqOutputPresenter)
@@ -93,6 +100,7 @@ class TestAction:
         runtime_repo = create_autospec(RuntimeRepo)
         config_repo = create_autospec(ConfigRepo)
         login_server = create_autospec(_login_server.LoginServer)
+        config_resolver = create_autospec(ConfigResolver)
 
         config_repo.store_token_in_config.return_value = config_name
         runtime_repo.get_login_url.return_value = login_url
@@ -104,15 +112,17 @@ class TestAction:
             runtime_repo=runtime_repo,
             config_repo=config_repo,
             login_server=login_server,
+            config_resolver=config_resolver,
         )
         monkeypatch.setattr(
             action, "_get_token_from_server", Mock(side_effect=web.GracefulExit)
         )
 
         # When
-        action.on_cmd_call(url=url, token=token, ce=ce)
+        action.on_cmd_call(config=config, url=url, token=token, ce=ce)
 
         # Then
+        config_resolver.resolve.assert_not_called()
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_called_once_with(
             url, retrieved_token, ce
@@ -128,6 +138,7 @@ class TestAction:
         config_name = "cfg"
         token = None
         retrieved_token = None
+        config = None
 
         # Mocks
         exception_presenter = create_autospec(WrappedCorqOutputPresenter)
@@ -135,6 +146,7 @@ class TestAction:
         runtime_repo = create_autospec(RuntimeRepo)
         config_repo = create_autospec(ConfigRepo)
         login_server = create_autospec(_login_server.LoginServer)
+        config_resolver = create_autospec(ConfigResolver)
 
         config_repo.store_token_in_config.return_value = config_name
         runtime_repo.get_login_url.return_value = login_url
@@ -147,13 +159,15 @@ class TestAction:
             runtime_repo=runtime_repo,
             config_repo=config_repo,
             login_server=login_server,
+            config_resolver=config_resolver,
         )
 
         # When
-        action.on_cmd_call(url=url, token=token, ce=ce)
+        action.on_cmd_call(config=config, url=url, token=token, ce=ce)
 
         # Then
         async_sleep.assert_not_called()
+        config_resolver.resolve.assert_not_called()
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_not_called()
         login_presenter.prompt_config_saved.assert_not_called()
@@ -168,13 +182,16 @@ class TestAction:
         # CLI inputs
         url = "my_url"
         token = "my_token"
+        config = None
 
+        # Mocks
         config_name = "cfg"
         exception_presenter = create_autospec(WrappedCorqOutputPresenter)
         login_presenter = create_autospec(LoginPresenter)
         runtime_repo = create_autospec(RuntimeRepo)
         config_repo = create_autospec(ConfigRepo)
         login_server = create_autospec(_login_server.LoginServer)
+        config_resolver = create_autospec(ConfigResolver)
 
         config_repo.store_token_in_config.return_value = config_name
 
@@ -184,14 +201,159 @@ class TestAction:
             runtime_repo=runtime_repo,
             config_repo=config_repo,
             login_server=login_server,
+            config_resolver=config_resolver,
         )
 
         # When
-        action.on_cmd_call(url=url, token=token, ce=ce)
+        action.on_cmd_call(config=config, url=url, token=token, ce=ce)
 
         # Then
         # We should get the login url from QE
         async_sleep.assert_not_called()
+        config_resolver.resolve.assert_not_called()
         exception_presenter.show_error.assert_not_called()
         config_repo.store_token_in_config.assert_called_once_with(url, token, ce)
         login_presenter.prompt_config_saved.assert_called_once_with(url, config_name)
+
+    @staticmethod
+    def test_passed_config_no_token(async_sleep, ce):
+        # GIVEN
+        # CLI inputs
+        url = None
+        token = None
+        config = "<cli config sentinel>"
+
+        login_url = "config_url"
+        config_name = "cfg"
+        retrieved_token = "mocked_token"
+
+        # Mocks
+        exception_presenter = create_autospec(WrappedCorqOutputPresenter)
+        login_presenter = create_autospec(LoginPresenter)
+        runtime_repo = create_autospec(RuntimeRepo)
+        config_repo = create_autospec(ConfigRepo)
+        login_server = create_autospec(_login_server.LoginServer)
+        config_resolver = create_autospec(ConfigResolver)
+        loaded_runtime_config = create_autospec(RuntimeConfiguration)
+
+        loaded_runtime_config.runtime_options = {"uri": login_url}
+        loaded_runtime_config.runtime_name = "CE_REMOTE" if ce else "QE_REMOTE"
+        config_resolver.resolve.return_value = config_name
+        config_repo.read_config.return_value = loaded_runtime_config
+        config_repo.store_token_in_config.return_value = config_name
+        type(login_server).token = PropertyMock(return_value=retrieved_token)
+
+        action = _login.Action(
+            exception_presenter=exception_presenter,
+            login_presenter=login_presenter,
+            runtime_repo=runtime_repo,
+            config_repo=config_repo,
+            login_server=login_server,
+            config_resolver=config_resolver,
+        )
+
+        # WHEN
+        action.on_cmd_call(config=config, url=url, token=token, ce=ce)
+
+        # THEN
+        async_sleep.assert_called_once()
+        config_resolver.resolve.assert_called_once_with(config)
+        exception_presenter.show_error.assert_not_called()
+        config_repo.store_token_in_config.assert_called_once_with(
+            login_url, retrieved_token, ce
+        )
+        login_presenter.prompt_config_saved.assert_called_once_with(
+            login_url, config_name
+        )
+
+    @staticmethod
+    def test_passed_config_and_token(async_sleep, ce):
+        # GIVEN
+        # CLI inputs
+        url = None
+        token = "<cli token sentinel>"
+        config = "<cli config sentinel>"
+
+        login_url = "config_url"
+        config_name = "cfg"
+
+        # Mocks
+        exception_presenter = create_autospec(WrappedCorqOutputPresenter)
+        login_presenter = create_autospec(LoginPresenter)
+        runtime_repo = create_autospec(RuntimeRepo)
+        config_repo = create_autospec(ConfigRepo)
+        login_server = create_autospec(_login_server.LoginServer)
+        config_resolver = create_autospec(ConfigResolver)
+        loaded_runtime_config = create_autospec(RuntimeConfiguration)
+
+        loaded_runtime_config.runtime_options = {"uri": login_url}
+        loaded_runtime_config.runtime_name = "CE_REMOTE" if ce else "QE_REMOTE"
+        config_resolver.resolve.return_value = config_name
+        config_repo.read_config.return_value = loaded_runtime_config
+        config_repo.store_token_in_config.return_value = config_name
+
+        action = _login.Action(
+            exception_presenter=exception_presenter,
+            login_presenter=login_presenter,
+            runtime_repo=runtime_repo,
+            config_repo=config_repo,
+            login_server=login_server,
+            config_resolver=config_resolver,
+        )
+
+        # WHEN
+        action.on_cmd_call(config=config, url=url, token=token, ce=ce)
+
+        # THEN
+        async_sleep.assert_not_called()
+        config_resolver.resolve.assert_called_once_with(config)
+        exception_presenter.show_error.assert_not_called()
+        config_repo.store_token_in_config.assert_called_once_with(login_url, token, ce)
+        login_presenter.prompt_config_saved.assert_called_once_with(
+            login_url, config_name
+        )
+
+    @staticmethod
+    def test_passed_config_and_server_exits_gracefully(async_sleep, ce):
+        # GIVEN
+        # CLI inputs
+        url = "<cli url sentinel>"
+        token = "<cli token sentinel>"
+        config = "<cli config sentinel>"
+
+        login_url = "config_url"
+        config_name = "cfg"
+
+        # Mocks
+        exception_presenter = create_autospec(WrappedCorqOutputPresenter)
+        login_presenter = create_autospec(LoginPresenter)
+        runtime_repo = create_autospec(RuntimeRepo)
+        config_repo = create_autospec(ConfigRepo)
+        login_server = create_autospec(_login_server.LoginServer)
+        config_resolver = create_autospec(ConfigResolver)
+        loaded_runtime_config = create_autospec(RuntimeConfiguration)
+
+        loaded_runtime_config.runtime_options = {"uri": login_url}
+        loaded_runtime_config.runtime_name = "CE_REMOTE" if ce else "QE_REMOTE"
+        config_resolver.resolve.return_value = config_name
+        config_repo.read_config.return_value = loaded_runtime_config
+        config_repo.store_token_in_config.return_value = config_name
+
+        action = _login.Action(
+            exception_presenter=exception_presenter,
+            login_presenter=login_presenter,
+            runtime_repo=runtime_repo,
+            config_repo=config_repo,
+            login_server=login_server,
+            config_resolver=config_resolver,
+        )
+
+        # WHEN
+        action.on_cmd_call(config=config, url=url, token=token, ce=ce)
+
+        # THEN
+        async_sleep.assert_not_called()
+        config_resolver.resolve.assert_not_called()
+        exception_presenter.show_error.assert_called_once()
+        config_repo.store_token_in_config.assert_not_called()
+        login_presenter.prompt_config_saved.assert_not_called()

--- a/tests/cli/dorq/ui/test_prompts.py
+++ b/tests/cli/dorq/ui/test_prompts.py
@@ -100,55 +100,56 @@ class TestChoice:
 
 
 class TestCheckbox:
-    @staticmethod
-    def test_user_accepts_selection_single_values(monkeypatch):
-        mock_confirm = Mock()
-        mock_checkbox = Mock()
-        mock_confirm.return_value = True
-        monkeypatch.setattr(Prompter, "confirm", mock_confirm)
-        monkeypatch.setattr(inquirer, "Checkbox", mock_checkbox)
+    class TestSingleOption:
+        @staticmethod
+        def test_user_accepts_selection_single_values(monkeypatch):
+            mock_confirm = Mock()
+            mock_checkbox = Mock()
+            mock_confirm.return_value = True
+            monkeypatch.setattr(Prompter, "confirm", mock_confirm)
+            monkeypatch.setattr(inquirer, "Checkbox", mock_checkbox)
 
-        chosen = prompter.checkbox(["A"], "<message sentinel>")
+            chosen = prompter.checkbox(["A"], "<message sentinel>")
 
-        assert chosen == "A"
-        mock_confirm.assert_called_once_with(
-            "<message sentinel> - only one option is available. Proceed with A?",
-            default=True,
-        )
-        mock_checkbox.assert_not_called()
+            assert chosen == ["A"]
+            mock_confirm.assert_called_once_with(
+                "<message sentinel> - only one option is available. Proceed with A?",
+                default=True,
+            )
+            mock_checkbox.assert_not_called()
 
-    @staticmethod
-    def test_user_accepts_selection_tuples(monkeypatch):
-        mock_confirm = Mock()
-        mock_checkbox = Mock()
-        mock_confirm.return_value = True
-        monkeypatch.setattr(Prompter, "confirm", mock_confirm)
-        monkeypatch.setattr(inquirer, "Checkbox", mock_checkbox)
+        @staticmethod
+        def test_user_accepts_selection_tuples(monkeypatch):
+            mock_confirm = Mock()
+            mock_checkbox = Mock()
+            mock_confirm.return_value = True
+            monkeypatch.setattr(Prompter, "confirm", mock_confirm)
+            monkeypatch.setattr(inquirer, "Checkbox", mock_checkbox)
 
-        chosen = prompter.checkbox([("name", "value")], "<message sentinel>")
+            chosen = prompter.checkbox([("name", "value")], "<message sentinel>")
 
-        assert chosen == "value"
-        mock_confirm.assert_called_once_with(
-            "<message sentinel> - only one option is available. Proceed with name?",
-            default=True,
-        )
-        mock_checkbox.assert_not_called()
+            assert chosen == ["value"]
+            mock_confirm.assert_called_once_with(
+                "<message sentinel> - only one option is available. Proceed with name?",
+                default=True,
+            )
+            mock_checkbox.assert_not_called()
 
-    @staticmethod
-    def test_raises_exception_when_user_rejects_selection(monkeypatch):
-        mock_confirm = Mock()
-        mock_checkbox = Mock()
-        mock_confirm.return_value = False
-        monkeypatch.setattr(Prompter, "confirm", mock_confirm)
-        monkeypatch.setattr(inquirer, "Checkbox", mock_checkbox)
+        @staticmethod
+        def test_raises_exception_when_user_rejects_selection(monkeypatch):
+            mock_confirm = Mock()
+            mock_checkbox = Mock()
+            mock_confirm.return_value = False
+            monkeypatch.setattr(Prompter, "confirm", mock_confirm)
+            monkeypatch.setattr(inquirer, "Checkbox", mock_checkbox)
 
-        with pytest.raises(UserCancelledPrompt):
-            prompter.checkbox(["A"], "<message sentinel>")
+            with pytest.raises(UserCancelledPrompt):
+                prompter.checkbox(["A"], "<message sentinel>")
 
-        mock_confirm.assert_called_once_with(
-            "<message sentinel> - only one option is available. Proceed with A?",
-            default=True,
-        )
+            mock_confirm.assert_called_once_with(
+                "<message sentinel> - only one option is available. Proceed with A?",
+                default=True,
+            )
 
     @staticmethod
     def test_raises_exception_when_there_are_no_options(monkeypatch):


### PR DESCRIPTION
# The problem

If I want to log in to a config I've already used, I typically have a) have memorized the uri, or b) open the config.json to check the uri. It's also very easy to forget the `--ce` flag and have to log in _again_ once I notice.

# This PR's solution

Adds a config option to orq login, so users can now do:

```
orq login -c my_config
```

the uri and CE/not CE are then read from the saved config, and login proceeds with those parameters.

If the token is already known, then updating it is equally simple:

```
orq login -c my_config -t my_token
```

This creates a number of potential clashes which are mitigated as follows:

| case | mitigation |
|------|-----------|
| uri and config both specified | The cli requires exactly one argument out of `-c` and `-s`, and raises an exception otherwise.|
| `--ce` with a non-CE stored config | Raise an exception informing the user fo the clash and giving the precise command to change the runtime in the stored config (`orq login` with the uri sourced from the stored config) if that's what's intended. |
| `--ce` not flagged with a CE config | In the absence of explicit action from the user, we assume the stored config is authoritative, so proceed as though `--ce` had been flagged |

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
