### PR TITLE
fix: Bump minimum Pydantic version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     pip-api==0.0.30
     # Python Standard Library Backports
     importlib_metadata~=4.0
-    typing-extensions>=4.1.0
+    typing-extensions>=4.6.0
     # QE Workflow export 
     pyyaml
     # Web requests for external services

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     pip-api==0.0.30
     # Python Standard Library Backports
     importlib_metadata~=4.0
-    typing-extensions>=4.6.0
+    typing-extensions>=4.1.0
     # QE Workflow export 
     pyyaml
     # Web requests for external services

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ python_requires = >=3.8
 
 install_requires =
     # Schema definition
-    pydantic<2
+    pydantic>=1.10.8,<2
     # Pickling library
     cloudpickle==2.2.1
     # We should keep `dill` to make sure old workflows can be unpickled.

--- a/src/orquestra/sdk/schema/responses.py
+++ b/src/orquestra/sdk/schema/responses.py
@@ -11,7 +11,7 @@ import enum
 import typing as t
 
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated
+from typing_extensions import Annotated, Literal
 
 from .configs import RuntimeConfiguration
 from .ir import (
@@ -148,7 +148,7 @@ class ServicesStatusResponse(BaseModel):
 class JSONResult(BaseModel):
     # Output value dumped to a flat JSON string.
     value: str
-    serialization_format: t.Literal[ArtifactFormat.JSON] = ArtifactFormat.JSON
+    serialization_format: Literal[ArtifactFormat.JSON] = ArtifactFormat.JSON
 
 
 class PickleResult(BaseModel):
@@ -156,7 +156,7 @@ class PickleResult(BaseModel):
     # chunks. Chunking is required because some JSON parsers have limitation on max
     # string field length.
     chunks: t.List[str]
-    serialization_format: t.Literal[
+    serialization_format: Literal[
         ArtifactFormat.ENCODED_PICKLE
     ] = ArtifactFormat.ENCODED_PICKLE
 
@@ -168,7 +168,7 @@ WorkflowResult = Annotated[
 
 class ComputeEngineWorkflowResult(BaseModel):
     results: t.Tuple[WorkflowResult, ...]
-    type: t.Literal["ComputeEngineWorkflowResult"] = "ComputeEngineWorkflowResult"
+    type: Literal["ComputeEngineWorkflowResult"] = "ComputeEngineWorkflowResult"
 
 
 class GetWorkflowRunResultsResponse(BaseModel):

--- a/src/orquestra/sdk/schema/responses.py
+++ b/src/orquestra/sdk/schema/responses.py
@@ -11,7 +11,7 @@ import enum
 import typing as t
 
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated, Literal
+from typing_extensions import Annotated
 
 from .configs import RuntimeConfiguration
 from .ir import (
@@ -148,7 +148,7 @@ class ServicesStatusResponse(BaseModel):
 class JSONResult(BaseModel):
     # Output value dumped to a flat JSON string.
     value: str
-    serialization_format: Literal[ArtifactFormat.JSON] = ArtifactFormat.JSON
+    serialization_format: t.Literal[ArtifactFormat.JSON] = ArtifactFormat.JSON
 
 
 class PickleResult(BaseModel):
@@ -156,7 +156,7 @@ class PickleResult(BaseModel):
     # chunks. Chunking is required because some JSON parsers have limitation on max
     # string field length.
     chunks: t.List[str]
-    serialization_format: Literal[
+    serialization_format: t.Literal[
         ArtifactFormat.ENCODED_PICKLE
     ] = ArtifactFormat.ENCODED_PICKLE
 
@@ -168,7 +168,7 @@ WorkflowResult = Annotated[
 
 class ComputeEngineWorkflowResult(BaseModel):
     results: t.Tuple[WorkflowResult, ...]
-    type: Literal["ComputeEngineWorkflowResult"] = "ComputeEngineWorkflowResult"
+    type: t.Literal["ComputeEngineWorkflowResult"] = "ComputeEngineWorkflowResult"
 
 
 class GetWorkflowRunResultsResponse(BaseModel):


### PR DESCRIPTION
# The problem

`typing_extensions==4.6.0` introduced their version of `Literal`. This caused `pydantic` to fail.

Possible solutions:
* Pin `typing_extensions==4.5.0`
* Wait until `pydantic` release the fix (`1.10.8`)
* Use Python 3.10 only
* Use `typing_extensions.Literal` instead of `typing.Literal`

# This PR's solution

* Update minimum `pydantic` version to `1.10.8`.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
