### PR TITLE
Chore!: Removed `WorkflowDef.prepare()` and `WorkflowRun.start()` functions from public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 🚨 *Breaking Changes*
+* Removed `WorkflowDef.prepare()` and `WorkflowRun.start()` functions. Use `WorkflowDef.run()` instead
 
 🔥 *Features*
 * The API list_workflow_runs() function now accepts workspace and project arguments when used with CE configs.

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -313,7 +313,9 @@ class WorkflowRun:
             results = (
                 *(
                     serde.deserialize(o)
-                    for o in self._runtime.get_workflow_run_outputs_non_blocking(run_id)
+                    for o in self._runtime.get_workflow_run_outputs_non_blocking(
+                        self.run_id
+                    )
                 ),
             )
         except WorkflowRunNotSucceeded:

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -18,7 +18,6 @@ from ...exceptions import (
     WorkflowRunCanNotBeTerminated,
     WorkflowRunNotFinished,
     WorkflowRunNotFoundError,
-    WorkflowRunNotStarted,
     WorkflowRunNotSucceeded,
 )
 from ...schema import ir
@@ -29,7 +28,6 @@ from ...schema.workflow_run import WorkflowRun as WorkflowRunModel
 from ...schema.workflow_run import WorkflowRunId, WorkflowRunMinimal, WorkspaceId
 from .. import serde
 from .._spaces._resolver import resolve_studio_project_ref
-from .._spaces._structs import ProjectRef
 from ..abc import RuntimeInterface
 from ._config import RuntimeConfig, _resolve_config
 from ._task_run import TaskRun
@@ -210,9 +208,6 @@ class WorkflowRun:
             verbose: If ``True``, each iteration of the polling loop will print to
                 stderr.
 
-        Raises:
-            WorkflowRunNotStarted: when the workflow run has not started
-
         Returns:
             State: The state of the finished workflow.
         """
@@ -265,9 +260,6 @@ class WorkflowRun:
     def get_status(self) -> State:
         """
         Return the current status of the workflow.
-
-        Raises:
-            WorkflowRunNotStarted: when the workflow run has not started
         """
         return self.get_status_model().status.state
 

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -149,7 +149,6 @@ class WorkflowRun:
         wf_def: ir.WorkflowDef,
         runtime: RuntimeInterface,
         config: t.Optional["RuntimeConfig"] = None,
-        project: t.Optional[ProjectRef] = None,
     ):
         """
         Users aren't expected to use __init__() directly. Please use
@@ -167,7 +166,6 @@ class WorkflowRun:
         self._wf_def = wf_def
         self._runtime = runtime
         self._config = config
-        self._project = project
 
     def __str__(self) -> str:
         outstr: str = ""

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -169,8 +169,9 @@ class WorkflowDef(Generic[_R]):
         Schedules workflow for execution.
 
         Args:
-            config: SDK needs to know where to execute the workflow. This
-                objects contains the required details.
+            config: SDK needs to know where to execute the workflow. The config
+                contains the required details. This can be a RuntimeConfig object, or
+                the name of a saved configuration.
             project_dir: the path to the project directory. If omitted, the current
                 working directory is used.
             workspace_id: ID of the workspace for workflow - supported only on CE
@@ -180,6 +181,8 @@ class WorkflowDef(Generic[_R]):
             orquestra.sdk.exceptions.DirtyGitRepo: (warning) when a task def used by
                 this workflow def has a "GitImport" and the git repo that contains it
                 has uncommitted changes.
+            ProjectInvalidError: when only 1 out of project and workspace is passed
+
         """
         # This exists for users who have gotten used to doing `run()`. Once this has
         # been released, the following release should make config a required argument
@@ -188,7 +191,7 @@ class WorkflowDef(Generic[_R]):
             raise FutureWarning(
                 "Please specify the runtime configuration for this run. "
                 "The built in `local` and `in_process` configurations can be used by "
-                'calling `run.("local")` and `run("in_process")` respectively. '
+                'calling `run("local")` and `run("in_process")` respectively. '
                 "User defined configurations can be specified by providing the name "
                 "under which they are saved, or passing in the RuntimeConfig object "
                 "directly. "

--- a/tests/runtime/api/test_api_with_qe.py
+++ b/tests/runtime/api/test_api_with_qe.py
@@ -137,8 +137,7 @@ class TestStartWorkflowRun:
             body="workflow-id",
         )
 
-        run = my_workflow().prepare(remote_config)
-        run.start()
+        run = my_workflow().run(remote_config)
 
         assert run.run_id == "workflow-id"
 
@@ -154,10 +153,8 @@ class TestStartWorkflowRun:
         def BadNameWorkflow():
             return [simple_task()]
 
-        run = BadNameWorkflow().prepare(remote_config)
-
         with pytest.raises(exceptions.InvalidWorkflowDefinitionError) as exc_info:
-            run.start()
+            BadNameWorkflow().run(remote_config)
         assert f'Workflow name "{workflow_name}" is invalid' in str(exc_info)
 
 
@@ -209,8 +206,7 @@ class TestGetWorkflowRunStatus:
             json=qe_status_response,
         )
 
-        run = my_workflow().prepare(remote_config)
-        run.start()
+        run = my_workflow().run(remote_config)
 
         assert run.get_status() == State.SUCCEEDED
 

--- a/tests/runtime/api/test_api_with_ray.py
+++ b/tests/runtime/api/test_api_with_ray.py
@@ -48,30 +48,11 @@ class TestRunningLocalInBackground:
         ):
             monkeypatch.setattr(Path, "cwd", Mock(return_value=tmp_path))
 
-            run = wf_pass_tuple().prepare(sdk.RuntimeConfig.ray())
-            run.start()
+            run = wf_pass_tuple().run(sdk.RuntimeConfig.ray())
             run.wait_until_finished()
             results = run.get_results()
 
             assert results == 3
-
-        @staticmethod
-        def test_multiple_starts(
-            patch_config_location, ray, monkeypatch, tmp_path, mock_workflow_db_location
-        ):
-            monkeypatch.setattr(Path, "cwd", Mock(return_value=tmp_path))
-
-            run = wf_pass_tuple().prepare(sdk.RuntimeConfig.ray())
-
-            run.start()
-            run.wait_until_finished()
-            results1 = run.get_results()
-
-            run.start()
-            run.wait_until_finished()
-            results2 = run.get_results()
-
-            assert results1 == results2
 
     class TestShorthand:
         @staticmethod

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -841,13 +841,6 @@ class TestListWorkflows:
     ],
 )
 class TestProjectId:
-    def test_prepare(self, workspace_id, project_id, raises, expected):
-        with raises:
-            wf = wf_pass_tuple().prepare(
-                "in_process", workspace_id=workspace_id, project_id=project_id
-            )
-            assert wf._project == expected
-
     def test_run(self, workspace_id, project_id, raises, expected, monkeypatch):
         monkeypatch.setattr(_api._wf_run.WorkflowRun, "start", Mock())
         with raises:


### PR DESCRIPTION
# The problem

.prepare and .start functions were bringing no value except making the WorkflowRun state-dependent

# This PR's solution

Remove those functions

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
