### PR TITLE
chore: Add QE CLI flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 🔥 *Features*
 * Add .project property to WorkflowRun to get the info about workspace and project of running workflow
+* Add `--qe` flag to `orq login`, this is the default so there is no change in behavior.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -12,6 +12,8 @@ from pathlib import Path
 import click
 import cloup
 
+from orquestra.sdk.schema.configs import RemoteRuntime, RuntimeName
+
 from . import _cli_logs
 
 # Adds '-h' alias for '--help'
@@ -405,20 +407,28 @@ server_config_group = cloup.OptionGroup(
     help="User Token to given server. To generate token, use this command without -t"
     "option first",
 )
-@cloup.option(
-    "--ce",
-    is_flag=True,
-    default=False,
-    help="Log in to Compute Engine. If not passed, will log in to Quantum Engine",
+@cloup.option_group(
+    "Remote Environment",
+    cloup.option(
+        "--qe", is_flag=True, default=False, help="Log in to Quantum Engine. (Default)"
+    ),
+    cloup.option("--ce", is_flag=True, default=False, help="Log in to Compute Engine."),
+    constraint=cloup.constraints.mutually_exclusive,
 )
-def login(config: str, server: str, token: t.Optional[str], ce: bool):
+def login(config: str, server: str, token: t.Optional[str], ce: bool, qe: bool):
     """
     Login in to remote cluster
     """
     from ._login._login import Action
 
+    runtime_name: RemoteRuntime
+    if ce:
+        runtime_name = RuntimeName.CE_REMOTE
+    else:
+        runtime_name = RuntimeName.QE_REMOTE
+
     action = Action()
-    action.on_cmd_call(config, server, token, ce)
+    action.on_cmd_call(config, server, token, runtime_name)
 
 
 def main():

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -10,12 +10,12 @@ import datetime
 import importlib
 import os
 import sys
-import typing
 import typing as t
 import warnings
 from contextlib import contextmanager
 
 import requests
+from typing_extensions import assert_never
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
@@ -26,7 +26,12 @@ from orquestra.sdk._base._qe import _client
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base.abc import ArtifactValue
 from orquestra.sdk.schema import _compat
-from orquestra.sdk.schema.configs import ConfigName, RuntimeConfiguration, RuntimeName
+from orquestra.sdk.schema.configs import (
+    ConfigName,
+    RemoteRuntime,
+    RuntimeConfiguration,
+    RuntimeName,
+)
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
 from orquestra.sdk.schema.workflow_run import (
     ProjectId,
@@ -505,7 +510,7 @@ class ConfigRepo:
             if config not in _config.CLI_IGNORED_CONFIGS
         ]
 
-    def store_token_in_config(self, uri, token, ce):
+    def store_token_in_config(self, uri: str, token: str, runtime_name: RemoteRuntime):
         """
         Saves the token in the config file
 
@@ -515,7 +520,6 @@ class ConfigRepo:
         """
         check_jwt_without_signature_verification(token)
 
-        runtime_name = RuntimeName.CE_REMOTE if ce else RuntimeName.QE_REMOTE
         config_name = _config.generate_config_name(runtime_name, uri)
 
         config = sdk.RuntimeConfig(
@@ -556,13 +560,19 @@ class RuntimeRepo:
     Wraps access to QE/CE clients
     """
 
-    def get_login_url(self, uri: str, ce: bool, redirect_port: int):
-        client: typing.Union[DriverClient, _client.QEClient]
-        if ce:
+    def get_login_url(
+        self,
+        uri: str,
+        runtime_name: RemoteRuntime,
+        redirect_port: int,
+    ):
+        client: t.Union[DriverClient, _client.QEClient]
+        if runtime_name == RuntimeName.CE_REMOTE:
             client = DriverClient(base_uri=uri, session=requests.Session())
-        else:
+        elif runtime_name == RuntimeName.QE_REMOTE:
             client = _client.QEClient(session=requests.Session(), base_uri=uri)
-            # Ask QE for the login url to log in to the platform
+        else:
+            assert_never(runtime_name)
         try:
             target_url = client.get_login_url(redirect_port)
         except requests.RequestException as e:

--- a/src/orquestra/sdk/schema/configs.py
+++ b/src/orquestra/sdk/schema/configs.py
@@ -2,7 +2,7 @@
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
 from enum import Enum
-from typing import Any, Dict
+from typing import Any, Dict, Literal, Union
 
 from pydantic.main import BaseModel
 
@@ -16,6 +16,9 @@ class RuntimeName(str, Enum):
     CE_REMOTE = "CE_REMOTE"
     QE_REMOTE = "QE_REMOTE"
     IN_PROCESS = "IN_PROCESS"
+
+
+RemoteRuntime = Union[Literal[RuntimeName.CE_REMOTE], Literal[RuntimeName.QE_REMOTE]]
 
 
 class RuntimeConfiguration(BaseModel):

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1200,8 +1200,10 @@ class TestConfigRepo:
             # Then
             assert names == configs
 
-        @pytest.mark.parametrize("ce", [True, False])
-        def test_store_token(self, monkeypatch, ce):
+        @pytest.mark.parametrize(
+            "runtime_name", [RuntimeName.CE_REMOTE, RuntimeName.QE_REMOTE]
+        )
+        def test_store_token(self, monkeypatch, runtime_name):
             repo = _repos.ConfigRepo()
             uri = "funny_uri"
             token = "even_funnier_token"
@@ -1219,7 +1221,7 @@ class TestConfigRepo:
             )
 
             # When
-            config_name = repo.store_token_in_config(uri, token, ce)
+            config_name = repo.store_token_in_config(uri, token, runtime_name)
 
             # Then
             (
@@ -1229,11 +1231,7 @@ class TestConfigRepo:
             ) = mock_save_or_update.call_args[0]
 
             assert config_parameter == generated_name
-            assert (
-                runtime_parameter == RuntimeName.CE_REMOTE
-                if ce
-                else RuntimeName.QE_REMOTE
-            )
+            assert runtime_parameter == runtime_name
             assert options_parameter["uri"] == uri
             assert options_parameter["token"] == token
             assert config_name == generated_name
@@ -1286,7 +1284,7 @@ class TestConfigRepo:
 
         @staticmethod
         @pytest.mark.parametrize(
-            "ce, runtime_name", [(True, "CE_REMOTE"), (False, "QE_REMOTE")]
+            "runtime_name", [RuntimeName.CE_REMOTE, RuntimeName.QE_REMOTE]
         )
         @pytest.mark.parametrize(
             "uri, token, config_name",
@@ -1306,7 +1304,6 @@ class TestConfigRepo:
             uri,
             token,
             config_name,
-            ce,
             runtime_name,
         ):
             """
@@ -1328,7 +1325,7 @@ class TestConfigRepo:
             )
 
             # When
-            repo.store_token_in_config(uri, token, ce)
+            repo.store_token_in_config(uri, token, runtime_name)
 
             # Then
             with open(config_path) as f:
@@ -1337,17 +1334,22 @@ class TestConfigRepo:
                 assert (
                     content["configs"][config_name]["runtime_options"]["token"] == token
                 )
-                assert content["configs"][config_name]["runtime_name"] == runtime_name
+                assert (
+                    content["configs"][config_name]["runtime_name"]
+                    == runtime_name.value
+                )
 
 
 class TestRuntimeRepo:
-    @pytest.mark.parametrize("ce", [True, False])
-    def test_return_valid_token(self, monkeypatch, ce):
+    @pytest.mark.parametrize(
+        "runtime_name", [RuntimeName.CE_REMOTE, RuntimeName.QE_REMOTE]
+    )
+    def test_return_valid_token(self, monkeypatch, runtime_name):
         # Given
         fake_login_url = "http://my_login.url"
 
         monkeypatch.setattr(
-            DriverClient if ce else QEClient,
+            DriverClient if runtime_name == RuntimeName.CE_REMOTE else QEClient,
             "get_login_url",
             lambda x, _: fake_login_url,
         )
@@ -1355,29 +1357,33 @@ class TestRuntimeRepo:
         repo = _repos.RuntimeRepo()
 
         # When
-        login_url = repo.get_login_url("uri", ce, 0)
+        login_url = repo.get_login_url("uri", runtime_name, 0)
 
         # Then
         assert login_url == fake_login_url
 
-    @pytest.mark.parametrize("ce", [True, False])
+    @pytest.mark.parametrize(
+        "runtime_name", [RuntimeName.CE_REMOTE, RuntimeName.QE_REMOTE]
+    )
     @pytest.mark.parametrize(
         "exception", [requests.ConnectionError, requests.exceptions.MissingSchema]
     )
-    def test_exceptions(self, monkeypatch, exception, ce):
+    def test_exceptions(self, monkeypatch, exception, runtime_name):
         # Given
         def _exception(_, __):
             raise exception
 
         monkeypatch.setattr(
-            DriverClient if ce else QEClient, "get_login_url", _exception
+            DriverClient if runtime_name == RuntimeName.CE_REMOTE else QEClient,
+            "get_login_url",
+            _exception,
         )
 
         repo = _repos.RuntimeRepo()
 
         # Then
         with pytest.raises(exceptions.LoginURLUnavailableError):
-            repo.get_login_url("uri", ce, 0)
+            repo.get_login_url("uri", runtime_name, 0)
 
 
 class TestResolveDottedName:


### PR DESCRIPTION
# The problem

We want to swap the defaults for logging in soon, however we don't have a QE flag.

# This PR's solution

* Add `--qe` option for logging in, mutually exclusive with `--ce`.
* Restructure CLI code to pass a `RuntimeName` instead of "is CE" bool.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
