### PR TITLE
Fix: Fix prompters for workspaces and projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
+* Fix CLI prompters to not throw exceptions after selecting project and workspace
 
 💅 *Improvements*
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -210,7 +210,9 @@ class SpacesResolver:
         prompt_choices = [(label, project) for label, project in zip(labels, projects)]
 
         selected_id = self._prompter.choice(prompt_choices, message="Projects")
-        return selected_id.project_id if selected_id else selected_id
+        if selected_id is not None:
+            return selected_id.project_id
+        return None
 
 
 class WFRunResolver:

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -180,7 +180,7 @@ class SpacesResolver:
         prompt_choices = [(label, ws) for label, ws in zip(labels, workspaces)]
         selected_id = self._prompter.choice(prompt_choices, message="Workspace")
 
-        return selected_id
+        return selected_id.workspace_id
 
     def resolve_project_id(
         self,
@@ -207,9 +207,10 @@ class SpacesResolver:
         if optional:
             projects.append(None)
             labels.append("All")
-        prompt_choices = [(label, ws) for label, ws in zip(labels, projects)]
+        prompt_choices = [(label, project) for label, project in zip(labels, projects)]
 
-        return self._prompter.choice(prompt_choices, message="Projects")
+        selected_id = self._prompter.choice(prompt_choices, message="Projects")
+        return selected_id.project_id if selected_id else selected_id
 
 
 class WFRunResolver:
@@ -266,14 +267,13 @@ class WFRunResolver:
             resolved_project_id = self._spaces_resolver.resolve_project_id(
                 config, workspace_id=resolved_workspace_id
             )
-            project = ProjectRef(
-                workspace_id=resolved_workspace_id, project_id=resolved_project_id
-            )
-
         except exceptions.WorkspacesNotSupportedError:
-            project = None
+            resolved_workspace_id = None
+            resolved_project_id = None
 
-        runs = self._wf_run_repo.list_wf_runs(config, project=project)
+        runs = self._wf_run_repo.list_wf_runs(
+            config, workspace=resolved_workspace_id, project=resolved_project_id
+        )
 
         runs, tabulated_labels = self._presenter.wf_list_for_prompt(runs)
         prompt_choices = [(label, wf) for label, wf in zip(tabulated_labels, runs)]

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -241,14 +241,14 @@ class WFRunResolver:
             resolved_project_id = self._spaces_resolver.resolve_project_id(
                 config, workspace_id=resolved_workspace_id
             )
-            project = ProjectRef(
-                workspace_id=resolved_workspace_id, project_id=resolved_project_id
-            )
         except exceptions.WorkspacesNotSupportedError:
             # if run on runtime that doesn't support workspaces
-            project = None
+            resolved_workspace_id = None
+            resolved_project_id = None
 
-        wfs = self._wf_run_repo.list_wf_runs(config, project=project)
+        wfs = self._wf_run_repo.list_wf_runs(
+            config, workspace=resolved_workspace_id, project=resolved_project_id
+        )
 
         wfs, tabulated_labels = self._presenter.wf_list_for_prompt(wfs)
         prompt_choices = [(label, wf.id) for label, wf in zip(tabulated_labels, wfs)]

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -526,11 +526,12 @@ class TestWFRunResolver:
             # We should pass config value to wf_run_repo.
             if runtime_supports_workspaces:
                 wf_run_repo.list_wf_runs.assert_called_with(
-                    config,
-                    project=ProjectRef(workspace_id=fake_ws, project_id=fake_project),
+                    config, workspace=fake_ws, project=fake_project
                 )
             else:
-                wf_run_repo.list_wf_runs.assert_called_with(config, project=None)
+                wf_run_repo.list_wf_runs.assert_called_with(
+                    config, workspace=None, project=None
+                )
 
             # We should prompt for selecting workflow ID from the ones returned
             # by the repo. Those choices should be sorted from newest at the top

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -627,14 +627,12 @@ class TestWFRunResolver:
             # We should pass config value to wf_run_repo.
             if runtime_supports_workspaces:
                 wf_run_repo.list_wf_runs.assert_called_with(
-                    config,
-                    project=ProjectRef(
-                        workspace_id="wake ws", project_id="fake project"
-                    ),
+                    config, workspace="wake ws", project="fake project"
                 )
             else:
                 wf_run_repo.list_wf_runs.assert_called_with(
                     config,
+                    workspace=None,
                     project=None,
                 )
 
@@ -1277,7 +1275,7 @@ class TestSpacesResolver:
             )
 
             # Resolver should return the user's choice.
-            assert resolved_workspace == selected_workspace
+            assert resolved_workspace == selected_workspace.workspace_id
 
     class TestProjectResolver:
         @staticmethod
@@ -1342,7 +1340,7 @@ class TestSpacesResolver:
             )
 
             # Resolver should return the user's choice.
-            assert resolved_project == selected_project
+            assert resolved_project == selected_project.project_id
 
         @staticmethod
         def test_optional():
@@ -1382,4 +1380,4 @@ class TestSpacesResolver:
             )
 
             # Resolver should return the user's choice.
-            assert resolved_project == selected_project
+            assert resolved_project == selected_project.project_id


### PR DESCRIPTION
# The problem

Our prompters had invalid type returned - causing CLI to throw exceptions

# This PR's solution

Fix typings

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
