### PR TITLE
Feat: add support for Workspaces to all Secret-related functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * All CLI commands that prompted for wf_run_id will now first prompt for workspace and project if wf_run_ID is not provided
 * `sdk.current_run_ids()` can now be used within task code to access the workflow run ID, task invocation ID, and task run ID.
 * All CLI commands that prompted for `wf_run_id` will now first prompt for workspace and project if `wf_run_id` is not provided.
+* `sdk.secrets.list()`, `sdk.secrets.get()`, `sdk.secrets.set ()` and `sdk.secrets.delete()` now accept `workspace_id` parameter to specify secrets in particular workspace
 
 👩‍🔬 *Experimental*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * All CLI commands that prompted for wf_run_id will now first prompt for workspace and project if wf_run_ID is not provided
 * `sdk.current_run_ids()` can now be used within task code to access the workflow run ID, task invocation ID, and task run ID.
 * All CLI commands that prompted for `wf_run_id` will now first prompt for workspace and project if `wf_run_id` is not provided.
-* `sdk.secrets.list()`, `sdk.secrets.get()`, `sdk.secrets.set ()` and `sdk.secrets.delete()` now accept `workspace_id` parameter to specify secrets in particular workspace
+* `sdk.secrets.list()`, `sdk.secrets.get()`, `sdk.secrets.set()` and `sdk.secrets.delete()` now accept `workspace_id` parameter to specify secrets in particular workspace
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -11,9 +11,17 @@ from .._base import _dsl, _exec_ctx
 from . import _auth, _exceptions, _models
 
 
+def _translate_to_zri(workspace_id: str, secret_name: str) -> str:
+    """
+    Create ZRI from workspace_id and secret_name
+    """
+    return f"zri:v1:unused:0:{workspace_id}:secret:{secret_name}"
+
+
 def get(
     name: str,
     *,
+    workspace_id: t.Optional[str] = None,
     config_name: t.Optional[str] = None,
 ) -> str:
     """
@@ -21,6 +29,7 @@ def get(
 
     Args:
         name: secret identifier.
+        workspace_id: ID of the workspace. Using platform-defined default if omitted
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.
@@ -48,6 +57,9 @@ def get(
     except sdk_exc.ConfigNameNotFoundError:
         raise
 
+    if workspace_id:
+        name = _translate_to_zri(workspace_id, name)
+
     try:
         return client.get_secret(name).value
     # explicit rethrows of known errors
@@ -59,12 +71,14 @@ def get(
 
 def list(
     *,
+    workspace_id: t.Optional[str] = None,
     config_name: t.Optional[str] = None,
 ) -> t.Sequence[str]:
     """
     Lists all secret names.
 
     Args:
+        workspace_id: ID of the workspace. Using platform-defined default if omitted
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.
@@ -83,7 +97,7 @@ def list(
         raise
 
     try:
-        return [obj.name for obj in client.list_secrets()]
+        return [obj.name for obj in client.list_secrets(workspace_id)]
     # explicit rethrows of known errors
     except _exceptions.InvalidTokenError as e:
         raise sdk_exc.UnauthorizedError() from e
@@ -93,6 +107,7 @@ def set(
     name: str,
     value: str,
     *,
+    workspace_id: t.Optional[str] = None,
     config_name: t.Optional[str] = None,
 ):
     """
@@ -101,6 +116,8 @@ def set(
     Args:
         name: secret identifier.
         value: new secret name.
+        workspace_id: workspace in which secret will be created. Using platform-defined
+            default if omitted
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.
@@ -118,8 +135,14 @@ def set(
 
     try:
         try:
-            client.create_secret(_models.SecretDefinition(name=name, value=value))
+            client.create_secret(
+                _models.SecretDefinition(
+                    name=name, value=value, resourceGroup=workspace_id
+                )
+            )
         except _exceptions.SecretAlreadyExistsError:
+            if workspace_id:
+                name = _translate_to_zri(workspace_id, name)
             client.update_secret(name, value)
     # explicit rethrows of known errors
     except _exceptions.InvalidTokenError as e:
@@ -129,6 +152,7 @@ def set(
 def delete(
     name: str,
     *,
+    workspace_id: t.Optional[str] = None,
     config_name: t.Optional[str] = None,
 ):
     """
@@ -136,7 +160,7 @@ def delete(
 
     Args:
         name: secret identifier.
-        value: new secret name.
+        workspace_id: ID of the workspace. Using platform-defined default if omitted
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.
@@ -153,7 +177,8 @@ def delete(
         client = _auth.authorized_client(config_name)
     except sdk_exc.ConfigNameNotFoundError:
         raise
-
+    if workspace_id:
+        name = _translate_to_zri(workspace_id, name)
     try:
         client.delete_secret(name)
     # explicit rethrows of known errors

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -15,7 +15,7 @@ def _translate_to_zri(workspace_id: str, secret_name: str) -> str:
     """
     Create ZRI from workspace_id and secret_name
     """
-    return f"zri:v1:unused:0:{workspace_id}:secret:{secret_name}"
+    return f"zri:v1::0:{workspace_id}:secret:{secret_name}"
 
 
 def get(
@@ -29,7 +29,8 @@ def get(
 
     Args:
         name: secret identifier.
-        workspace_id: ID of the workspace. Using platform-defined default if omitted
+        workspace_id: ID of the workspace. Using platform-defined default if omitted -
+            - currently it is personal workspace
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.
@@ -78,7 +79,8 @@ def list(
     Lists all secret names.
 
     Args:
-        workspace_id: ID of the workspace. Using platform-defined default if omitted
+        workspace_id: ID of the workspace. Using platform-defined default if omitted -
+            - currently it is personal workspace
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.
@@ -117,7 +119,7 @@ def set(
         name: secret identifier.
         value: new secret name.
         workspace_id: workspace in which secret will be created. Using platform-defined
-            default if omitted
+            default if omitted - currently it is personal workspace
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.
@@ -160,7 +162,8 @@ def delete(
 
     Args:
         name: secret identifier.
-        workspace_id: ID of the workspace. Using platform-defined default if omitted
+        workspace_id: ID of the workspace. Using platform-defined default if omitted -
+            - currently it is personal workspace
         config_name: config entry to use to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when
             ORQUESTRA_PASSPORT_FILE env variable is set.

--- a/src/orquestra/sdk/secrets/_models.py
+++ b/src/orquestra/sdk/secrets/_models.py
@@ -6,10 +6,14 @@ Models for accessing the Config Service API.
 
 API spec: https://github.com/zapatacomputing/config-service/tree/main/openapi/src
 """
+from typing import Optional
+
 import pydantic
 
 SecretName = str
 SecretValue = str
+ResourceGroup = str
+WorkspaceId = str
 
 
 class SecretNameObj(pydantic.BaseModel):
@@ -44,3 +48,13 @@ class SecretDefinition(pydantic.BaseModel):
 
     name: SecretName
     value: SecretValue
+    resourceGroup: Optional[ResourceGroup]
+
+
+class ListSecretsRequest(pydantic.BaseModel):
+    """
+    Model for
+    https://github.com/zapatacomputing/config-service/blob/fbfc4627450bc9a460278b242738e55210e7bf03/openapi/src/parameters/query/workspace.yaml
+    """
+
+    workspace: WorkspaceId

--- a/tests/sdk/v2/secrets/test_api.py
+++ b/tests/sdk/v2/secrets/test_api.py
@@ -117,7 +117,7 @@ class TestIntegrationWithClient:
             expected_secret_name = (
                 secret_name
                 if workspace_id is None
-                else f"zri:v1:unused:0:{workspace_id}:secret:{secret_name}"
+                else f"zri:v1::0:{workspace_id}:secret:{secret_name}"
             )
             secrets_client_mock.update_secret.assert_called_with(
                 expected_secret_name, secret_value
@@ -137,7 +137,7 @@ class TestIntegrationWithClient:
             expected_secret_name = (
                 secret_name
                 if workspace_id is None
-                else f"zri:v1:unused:0:{workspace_id}:secret:{secret_name}"
+                else f"zri:v1::0:{workspace_id}:secret:{secret_name}"
             )
 
             secrets_client_mock.delete_secret.assert_called_with(expected_secret_name)


### PR DESCRIPTION
# The problem

Secrets are workspace related. Users could not create/list/update anything in non-default workspace
https://zapatacomputing.atlassian.net/browse/ORQSDK-851

# This PR's solution

Add workspace_id to all secret-related API functions

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
