### PR TITLE
Internal: Fix random failures due to the warning of socket not being closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 💅 *Improvements*
 
 🥷 *Internal*
+* Fix random CI failures on socket warning
 
 📃 *Docs*
 

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -194,6 +194,23 @@ def add_with_trigger(a, b, port, timeout: float):
     return a + b
 
 
+@sdk.task
+def infinite_task(*_):
+    import time
+
+    while True:
+        time.sleep(10)
+
+
+@sdk.workflow
+def infinite_workflow():
+    """
+    Allows reproducing scenario where tasks take some time to run.
+    This workflow is used to test termination as it will never complete
+    """
+    return infinite_task()
+
+
 @sdk.workflow
 def serial_wf_with_file_triggers(ports: Sequence[int], task_timeout: float):
     """

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -195,11 +195,11 @@ def add_with_trigger(a, b, port, timeout: float):
 
 
 @sdk.task
-def infinite_task(*_):
+def long_task(*_):
     import time
 
-    while True:
-        time.sleep(10)
+    # sleep for an hour - just in case someone forgets to terminate this buddy
+    time.sleep(60 * 60)
 
 
 @sdk.workflow
@@ -207,8 +207,10 @@ def infinite_workflow():
     """
     Allows reproducing scenario where tasks take some time to run.
     This workflow is used to test termination as it will never complete
+    This workflow isn't actually infinite - it just takes an hour of sleep time to
+    complete
     """
-    return infinite_task()
+    return long_task()
 
 
 @sdk.workflow

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1515,6 +1515,7 @@ class TestWorkflowDefRepoIntegration:
                 "wf_using_inline_imports",
                 "wf_using_git_imports",
                 "serial_wf_with_slow_middle_task",
+                "infinite_workflow",
                 "serial_wf_with_file_triggers",
                 "exception_wf_with_multiple_values",
                 "wf_with_log",

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -271,16 +271,9 @@ class TestRayRuntimeMethods:
                │
                │
                ▼
-              [ ]  => waiting
-               │
-               │
-               ▼
             """
-            triggers = [_ipc.TriggerServer() for _ in range(2)]
 
-            wf = _example_wfs.serial_wf_with_file_triggers(
-                [trigger.port for trigger in triggers], task_timeout=2.0
-            ).model
+            wf = _example_wfs.infinite_workflow().model
 
             wf_run_id = runtime.create_workflow_run(wf, None)
             wf_run = runtime.get_workflow_run_status(wf_run_id)


### PR DESCRIPTION
# The problem

Due to the workflow termination during socket usage, sometimes ray cleaned up stuff async, causing random failures due to the warning of socket not being closed properly

# This PR's solution

limit usage of sockets when they are not needed

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
