### PR TITLE
Feat: New API to start workflow runs from IR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * `VersionMismatch` warnings are shown only when interacting with specific workflow runs, not while listing workflows.
 * Add `--qe` flag to `orq login`, this is the default so there is no change in behavior.
 * Bump Ray version to 2.4.0
+* New API method `WorkflowRun.start_from_ir()` that allows to start workflow run having only IR object
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -143,7 +143,8 @@ class WorkflowRun:
             _config = RuntimeConfig.load(config)
         else:
             raise TypeError(
-                f"'config' argument to `run()` has unsupported type {type(config)}."
+                f"'config' argument to `start_from_ir()` has unsupported "
+                f"type {type(config)}."
             )
         runtime: RuntimeInterface
         if _config._runtime_name == "IN_PROCESS":

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -135,7 +135,21 @@ class WorkflowRun:
         cls,
         wf_def: ir.WorkflowDef,
         config: t.Union[RuntimeConfig, str],
+        workspace_id: t.Optional[WorkspaceId] = None,
+        project_id: t.Optional[ProjectId] = None,
     ):
+        """
+        Start workflow run from its IR representation
+
+        Args:
+            wf_def: IR definition of a workflow.
+            config: SDK needs to know where to execute the workflow. The config
+                contains the required details. This can be a RuntimeConfig object, or
+                the name of a saved configuration.
+            workspace_id: ID of the workspace for workflow - supported only on CE
+            project_id: ID of the project for workflow - supported only on CE
+
+        """
         _config: RuntimeConfig
         if isinstance(config, RuntimeConfig):
             _config = config
@@ -154,11 +168,14 @@ class WorkflowRun:
 
         assert runtime is not None
 
-        wf_run = cls._start(
-            wf_def=wf_def,
-            runtime=runtime,
-            config=_config,
+        _project: t.Optional[ProjectRef] = resolve_studio_project_ref(
+            workspace_id, project_id, _config.name
         )
+
+        wf_run = cls._start(
+            wf_def=wf_def, runtime=runtime, config=_config, project=_project
+        )
+
         return wf_run
 
     @classmethod

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -132,7 +132,6 @@ class WorkflowRun:
         cls,
         wf_def: ir.WorkflowDef,
         config: t.Union[RuntimeConfig, str],
-        project_dir: t.Optional[t.Union[str, Path]] = None,
     ):
         _config: RuntimeConfig
         if isinstance(config, RuntimeConfig):
@@ -147,7 +146,7 @@ class WorkflowRun:
         if _config._runtime_name == "IN_PROCESS":
             runtime = InProcessRuntime()
         else:
-            runtime = _config._get_runtime(project_dir=project_dir)
+            runtime = _config._get_runtime()
 
         assert runtime is not None
 
@@ -163,7 +162,7 @@ class WorkflowRun:
         cls,
         wf_def: ir.WorkflowDef,
         runtime: RuntimeInterface,
-        config: RuntimeConfig,
+        config: t.Optional[RuntimeConfig],
         project: t.Optional[ProjectRef] = None,
     ):
         """

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -10,8 +10,9 @@ import warnings
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
-from orquestra.sdk import ProjectRef, exceptions
+from orquestra.sdk import exceptions
 from orquestra.sdk._base import abc
+from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.responses import WorkflowResult
 from orquestra.sdk.schema.workflow_run import (

--- a/tests/runtime/api/test_api_with_qe.py
+++ b/tests/runtime/api/test_api_with_qe.py
@@ -174,42 +174,6 @@ class TestGetWorkflowRunStatus:
             "created": "1989-12-13T09:03:49.39478764Z",
         }
 
-    def test_two_step_form(
-        self,
-        monkeypatch,
-        mocked_responses,
-        remote_config,
-        qe_status_response,
-        tmp_path,
-        mock_workflow_db_location,
-    ):
-        monkeypatch.setattr(
-            _db.WorkflowDB,
-            "get_workflow_run",
-            Mock(
-                return_value=StoredWorkflowRun(
-                    workflow_run_id="workflow-id",
-                    config_name="hello",
-                    workflow_def=my_workflow().model,
-                )
-            ),
-        )
-        monkeypatch.setattr(_db.WorkflowDB, "save_workflow_run", Mock())
-        mocked_responses.add(
-            responses.POST,
-            "http://localhost/v1/workflows",
-            body="workflow-id",
-        )
-        mocked_responses.add(
-            responses.GET,
-            "http://localhost/v1/workflow",
-            json=qe_status_response,
-        )
-
-        run = my_workflow().run(remote_config)
-
-        assert run.get_status() == State.SUCCEEDED
-
     def test_shorthand_form(
         self,
         monkeypatch,

--- a/tests/runtime/api/test_api_with_ray.py
+++ b/tests/runtime/api/test_api_with_ray.py
@@ -54,14 +54,15 @@ class TestRunningLocalInBackground:
 
             assert results == 3
 
-    class TestShorthand:
+    class TestStartFromIr:
         @staticmethod
         def test_single_run(
             patch_config_location, ray, monkeypatch, tmp_path, mock_workflow_db_location
         ):
             monkeypatch.setattr(Path, "cwd", Mock(return_value=tmp_path))
-
-            run = wf_pass_tuple().run(sdk.RuntimeConfig.ray())
+            run = sdk.WorkflowRun.start_from_ir(
+                wf_pass_tuple().model, sdk.RuntimeConfig.ray()
+            )
             run.wait_until_finished()
             results = run.get_results()
 

--- a/tests/runtime/api/test_api_with_ray.py
+++ b/tests/runtime/api/test_api_with_ray.py
@@ -57,7 +57,7 @@ class TestRunningLocalInBackground:
 
             assert results == 3
 
-    class TestStartFromIr:
+    class TestStartFromIR:
         @staticmethod
         def test_single_run(
             patch_config_location, ray, monkeypatch, tmp_path, mock_workflow_db_location

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -353,7 +353,7 @@ class TestWorkflowRun:
                         # When
                         _ = _api.WorkflowRun.by_id(run_id=run_id)
 
-    class TestStartFromIr:
+    class TestStartFromIR:
         @pytest.fixture
         def wf_ir_def(self, sample_wf_def):
             return sample_wf_def.model

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -365,7 +365,7 @@ class TestWorkflowRun:
 
         def test_wrong_config_type(self, wf_ir_def):
             with pytest.raises(TypeError):
-                _api.WorkflowRun.start_from_ir(wf_ir_def, 123)  # noqa
+                _api.WorkflowRun.start_from_ir(wf_ir_def, 123)  # type: ignore
 
         def test_different_runtime(self, wf_ir_def, mock_runtime):
             mock_config = MagicMock(_api.RuntimeConfig)

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -350,6 +350,32 @@ class TestWorkflowRun:
                         # When
                         _ = _api.WorkflowRun.by_id(run_id=run_id)
 
+    class TestStartFromIr:
+        @pytest.fixture
+        def wf_ir_def(self, sample_wf_def):
+            return sample_wf_def.model
+
+        @pytest.mark.parametrize(
+            "config", ["in_process", _api.RuntimeConfig.in_process()]
+        )
+        def test_happy_path(self, wf_ir_def, config):
+            wf_run = _api.WorkflowRun.start_from_ir(wf_ir_def, config)
+
+            assert wf_run.get_results() == ("Hellothere", "Generalkenobi")
+
+        def test_wrong_config_type(self, wf_ir_def):
+            with pytest.raises(TypeError):
+                _api.WorkflowRun.start_from_ir(wf_ir_def, 123)  # noqa
+
+        def test_different_runtime(self, wf_ir_def, mock_runtime):
+            mock_config = MagicMock(_api.RuntimeConfig)
+            mock_config._runtime_name = "runtime_name"
+            mock_config._get_runtime.return_value = mock_runtime
+
+            wf_run = _api.WorkflowRun.start_from_ir(wf_ir_def, mock_config)
+
+            assert wf_run.run_id == "wf_pass_tuple-1"
+
     class TestGetStatus:
         @staticmethod
         def test_returns_status_from_runtime(run, mock_runtime):


### PR DESCRIPTION
# The problem

Workflow driver ray (our CE backend) only receives IR of a workflow, not workflow function. To start internally a workflow it has to use internals of SDK
https://zapatacomputing.atlassian.net/browse/ORQSDK-680

# This PR's solution

Make valid external API tthat WDR can use

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
