### PR TITLE
feat: suppress VersionMismatch warnings when listing wf runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * `sdk.secrets.list()`, `sdk.secrets.get()`, `sdk.secrets.set()` and `sdk.secrets.delete()` now accept `workspace_id` parameter to specify secrets in particular workspace.
 * `auto` config inside studio will infer workspace and project IDs from studio instance.
 * Support for running tasks in Docker containers with custom images on Compute Engine.
+* VersionMismatch warnings are shown only when interacting with specific workflow runs, not while listing workflows.
 
 👩‍🔬 *Experimental*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 🔥 *Features*
 * Add .project property to WorkflowRun to get the info about workspace and project of running workflow
+* VersionMismatch warnings are shown only when interacting with specific workflow runs, not while listing workflows.
 
 👩‍🔬 *Experimental*
 
@@ -41,7 +42,6 @@
 * `sdk.secrets.list()`, `sdk.secrets.get()`, `sdk.secrets.set()` and `sdk.secrets.delete()` now accept `workspace_id` parameter to specify secrets in particular workspace.
 * `auto` config inside studio will infer workspace and project IDs from studio instance.
 * Support for running tasks in Docker containers with custom images on Compute Engine.
-* VersionMismatch warnings are shown only when interacting with specific workflow runs, not while listing workflows.
 
 🐛 *Bug Fixes*
 * Fixed tasks that failed when explicitly state `n_outputs=1` on QE and in-process.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 🔥 *Features*
 * Add .project property to WorkflowRun to get the info about workspace and project of running workflow
-* VersionMismatch warnings are shown only when interacting with specific workflow runs, not while listing workflows.
+* `VersionMismatch` warnings are shown only when interacting with specific workflow runs, not while listing workflows.
+* ```
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -97,7 +97,8 @@ class WorkflowRunRepo:
             except (ConnectionError, exceptions.UnauthorizedError):
                 raise
 
-            return [run.get_status_model() for run in wf_runs]
+            ret = [run.get_status_model() for run in wf_runs]
+        return ret
 
     def get_wf_by_run_id(
         self, wf_run_id: WorkflowRunId, config_name: t.Optional[ConfigName]

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -83,21 +83,19 @@ class WorkflowRunRepo:
             orquestra.sdk.exceptions.UnauthorizedError: when connection with runtime
                 failed because of an auth error.
         """
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=exceptions.VersionMismatch)
-            try:
-                wf_runs = sdk.list_workflow_runs(
-                    config,
-                    limit=limit,
-                    max_age=max_age,
-                    state=state,
-                    workspace=workspace,
-                    project=project,
-                )
-            except (ConnectionError, exceptions.UnauthorizedError):
-                raise
+        try:
+            wf_runs = sdk.list_workflow_runs(
+                config,
+                limit=limit,
+                max_age=max_age,
+                state=state,
+                workspace=workspace,
+                project=project,
+            )
+        except (ConnectionError, exceptions.UnauthorizedError):
+            raise
 
-            ret = [run.get_status_model() for run in wf_runs]
+        ret = [run.get_status_model() for run in wf_runs]
         return ret
 
     def get_wf_by_run_id(

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -83,19 +83,21 @@ class WorkflowRunRepo:
             orquestra.sdk.exceptions.UnauthorizedError: when connection with runtime
                 failed because of an auth error.
         """
-        try:
-            wf_runs = sdk.list_workflow_runs(
-                config,
-                limit=limit,
-                max_age=max_age,
-                state=state,
-                workspace=workspace,
-                project=project,
-            )
-        except (ConnectionError, exceptions.UnauthorizedError):
-            raise
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=exceptions.VersionMismatch)
+            try:
+                wf_runs = sdk.list_workflow_runs(
+                    config,
+                    limit=limit,
+                    max_age=max_age,
+                    state=state,
+                    workspace=workspace,
+                    project=project,
+                )
+            except (ConnectionError, exceptions.UnauthorizedError):
+                raise
 
-        return [run.get_status_model() for run in wf_runs]
+            return [run.get_status_model() for run in wf_runs]
 
     def get_wf_by_run_id(
         self, wf_run_id: WorkflowRunId, config_name: t.Optional[ConfigName]

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -231,30 +231,6 @@ class TestWorkflowRunRepo:
                         config_name=config,
                     )
 
-        class TestListWFRuns:
-            @staticmethod
-            def test_suppresses_versionmismatch_marnings(monkeypatch, mock_wf_run):
-                config = "<config sentinel>"
-                repo = _repos.WorkflowRunRepo()
-
-                def raise_warnings(*args, **kwargs):
-                    warnings.warn("a warning that should not be suppressed")
-                    warnings.warn(exceptions.VersionMismatch("foo", "bar", None))
-                    warnings.warn(exceptions.VersionMismatch("foo", "bar", None))
-                    return [mock_wf_run, mock_wf_run]
-
-                monkeypatch.setattr(
-                    sdk, "list_workflow_runs", Mock(side_effect=raise_warnings)
-                )
-
-                with pytest.warns(Warning) as record:
-                    _ = repo.list_wf_runs(config)
-
-                assert len(record) == 1
-                assert str(record[0].message) == str(
-                    UserWarning("a warning that should not be suppressed")
-                )
-
         class TestListWFRunIDs:
             """
             Boundaries::

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -231,6 +231,30 @@ class TestWorkflowRunRepo:
                         config_name=config,
                     )
 
+        class TestListWFRuns:
+            @staticmethod
+            def test_suppresses_versionmismatch_marnings(monkeypatch, mock_wf_run):
+                config = "<config sentinel>"
+                repo = _repos.WorkflowRunRepo()
+
+                def raise_warnings(*args, **kwargs):
+                    warnings.warn("a warning that should not be suppressed")
+                    warnings.warn(exceptions.VersionMismatch("foo", "bar", None))
+                    warnings.warn(exceptions.VersionMismatch("foo", "bar", None))
+                    return [mock_wf_run, mock_wf_run]
+
+                monkeypatch.setattr(
+                    sdk, "list_workflow_runs", Mock(side_effect=raise_warnings)
+                )
+
+                with pytest.warns(Warning) as record:
+                    _ = repo.list_wf_runs(config)
+
+                assert len(record) == 1
+                assert str(record[0].message) == str(
+                    UserWarning("a warning that should not be suppressed")
+                )
+
         class TestListWFRunIDs:
             """
             Boundaries::


### PR DESCRIPTION
# The problem

VersionMismatch warnings are being spammed when dealing with multiple wf runs, specifically when listing wf runs or prompting the user to choose between runs.

VersionMismatch is raised when an older JSON representation of a workflow def is loaded in a new SDK version.

# This PR's solution

Suppresses VersionMismatch warnings when listing wf runs. 

This covers both the `orq list wf list` workflow, and the prompting (e.g. `orq wf logs` without specify a workflow).

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).

[ORQSDK-843]


[ORQSDK-843]: https://zapatacomputing.atlassian.net/browse/ORQSDK-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ