### PR TITLE
feat: give more informative error message when ray cluster isn't running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Setting workflow_id and project_id is now available using "orq wf submit" command
 * `sdk.current_run_ids()` can now be used within task code to access the workflow run ID, task invocation ID, and task run ID.
 * All CLI commands that prompted for `wf_run_id` will now first prompt for workspace and project if `wf_run_id` is not provided.
+* The error raised when trying to submit to ray while ray is not running now tells the user how to start ray.
 
 👩‍🔬 *Experimental*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * Setting workflow_id and project_id is now available using "orq wf submit" command
 * `sdk.current_run_ids()` can now be used within task code to access the workflow run ID, task invocation ID, and task run ID.
 * All CLI commands that prompted for `wf_run_id` will now first prompt for workspace and project if `wf_run_id` is not provided.
-* The error raised when trying to submit to ray while ray is not running now tells the user how to start ray.
+* The error raised when trying to submit to Ray while Ray is not running now tells the user how to start Ray.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -89,7 +89,11 @@ def _(e: exceptions.WorkflowRunNotFinished) -> ResponseStatusCode:
 
 @pretty_print_exception.register
 def _(e: exceptions.RayNotRunningError) -> ResponseStatusCode:
-    click.echo(f"{e}")
+    click.echo(
+        "Could not find any running Ray instance. "
+        "You can use 'orq status' to check the status of the ray service. "
+        "If it is not running, it can be started with the `orq up` command."
+    )
     return ResponseStatusCode.CONNECTION_ERROR
 
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -88,6 +88,12 @@ def _(e: exceptions.WorkflowRunNotFinished) -> ResponseStatusCode:
 
 
 @pretty_print_exception.register
+def _(e: exceptions.RayNotRunningError) -> ResponseStatusCode:
+    click.echo(f"{e}")
+    return ResponseStatusCode.CONNECTION_ERROR
+
+
+@pretty_print_exception.register
 def _(e: ConnectionError) -> ResponseStatusCode:
     _print_traceback(e)
     click.echo(f"{e}")

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -243,10 +243,13 @@ class RayRuntime(RuntimeInterface):
         try:
             client.init(**dataclasses.asdict(ray_params))
         except ConnectionError as e:
-            raise exceptions.RayNotRunningError(
-                "Could not find any running Ray instance. "
-                "You may need to run \n    orq up\n to start one."
-            ) from e
+            if "Could not find any running Ray instance" in str(e):
+                raise exceptions.RayNotRunningError(
+                    "Could not find any running Ray instance. "
+                    "You can use 'orq status' to check the status of the ray service. "
+                    "If it is not running, it can be started with the `orq up` command."
+                ) from e
+            raise e
 
         try:
             client.workflow_init()

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -25,7 +25,7 @@ from .._base import _services, serde
 from .._base._db import WorkflowDB
 from .._base._env import RAY_GLOBAL_WF_RUN_ID_ENV
 from .._base._spaces._structs import ProjectRef
-from .._base.abc import ArtifactValue, LogReader, RuntimeInterface
+from .._base.abc import LogReader, RuntimeInterface
 from ..schema import ir
 from ..schema.configs import RuntimeConfiguration
 from ..schema.local_database import StoredWorkflowRun
@@ -240,7 +240,13 @@ class RayRuntime(RuntimeInterface):
         logger.setLevel(logging.ERROR)
 
         client = RayClient()
-        client.init(**dataclasses.asdict(ray_params))
+        try:
+            client.init(**dataclasses.asdict(ray_params))
+        except ConnectionError as e:
+            raise exceptions.RayNotRunningError(
+                "Could not find any running Ray instance. "
+                "You may need to run \n    orq up\n to start one."
+            ) from e
 
         try:
             client.workflow_init()

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -245,11 +245,7 @@ class RayRuntime(RuntimeInterface):
         try:
             client.init(**dataclasses.asdict(ray_params))
         except ConnectionError as e:
-            raise exceptions.RayNotRunningError(
-                "Could not find any running Ray instance. "
-                "You can use 'orq status' to check the status of the ray service. "
-                "If it is not running, it can be started with the `orq up` command."
-            ) from e
+            raise exceptions.RayNotRunningError from e
 
         try:
             client.workflow_init()

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -245,13 +245,11 @@ class RayRuntime(RuntimeInterface):
         try:
             client.init(**dataclasses.asdict(ray_params))
         except ConnectionError as e:
-            if "Could not find any running Ray instance" in str(e):
-                raise exceptions.RayNotRunningError(
-                    "Could not find any running Ray instance. "
-                    "You can use 'orq status' to check the status of the ray service. "
-                    "If it is not running, it can be started with the `orq up` command."
-                ) from e
-            raise e
+            raise exceptions.RayNotRunningError(
+                "Could not find any running Ray instance. "
+                "You can use 'orq status' to check the status of the ray service. "
+                "If it is not running, it can be started with the `orq up` command."
+            ) from e
 
         try:
             client.workflow_init()

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -218,6 +218,12 @@ class RayActorNameClashError(BaseRuntimeError):
     pass
 
 
+class RayNotRunningError(ConnectionError):
+    """Raised when there isn't a running ray instance."""
+
+    pass
+
+
 # CLI Exceptions
 class UserCancelledPrompt(BaseRuntimeError):
     """Raised when the user cancels a CLI prompt."""

--- a/tests/cli/dorq/ui/test_errors.py
+++ b/tests/cli/dorq/ui/test_errors.py
@@ -90,6 +90,10 @@ class TestPrettyPrintException:
             ),
             (exceptions.InvalidTokenError, "The auth token is not valid"),
             (exceptions.ExpiredTokenError, "The auth token has expired"),
+            (
+                exceptions.RayNotRunningError(),
+                "Could not find any running Ray instance. You can use 'orq status' to check the status of the ray service. If it is not running, it can be started with the `orq up` command.",  # noqa: E501
+            ),
         ],
     )
     def tests_prints_exception_without_traceback(capsys, exc, stdout_marker: str):

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -363,7 +363,7 @@ class TestRayRuntime:
             runs = runtime.list_workflow_runs(limit=2)
             # Then
             assert len(runs) == 2
-            
+
         @staticmethod
         @pytest.mark.parametrize(
             "kwargs",

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -5,11 +5,9 @@
 Unit tests for orquestra.sdk._ray._dag. If you need a test against a live
 Ray connection, see tests/ray/test_integration.py instead.
 """
-import copy
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Dict, Union
-from unittest.mock import ANY, Mock, PropertyMock, call, create_autospec
+from unittest.mock import Mock, PropertyMock, create_autospec
 
 import pytest
 
@@ -17,10 +15,6 @@ from orquestra.sdk import exceptions
 from orquestra.sdk._base._config import RuntimeConfiguration, RuntimeName
 from orquestra.sdk._base._db import WorkflowDB
 from orquestra.sdk._base._spaces._structs import ProjectRef
-from orquestra.sdk._base._testing._example_wfs import (
-    wf_with_secrets,
-    workflow_parametrised_with_resources,
-)
 from orquestra.sdk._ray import _client, _dag, _ray_logs
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
 from orquestra.sdk.schema.workflow_run import State
@@ -369,3 +363,35 @@ class TestRayRuntime:
             runs = runtime.list_workflow_runs(limit=2)
             # Then
             assert len(runs) == 2
+
+    class TestStartup:
+        @staticmethod
+        # Ray mishandles log file handlers and we get "_io.FileIO [closed]"
+        # unraisable exceptions. Last tested with Ray 2.3.0.
+        @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+        def test_raises_RayNotRunningError_when_ray_not_running(
+            monkeypatch, runtime_config, tmp_path
+        ):
+            # GIVEN
+            monkeypatch.setattr(
+                _client.RayClient,
+                "init",
+                Mock(
+                    side_effect=ConnectionError(
+                        "Could not find any running Ray instance"
+                    )
+                ),
+            )
+            ray_params = _dag.RayParams()
+
+            # WHEN
+            with pytest.raises(exceptions.RayNotRunningError) as e:
+                _dag.RayRuntime.startup(ray_params=ray_params)
+
+            # THEN
+            assert e.exconly() == (
+                "orquestra.sdk.exceptions.RayNotRunningError: Could not find any "
+                "running Ray instance. You can use 'orq status' to check the status of "
+                "the ray service. If it is not running, it can be started with the `orq"
+                " up` command."
+            )

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -411,13 +411,6 @@ class TestRayRuntime:
             ray_params = _dag.RayParams()
 
             # WHEN
-            with pytest.raises(exceptions.RayNotRunningError) as e:
-                _dag.RayRuntime.startup(ray_params=ray_params)
-
             # THEN
-            assert e.exconly() == (
-                "orquestra.sdk.exceptions.RayNotRunningError: Could not find any "
-                "running Ray instance. You can use 'orq status' to check the status of "
-                "the ray service. If it is not running, it can be started with the `orq"
-                " up` command."
-            )
+            with pytest.raises(exceptions.RayNotRunningError):
+                _dag.RayRuntime.startup(ray_params=ray_params)


### PR DESCRIPTION
# The problem

When user tries to use local “ray” config, and ray isnt running, the error message that pops up is coming from ray itself saying something along “ray cluster not running bla bla bla” 

We should catch that error and translate it to more informative message - to see if ray is running and if not, to start it with orq up command

# This PR's solution

Adds `RayNotStartedError` which is raised from the ConnectionError when the client tries to connect to ray and cannot find a running instance.

example:
```
> orq wf submit scratch.py -c ray
Could not find any running Ray instance. You can use 'orq status' to check the status of the ray service. If it is not running, it can be started with the `orq up` command.
```

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).

[ORQSDK-828](https://zapatacomputing.atlassian.net/browse/ORQSDK-828)

[ORQSDK-828]: https://zapatacomputing.atlassian.net/browse/ORQSDK-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ