### PR TITLE
feat: Check tokens before saving in orq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+* `orq login` will perform some sanity checks before saving the token.
 
 🥷 *Internal*
 * Fix random CI failures on socket warning

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,8 @@ install_requires =
     pygments~=2.0
     # For automatic login
     aiohttp~=3.8
+    # Decoding JWTs
+    PyJWT~=2.6
 
 
 [options.entry_points]

--- a/src/orquestra/sdk/_base/_jwt.py
+++ b/src/orquestra/sdk/_base/_jwt.py
@@ -1,0 +1,28 @@
+################################################################################
+# © Copyright 2022-2023 Zapata Computing Inc.
+################################################################################
+import jwt
+
+from ..exceptions import ExpiredTokenError, InvalidTokenError
+
+
+def check_jwt_without_signature_verification(token: str):
+    """
+    Checks a token and ensures it is a JWT and it is not expired
+
+    Note: This DOES NOT CRYPTOGRAPHICALY VERIFY THE TOKEN.
+    Only used as a sanity check when reading a token from the CLI.
+
+    Raises:
+        ExpiredTokenError: if the current date is after the token's expiry
+        InvalidTokenError: if the token is not a JWT
+    """
+    try:
+        _ = jwt.decode(token, options={"verify_signature": False, "verify_exp": True})
+    except jwt.ExpiredSignatureError:
+        raise ExpiredTokenError(
+            "Auth token is expired. Try logging in again and verifying the date "
+            "on your computer is correct."
+        )
+    except jwt.DecodeError:
+        raise InvalidTokenError("Auth token is not a JWT. Try logging in again.")

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -21,6 +21,7 @@ from orquestra import sdk
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _config, _db, loader
 from orquestra.sdk._base._driver._client import DriverClient
+from orquestra.sdk._base._jwt import check_jwt_without_signature_verification
 from orquestra.sdk._base._qe import _client
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base.abc import ArtifactValue
@@ -494,6 +495,15 @@ class ConfigRepo:
         ]
 
     def store_token_in_config(self, uri, token, ce):
+        """
+        Saves the token in the config file
+
+        Raises:
+            ExpiredTokenError: if the token is expired
+            InvalidTokenError: if the token is not a valid format
+        """
+        check_jwt_without_signature_verification(token)
+
         runtime_name = RuntimeName.CE_REMOTE if ce else RuntimeName.QE_REMOTE
         config_name = _config.generate_config_name(runtime_name, uri)
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -142,3 +142,15 @@ def _(e: exceptions.NoOptionsAvailableError) -> ResponseStatusCode:
 def _(e: exceptions.LocalConfigLoginError) -> ResponseStatusCode:
     click.echo(e.message)
     return ResponseStatusCode.INVALID_CLI_COMMAND_ERROR
+
+
+@pretty_print_exception.register
+def _(e: exceptions.InvalidTokenError) -> ResponseStatusCode:
+    click.echo("The auth token is not valid.\n" "Please try logging in again.")
+    return ResponseStatusCode.UNAUTHORIZED
+
+
+@pretty_print_exception.register
+def _(e: exceptions.ExpiredTokenError) -> ResponseStatusCode:
+    click.echo("The auth token has expired.\n" "Please try logging in again.")
+    return ResponseStatusCode.UNAUTHORIZED

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -225,6 +225,18 @@ class UnauthorizedError(BaseRuntimeError):
     pass
 
 
+class ExpiredTokenError(BaseRuntimeError):
+    """Raised when the auth token is expired"""
+
+    pass
+
+
+class InvalidTokenError(BaseRuntimeError):
+    """Raised when an auth token is not a JWT"""
+
+    pass
+
+
 # Ray Errors
 class RayActorNameClashError(BaseRuntimeError):
     """Raised when multiple Ray actors exist with the same name."""

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1172,6 +1172,11 @@ class TestSummaryRepo:
 
 
 class TestConfigRepo:
+    @pytest.fixture(autouse=True)
+    def patch_token_checking(self, monkeypatch: pytest.MonkeyPatch):
+        check = create_autospec(_repos.check_jwt_without_signature_verification)
+        monkeypatch.setattr(_repos, "check_jwt_without_signature_verification", check)
+
     class TestUnit:
         """
         Test boundary::

--- a/tests/cli/dorq/ui/test_errors.py
+++ b/tests/cli/dorq/ui/test_errors.py
@@ -88,6 +88,8 @@ class TestPrettyPrintException:
                 'The "in_process" runtime is designed for debugging and testing via the'
                 " Python API only",
             ),
+            (exceptions.InvalidTokenError, "The auth token is not valid"),
+            (exceptions.ExpiredTokenError, "The auth token has expired"),
         ],
     )
     def tests_prints_exception_without_traceback(capsys, exc, stdout_marker: str):

--- a/tests/sdk/v2/test_jwt.py
+++ b/tests/sdk/v2/test_jwt.py
@@ -1,0 +1,41 @@
+################################################################################
+# © Copyright 2022-2023 Zapata Computing Inc.
+################################################################################
+from unittest.mock import create_autospec
+
+import jwt
+import pytest
+
+from orquestra.sdk import exceptions
+from orquestra.sdk._base import _jwt
+
+
+class TestCheckJWTWithoutSignatureValidation:
+    @pytest.fixture
+    def token(self):
+        return "mocked_token"
+
+    @pytest.fixture
+    def mock_jwt_decode(self, monkeypatch: pytest.MonkeyPatch):
+        decode = create_autospec(jwt.decode)
+        monkeypatch.setattr(jwt, "decode", decode)
+        return decode
+
+    def test_ok_token(self, token, mock_jwt_decode):
+        # When
+        _jwt.check_jwt_without_signature_verification(token)
+        # Then Expect no exception
+
+    def test_invalid_token(self, token, mock_jwt_decode):
+        # Given
+        mock_jwt_decode.side_effect = jwt.DecodeError
+        # When
+        with pytest.raises(exceptions.InvalidTokenError):
+            _jwt.check_jwt_without_signature_verification(token)
+
+    def test_expired_token(self, token, mock_jwt_decode):
+        # Given
+        mock_jwt_decode.side_effect = jwt.ExpiredSignatureError
+        # When
+        with pytest.raises(exceptions.ExpiredTokenError):
+            _jwt.check_jwt_without_signature_verification(token)


### PR DESCRIPTION
# The problem

Sometime folks were pasting in the wrong thing as a token and weren't notified until after they attempt to use the API

# This PR's solution

Adds a *non-cryptographic* check of the token.

After checking:
* the token is a JWT
* it is not expired

What this explicitly does not check:
* RSA signature
* Claims

This is OK because the server does the final auth check, we're just doing a sanity check that the JWT is of the right shape. If folks still have issues, we can fetch the public key and do the signature check

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
