### PR TITLE
Feat: Add project property to workflow run to return workspace and project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
+* Add .project property to WorkflowRun to get the info about worksapce and project of running workflow
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -8,6 +8,7 @@ import time
 import typing as t
 import warnings
 from datetime import timedelta
+from functools import cached_property
 from pathlib import Path
 
 from ...exceptions import (
@@ -196,6 +197,10 @@ class WorkflowRun:
         The run_id for this workflow run.
         """
         return self._run_id
+
+    @cached_property
+    def project(self):
+        return self._runtime.get_workflow_project(self.run_id)
 
     def wait_until_finished(self, frequency: float = 0.25, verbose=True) -> State:
         """Block until the workflow run finishes.

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -200,6 +200,14 @@ class WorkflowRun:
 
     @cached_property
     def project(self):
+        """Get the project and workspace id of a workflowrun,
+        Currently supported only on CE
+
+        Raises:
+            orquestra.sdk.exceptions.WorkspacesNotSupportedError: when runtime
+            does not support workspaces and projects
+        """
+
         return self._runtime.get_workflow_project(self.run_id)
 
     def wait_until_finished(self, frequency: float = 0.25, verbose=True) -> State:

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -490,3 +490,6 @@ class CERuntime(RuntimeInterface):
             raise exceptions.NotFoundError(
                 f"Could not find workspace with id: {workspace_id}."
             ) from e
+
+    def get_workflow_project(self, wf_run_id: WorkflowRunId) -> ProjectRef:
+        return self._client.get_workflow_project(wf_run_id)

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -403,8 +403,8 @@ class DriverClient:
 
         workflow_runs = []
         for r in parsed_response.data:
-            workflow_def = self.get_workflow_def(r.definitionId).workflow
-            workflow_runs.append(r.to_ir(workflow_def))
+            workflow_def = self.get_workflow_def(r.definitionId)
+            workflow_runs.append(r.to_ir(workflow_def.workflow))
 
         return Paginated(
             contents=workflow_runs,

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -271,7 +271,9 @@ class DriverClient:
         _handle_common_errors(resp)
         return resp.headers["Location"]
 
-    def get_workflow_def(self, workflow_def_id: _models.WorkflowDefID) -> WorkflowDef:
+    def get_workflow_def(
+        self, workflow_def_id: _models.WorkflowDefID
+    ) -> _models.GetWorkflowDefResponse:
         """
         Gets a stored workflow definition
 
@@ -301,7 +303,7 @@ class DriverClient:
             _models.GetWorkflowDefResponse, _models.MetaEmpty
         ].parse_obj(resp.json())
 
-        return parsed_resp.data.workflow
+        return parsed_resp.data
 
     def delete_workflow_def(self, workflow_def_id: _models.WorkflowDefID):
         """
@@ -401,7 +403,7 @@ class DriverClient:
 
         workflow_runs = []
         for r in parsed_response.data:
-            workflow_def = self.get_workflow_def(r.definitionId)
+            workflow_def = self.get_workflow_def(r.definitionId).workflow
             workflow_runs.append(r.to_ir(workflow_def))
 
         return Paginated(
@@ -439,7 +441,7 @@ class DriverClient:
 
         workflow_def = self.get_workflow_def(parsed_response.data.definitionId)
 
-        return parsed_response.data.to_ir(workflow_def)
+        return parsed_response.data.to_ir(workflow_def.workflow)
 
     def terminate_workflow_run(self, wf_run_id: _models.WorkflowRunID):
         """
@@ -742,3 +744,37 @@ class DriverClient:
         )
 
         return parsed_response
+
+    def get_workflow_project(self, wf_run_id: _models.WorkflowRunID) -> ProjectRef:
+        """
+        Gets the status of a workflow run from the workflow driver
+
+        Raises:
+            InvalidWorkflowRunID: see the exception's docstring
+            WorkflowRunNotFound: see the exception's docstring
+            InvalidTokenError: see the exception's docstring
+            ForbiddenError: see the exception's docstring
+            UnknownHTTPError: see the exception's docstring
+        """
+
+        resp = self._get(
+            API_ACTIONS["get_workflow_run"].format(wf_run_id),
+            query_params=None,
+        )
+
+        if resp.status_code == codes.BAD_REQUEST:
+            raise _exceptions.InvalidWorkflowRunID(wf_run_id)
+        elif resp.status_code == codes.NOT_FOUND:
+            raise _exceptions.WorkflowRunNotFound(wf_run_id)
+
+        _handle_common_errors(resp)
+
+        parsed_response = _models.Response[
+            _models.WorkflowRunResponse, _models.MetaEmpty
+        ].parse_obj(resp.json())
+
+        workflow_def = self.get_workflow_def(parsed_response.data.definitionId)
+
+        return ProjectRef(
+            workspace_id=workflow_def.workspaceId, project_id=workflow_def.project
+        )

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -84,13 +84,16 @@ class CreateWorkflowDefResponse(pydantic.BaseModel):
 class GetWorkflowDefResponse(pydantic.BaseModel):
     """
     Implements:
-        https://github.com/zapatacomputing/workflow-driver/blob/7b472546225d0a87be3694ddaa330db4ddcad3c1/openapi/src/schemas/WorkflowDefinition.yaml
+        https://github.com/zapatacomputing/workflow-driver/blob/cb61512e9f3da24addd933c7259aa4584ab04e4f/openapi/src/schemas/WorkflowDefinition.yaml
     """
 
     id: WorkflowDefID
     created: datetime
     owner: str
     workflow: WorkflowDef
+    workspaceId: WorkspaceId
+    project: ProjectId
+    sdkVersion: str
 
 
 class ListWorkflowDefsRequest(pydantic.BaseModel):

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -349,3 +349,6 @@ class InProcessRuntime(abc.RuntimeInterface):
         raise NotImplementedError(
             "This functionality isn't available for 'in_process' runtime"
         )
+
+    def get_workflow_project(self, wf_run_id: WorkflowRunId):
+        raise exceptions.WorkspacesNotSupportedError()

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -909,3 +909,6 @@ class QERuntime(RuntimeInterface):
                 -limit:
             ]
         return wf_runs
+
+    def get_workflow_project(self, wf_run_id: WorkflowRunId):
+        raise exceptions.WorkspacesNotSupportedError()

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -194,6 +194,12 @@ class RuntimeInterface(ABC):
         """
         raise NotImplementedError()
 
+    def get_workflow_project(self, wf_run_id: WorkflowRunId):
+        """
+        Returns project and workspace IDs of given workflow
+        """
+        raise WorkspacesNotSupportedError()
+
     def list_workspaces(self) -> t.Sequence[Workspace]:
         """
         List workspaces available to a user. Works only on CE

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -194,11 +194,12 @@ class RuntimeInterface(ABC):
         """
         raise NotImplementedError()
 
+    @abstractmethod
     def get_workflow_project(self, wf_run_id: WorkflowRunId):
         """
         Returns project and workspace IDs of given workflow
         """
-        raise WorkspacesNotSupportedError()
+        raise NotImplementedError()
 
     def list_workspaces(self) -> t.Sequence[Workspace]:
         """

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -547,6 +547,9 @@ class RayRuntime(RuntimeInterface):
             ]
         return wf_runs
 
+    def get_workflow_project(self, wf_run_id: WorkflowRunId):
+        raise exceptions.WorkspacesNotSupportedError()
+
 
 def get_current_ids() -> (
     t.Tuple[

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -157,7 +157,9 @@ class TestWorkflowRun:
             "task_run2": serde.result_from_artifact("another", ir.ArtifactFormat.AUTO),
             "task_run3": serde.result_from_artifact(123, ir.ArtifactFormat.AUTO),
         }
-
+        runtime.get_workflow_project.return_value = ProjectRef(
+            workspace_id="ws", project_id="proj"
+        )
         wf_def_model = sample_wf_def.model
         task_invs = list(wf_def_model.task_invocations.values())
         # Get logs, the runtime interface returns invocation IDs
@@ -587,6 +589,18 @@ class TestWorkflowRun:
             with pytest.raises(type(exc)):
                 # When
                 run.stop()
+
+    class TestProject:
+        def test_get_project(self, run):
+            project = run.project
+            assert project.workspace_id == "ws"
+            assert project.project_id == "proj"
+
+        def test_value_get_cashed(self, run):
+            _ = run.project
+            _ = run.project
+
+            run._runtime.get_workflow_project.assert_called_once()
 
 
 class TestListWorkflows:

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -596,7 +596,7 @@ class TestWorkflowRun:
             assert project.workspace_id == "ws"
             assert project.project_id == "proj"
 
-        def test_value_get_cashed(self, run):
+        def test_value_get_cached(self, run):
             _ = run.project
             _ = run.project
 

--- a/tests/sdk/v2/driver/resp_mocks.py
+++ b/tests/sdk/v2/driver/resp_mocks.py
@@ -32,6 +32,9 @@ def _wf_def_resp(id_: WorkflowDefID, wf_def: WorkflowDef):
         "created": "2022-11-23T18:58:13.86752161Z",
         "owner": "evil/emiliano.zapata@zapatacomputing.com",
         "workflow": wf_def.dict(),
+        "workspaceId": "evil/emiliano.zapata@zapatacomputing.com",
+        "project": "emiliano's project",
+        "sdkVersion": "0x859",
     }
 
 

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -2142,7 +2142,6 @@ class TestClient:
                 workflow_run_id: str,
                 workflow_def_id: str,
                 workflow_run_status: RunStatus,
-
             ):
                 endpoint_mocker(
                     json=resp_mocks.make_get_wf_run_missing_task_run_status(

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -14,7 +14,7 @@ import responses
 import orquestra.sdk as sdk
 from orquestra.sdk._base._driver import _exceptions
 from orquestra.sdk._base._driver._client import DriverClient, Paginated
-from orquestra.sdk._base._driver._models import Resources
+from orquestra.sdk._base._driver._models import GetWorkflowDefResponse, Resources
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.responses import JSONResult, PickleResult
@@ -129,7 +129,13 @@ class TestClient:
 
                 returned_wf_def = client.get_workflow_def(workflow_def_id)
 
-                assert returned_wf_def == workflow_def
+                assert returned_wf_def.workflow == workflow_def
+                assert (
+                    returned_wf_def.workspaceId
+                    == "evil/emiliano.zapata@zapatacomputing.com"
+                )
+                assert returned_wf_def.project == "emiliano's project"
+                assert returned_wf_def.sdkVersion == "0x859"
 
             @staticmethod
             def test_sets_auth(
@@ -628,9 +634,11 @@ class TestClient:
                 workflow_def: WorkflowDef,
                 monkeypatch: pytest.MonkeyPatch,
             ):
-                mock = create_autospec(client.get_workflow_def)
-                mock.return_value = workflow_def
-                monkeypatch.setattr(client, "get_workflow_def", mock)
+                mock = create_autospec(GetWorkflowDefResponse)
+                mock.workflow = workflow_def
+                function_mock = create_autospec(client.get_workflow_def)
+                function_mock.return_value = mock
+                monkeypatch.setattr(client, "get_workflow_def", function_mock)
 
             @staticmethod
             def test_invalid_wf_run_id(
@@ -769,9 +777,11 @@ class TestClient:
                 workflow_def: WorkflowDef,
                 monkeypatch: pytest.MonkeyPatch,
             ):
-                mock = create_autospec(client.get_workflow_def)
-                mock.return_value = workflow_def
-                monkeypatch.setattr(client, "get_workflow_def", mock)
+                mock = create_autospec(GetWorkflowDefResponse)
+                mock.workflow = workflow_def
+                function_mock = create_autospec(client.get_workflow_def)
+                function_mock.return_value = mock
+                monkeypatch.setattr(client, "get_workflow_def", function_mock)
 
             @staticmethod
             def test_list_workflow_runs(


### PR DESCRIPTION
# The problem

With workflowRun object obtained using by_id method, there was no way for the user to determine the workspace and project: https://zapatacomputing.atlassian.net/browse/ORQSDK-817

# This PR's solution

Add .project property to WorkflowRun class

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
