### PR TITLE
internal: Add a makefile for building the sdk images, tweak for building on M1

### DIFF
--- a/.github/workflows/publish-cuda-docker-image.yml
+++ b/.github/workflows/publish-cuda-docker-image.yml
@@ -24,13 +24,14 @@ jobs:
     steps:
       - name: Trigger cicd-actions repository workflow over Github API
         run: |
+          eventType="$repository | $ref"
           curl \
           "https://api.github.com/repos/zapatacomputing/cicd-actions/dispatches" \
           -H "Authorization: token "$USER_TOKEN \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           --data-raw '
           {
-            "event_type":  "'"$repository"' | '"$ref"'", 
+            "event_type":  "'"${eventType:0:100}"'",
             "client_payload": 
                 {
                   "repository": "'"$repository"'", 

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -22,13 +22,14 @@ jobs:
     steps:
       - name: Trigger cicd-actions repository workflow over Github API
         run: |
+          eventType="$repository | $ref"
           curl \
           "https://api.github.com/repos/zapatacomputing/cicd-actions/dispatches" \
           -H "Authorization: token "$USER_TOKEN \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           --data-raw '
           {
-            "event_type":  "'"$repository"' | '"$ref"'", 
+            "event_type":  "'"${eventType:0:100}"'",
             "client_payload": 
                 {
                   "repository": "'"$repository"'", 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,10 +4,21 @@
 FROM python:3.9-slim-bullseye
 ARG SDK_REQUIREMENT
 
+# Set by BuildKit
+ARG TARGETARCH
+
+# If statement installs any additional dependencies needed for building for ARM
+# (development using an M1 is fun :') )
 RUN <<EOF
+set -ex
 apt update --yes
 apt upgrade --yes
 apt install --yes --no-install-recommends git openssh-client
+
+if [ "$TARGETARCH" = "arm64" ]; then
+  apt install --yes --no-install-recommends gcc libc-dev
+fi
+
 python -m pip install -U pip wheel
 python -m pip install "${SDK_REQUIREMENT}"
 EOF

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,24 @@
+IMAGE_NAME ?= hub.stage.nexus.orquestra.io/zapatacomputing/orquestra-sdk-base
+IMAGE_TAG ?= dev
+
+SDK_REQUIREMENT ?= "git+https://github.com/zapatacomputing/orquestra-workflow-sdk.git@main"
+
+#####################
+# Build the sdk base image
+#####################
+build-base:
+	@echo "Building base image with SDK version $(SDK_REQUIREMENT)"
+	DOCKER_BUILDKIT=1 docker build -t $(IMAGE_NAME):$(IMAGE_TAG) -f Dockerfile . \
+		--build-arg SDK_REQUIREMENT=$(SDK_REQUIREMENT)
+
+#####################
+# Build the sdk cuda image
+#####################
+# Notes:
+# - This must be built for --platform=linux/amd64
+#####################
+build-cuda:
+	@echo "Building cuda image with SDK version $(SDK_REQUIREMENT)"
+	docker build -t $(IMAGE_NAME):$(IMAGE_TAG)-cuda -f cuda.Dockerfile . \
+		--build-arg SDK_REQUIREMENT=$(SDK_REQUIREMENT) \
+		--platform linux/amd64


### PR DESCRIPTION
# The problem

Studio development requires building images locally, which is _much_ faster if it's an ARM-native image. Also, Makefiles remove the need to remember `docker build` commands.

Thirdly, workflow dispatches have a limit of 100 chars on the `event_type` field 🥲 

# This PR's solution

Added a Makefile, and installed a few more dependencies in the image build, conditional on the `TARGETARCH` [automatic `ARG`](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope). Tweaked the `event_type` field in the CICD-actions dispatches.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
