### PR TITLE
ci: add `imp`/`improvement` prefix to the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,5 +12,5 @@ _Check that this PR satisfies the following items:_
 
 - [ ] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
 - [ ] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
-- [ ] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
+- [ ] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
 - [ ] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


### PR DESCRIPTION
# The problem

* There are PRs that neither add a new feature, fix a bug, or match any other prefixes we had in the PR template
* [Remark](https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/165#pullrequestreview-1440255268)


# This PR's solution

* Adds `imp`/`improvement` prefix to the list of suggested prefixes
* Adds `int` abbreviation for `internal`

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
