### PR TITLE
fix: Tasks that set n_outputs=1 in QE and in-process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
+* Fixed tasks that failed when explicitly state `n_outputs=1` on QE and in-process.
 
 💅 *Improvements*
 * `orq login` will perform some sanity checks before saving the token.

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -177,7 +177,7 @@ class InProcessRuntime(abc.RuntimeInterface):
             # Finally, we need to dereference the output IDs
             for artifact_id in task_inv.output_ids:
                 artifact = workflow_def.artifact_nodes[artifact_id]
-                if artifact.artifact_index is None:
+                if artifact.artifact_index is None or not isinstance(fn_output, tuple):
                     self._artifact_store[run_id][artifact_id] = fn_output
                 else:
                     self._artifact_store[run_id][artifact_id] = fn_output[

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -314,3 +314,13 @@ def workflow_with_different_resources():
     gpu = add(1, 1).with_invocation_meta(gpu="1")
     all_resources = add(1, 1).with_invocation_meta(cpu="2000m", memory="2Gi", gpu="0")
     return cpu, small_cpu, memory, small_memory, gpu, all_resources
+
+
+@sdk.task(source_import=sdk.InlineImport(), n_outputs=1)
+def task_with_single_output_explicit():
+    return True
+
+
+@sdk.workflow
+def wf_with_explicit_n_outputs():
+    return task_with_single_output_explicit()

--- a/src/orquestra/sdk/_base/dispatch.py
+++ b/src/orquestra/sdk/_base/dispatch.py
@@ -278,7 +278,7 @@ def exec_task_fn(
     ]
 
     for ret_node in ret_nodes:
-        if ret_node.artifact_index is None:
+        if ret_node.artifact_index is None or not isinstance(ret_obj, tuple):
             ret_val = ret_obj
         else:
             ret_val = ret_obj[ret_node.artifact_index]

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1529,6 +1529,7 @@ class TestWorkflowDefRepoIntegration:
                 "wf_with_secrets",
                 "workflow_parametrised_with_resources",
                 "workflow_with_different_resources",
+                "wf_with_explicit_n_outputs",
             ]
 
         @staticmethod

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -568,6 +568,15 @@ class TestRayRuntimeMethods:
                 "invocation-3-task-capitalize-inline": JSONResult(value='"Zapata"'),
             },
         ),
+        (
+            _example_wfs.wf_with_explicit_n_outputs,
+            (JSONResult(value="true"),),
+            {
+                "invocation-0-task-task-with-single-output-explicit": JSONResult(
+                    value="true"
+                ),
+            },
+        ),
     ],
 )
 def test_run_and_get_output(

--- a/tests/sdk/v2/test_in_process_runtime.py
+++ b/tests/sdk/v2/test_in_process_runtime.py
@@ -18,7 +18,10 @@ from orquestra.sdk import exceptions
 from orquestra.sdk._base import serde
 from orquestra.sdk._base._in_process_runtime import InProcessRuntime
 from orquestra.sdk._base._spaces._structs import ProjectRef
-from orquestra.sdk._base._testing._example_wfs import wf_with_secrets
+from orquestra.sdk._base._testing._example_wfs import (
+    wf_with_explicit_n_outputs,
+    wf_with_secrets,
+)
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.workflow_run import State, WorkflowRunId
 from orquestra.sdk.secrets import _client, _models
@@ -78,6 +81,13 @@ def test_secret_inside_ir(
     result = runtime.get_workflow_run_outputs_non_blocking(run_id)
 
     assert result == (serde.result_from_artifact("Mocked", ir.ArtifactFormat.AUTO),)
+
+
+def test_explicit_n_outputs_single(runtime: InProcessRuntime):
+    run_id = runtime.create_workflow_run(wf_with_explicit_n_outputs().model, None)
+    result = runtime.get_workflow_run_outputs_non_blocking(run_id)
+
+    assert result == (serde.result_from_artifact(True, ir.ArtifactFormat.AUTO),)
 
 
 class TestQueriesAfterRunning:


### PR DESCRIPTION
# The problem

Some workflows were having issues when `n_outputs=1` was set in the task decorator.

# This PR's solution

* Only try to access a task's output by index if the output is a tuple (QE + in-process)
* Adds a test for RayRuntime

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
