### PR TITLE
impr: show subprocess error for `orq up`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 💅 *Improvements*
 * `orq login` will perform some sanity checks before saving the token.
+* If `orq up` fails, the output will now include the error message from the underlying subprocess.
 
 🥷 *Internal*
 * Fix random CI failures on socket warning

--- a/src/orquestra/sdk/_base/_services.py
+++ b/src/orquestra/sdk/_base/_services.py
@@ -80,9 +80,7 @@ class RayManager:
         Starts a Ray cluster. If a Ray is already running, this does nothing.
 
         Raises:
-            RuntimeError: if we ask Ray to start and it fails
-            subprocess.CalledProcessError: if calling the `ray` CLI failed. This
-                shouldn't happen in regular conditions.
+            subprocess.CalledProcessError: if calling the `ray` CLI failed.
         """
         ray_temp = ray_temp_path()
         ray_storage = ray_storage_path()
@@ -97,7 +95,7 @@ class RayManager:
         # 1. Attempt to start the Ray cluster. Ignore errors.
         # 2. Check if the cluster is running to confirm that either the cluster was
         #    started, or it had been already running prior to this command.
-        _ = subprocess.run(
+        proc = subprocess.run(
             [
                 "ray",
                 "start",
@@ -108,11 +106,11 @@ class RayManager:
             ],
             check=False,
             timeout=IPC_TIMEOUT,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
         )
         if not self.is_running():
-            raise RuntimeError("Couldn't start Ray cluster")
+            proc.check_returncode()
 
     def down(self):
         """

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -12,7 +12,7 @@ import webbrowser
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Iterator, List
+from typing import Iterable, Iterator, List, Sequence
 
 import click
 from tabulate import tabulate
@@ -154,7 +154,7 @@ class ArtifactPresenter:
 class ServicePresenter:
     @contextmanager
     def show_progress(
-        self, services: List[_services.Service], *, label: str
+        self, services: Sequence[_services.Service], *, label: str
     ) -> Iterator[Iterable[_services.Service]]:
         """
         Starts a progress bar on the context enter.
@@ -171,7 +171,7 @@ class ServicePresenter:
         ) as bar:
             yield bar
 
-    def show_services(self, services: List[responses.ServiceResponse]):
+    def show_services(self, services: Sequence[responses.ServiceResponse]):
         click.echo(
             tabulate(
                 [
@@ -188,6 +188,11 @@ class ServicePresenter:
                 tablefmt="plain",
             ),
         )
+
+    def show_failure(self, service_responses: Sequence[responses.ServiceResponse]):
+        self.show_services(service_responses)
+
+        sys.exit(responses.ResponseStatusCode.SERVICES_ERROR.value)
 
 
 class LoginPresenter:

--- a/tests/cli/dorq/services/test_up.py
+++ b/tests/cli/dorq/services/test_up.py
@@ -1,0 +1,116 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Unit tests for ``orq services up`` CLI action.
+"""
+import inspect
+import subprocess
+from contextlib import contextmanager
+from unittest.mock import Mock, create_autospec
+
+import pytest
+
+from orquestra.sdk._base import _services
+from orquestra.sdk._base.cli._dorq import _arg_resolvers
+from orquestra.sdk._base.cli._dorq._services import _up
+from orquestra.sdk._base.cli._dorq._ui import _presenters
+from orquestra.sdk.schema.responses import ServiceResponse
+
+
+class TestAction:
+    """
+    Test boundary::
+
+        [_up.Action]->[Prompter]
+    """
+
+    class TestPassingAllValues:
+        @staticmethod
+        @pytest.fixture
+        def service():
+            service = create_autospec(_services.Service)
+            service.name = "testing"
+
+            return service
+
+        @staticmethod
+        @pytest.fixture
+        def action(service):
+            service_resolver = create_autospec(_arg_resolvers.ServiceResolver)
+            service_resolver.resolve.return_value = [service]
+
+            @contextmanager
+            def progress_ctx(self, label):
+                yield [service]
+
+            presenter = create_autospec(_presenters.ServicePresenter)
+            presenter.show_progress = progress_ctx
+
+            action = _up.Action(
+                presenter=presenter,
+                service_resolver=service_resolver,
+            )
+
+            return action
+
+        @staticmethod
+        def test_success(service: _services.Service, action):
+            # When
+            action.on_cmd_call(manage_ray=None, manage_all=None)
+
+            # Then
+            action._presenter.show_services.assert_called_with(
+                services=[
+                    ServiceResponse(name=service.name, is_running=True, info="Started!")
+                ]
+            )
+
+        @staticmethod
+        def test_failure(service, action: _up.Action):
+            # Given
+            service.up.side_effect = subprocess.CalledProcessError(
+                returncode=1,
+                cmd=[
+                    "ray",
+                    "start",
+                    "--head",
+                    "--temp-dir=.",
+                    "--storage=.",
+                    "--plasma-directory=.",
+                ],
+                output=(
+                    "Usage stats collection is disabled.\nLocal node IP: 127.0.0.1"
+                ).encode(),
+                stderr=inspect.cleandoc(
+                    """
+                        File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
+                        pyarrow.lib.ArrowInvalid: URI has empty scheme: '.'
+                    """
+                ).encode(),
+            )
+
+            # When
+            action.on_cmd_call(manage_ray=None, manage_all=None)
+
+            # Then
+            action._presenter.show_failure.assert_called_with(
+                [
+                    ServiceResponse(
+                        name=service.name,
+                        is_running=False,
+                        info=inspect.cleandoc(
+                            """
+                               command:
+                               ['ray', 'start', '--head', '--temp-dir=.', '--storage=.', '--plasma-directory=.']
+                               stdout:
+                               Usage stats collection is disabled.
+                               Local node IP: 127.0.0.1
+                               stderr:
+                               File "pyarrow/error.pxi", line 100, in pyarrow.lib.check_status
+                               pyarrow.lib.ArrowInvalid: URI has empty scheme: '.'
+                           """  # noqa: E501
+                        ),
+                    )
+                ]
+            )

--- a/tests/cli/dorq/ui/test_presenters.py
+++ b/tests/cli/dorq/ui/test_presenters.py
@@ -16,7 +16,7 @@ from orquestra.sdk._base.cli._dorq._ui import _models as ui_models
 from orquestra.sdk._base.cli._dorq._ui import _presenters
 from orquestra.sdk._base.cli._dorq._ui._corq_format import per_command
 from orquestra.sdk.schema.ir import ArtifactFormat
-from orquestra.sdk.schema.responses import ServiceResponse
+from orquestra.sdk.schema.responses import ResponseStatusCode, ServiceResponse
 from orquestra.sdk.schema.workflow_run import RunStatus, State
 
 
@@ -28,6 +28,13 @@ def add(a, b):
 @sdk.workflow
 def my_wf():
     return add(1, 2)
+
+
+@pytest.fixture
+def sys_exit_mock(monkeypatch):
+    exit_mock = Mock()
+    monkeypatch.setattr(sys, "exit", exit_mock)
+    return exit_mock
 
 
 class TestWrappedCorqOutputPresenter:
@@ -107,16 +114,13 @@ class TestWrappedCorqOutputPresenter:
             assert f"Workflow logs saved at {dummy_path}" in captured.out
 
     @staticmethod
-    def test_handling_error(monkeypatch):
+    def test_handling_error(monkeypatch, sys_exit_mock):
         # Given
         status_int = 42
         status_code_enum = Mock()
         status_code_enum.value = status_int
         pretty_print_mock = Mock(return_value=status_code_enum)
         monkeypatch.setattr(_errors, "pretty_print_exception", pretty_print_mock)
-
-        exit_mock = Mock()
-        monkeypatch.setattr(sys, "exit", exit_mock)
 
         exception: t.Any = "<exception object sentinel>"
 
@@ -130,7 +134,7 @@ class TestWrappedCorqOutputPresenter:
         pretty_print_mock.assert_called_with(exception)
 
         # We expect status code was passed to sys.exit()
-        exit_mock.assert_called_with(status_int)
+        sys_exit_mock.assert_called_with(status_int)
 
 
 class TestArtifactPresenter:
@@ -242,7 +246,7 @@ class TestArtifactPresenter:
         ) == captured.out
 
 
-class TestServicesPresneter:
+class TestServicesPresenter:
     class TestShowServices:
         def test_running(self, capsys):
             # Given
@@ -275,6 +279,27 @@ class TestServicesPresneter:
             # Then
             captured = capsys.readouterr()
             assert "mocked  Not Running  something" in captured.out
+
+    @staticmethod
+    def test_show_failure(capsys, sys_exit_mock):
+        # Given
+        presenter = _presenters.ServicePresenter()
+        services = [
+            ServiceResponse(
+                name="background service", is_running=False, info="something"
+            )
+        ]
+
+        # When
+        presenter.show_failure(services)
+
+        # Then
+        captured = capsys.readouterr()
+        assert services[0].name in captured.out
+        assert services[0].info in captured.out
+        assert captured.err == ""
+
+        sys_exit_mock.assert_called_with(ResponseStatusCode.SERVICES_ERROR.value)
 
 
 class TestLoginPresenter:

--- a/tests/runtime/test_services_integration.py
+++ b/tests/runtime/test_services_integration.py
@@ -30,7 +30,7 @@ class TestRayCLI:
     def test_failure(monkeypatch: pytest.MonkeyPatch):
         # Given
         with ray_suitable_temp_dir() as tmp_path:
-            tmp_path.mkdir()
+            tmp_path.mkdir(exist_ok=True)
             monkeypatch.chdir(tmp_path)
             # As of Ray 2.3.1 setting paths to "." is a reliable way to make 'ray start'
             # fail.
@@ -40,12 +40,10 @@ class TestRayCLI:
 
             ray = RayManager()
 
-            # TODO: use a better exception type
             with pytest.raises(subprocess.CalledProcessError) as exc_info:
                 # When
                 ray.up()
 
             # Then
-            # TODO: use a better assertion heuristic
-            assert exc_info.value.stdout != ""
-            assert exc_info.value.stderr != ""
+            assert b"Local node IP" in exc_info.value.stdout
+            assert b"URI has empty scheme" in exc_info.value.stderr


### PR DESCRIPTION
# The problem

Sometimes, `orq up` fails because of a problem with Ray. Previously, we only told the user that starting Ray failed, but it didn't provide any insight into fixing the issue.

# This PR's solution

* Captures the subprocess stdout and stderr, and presents it to the user.
* Adds missing unit tests for `orq up` action.
* Adds integration test for `[RayManager service]-[Ray cluster]` when `ray start` fails.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
