### PR TITLE
Imp: Prompt for workspace and project while submitting a workflow via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,14 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
-* Add .project property to WorkflowRun to get the info about worksapce and project of running workflow
+* Add .project property to WorkflowRun to get the info about workspace and project of running workflow
 
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
 
 💅 *Improvements*
-
+* Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly
 🥷 *Internal*
 
 📃 *Docs*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 💅 *Improvements*
 * Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly
+
 🥷 *Internal*
 
 📃 *Docs*

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_submit.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_submit.py
@@ -74,12 +74,16 @@ class Action:
         # 1. Resolve config, workspace and project
         resolved_config = self._config_resolver.resolve(config)
 
-        resolved_workspace_id = self._space_resolver.resolve_workspace_id(
-            resolved_config, workspace_id
-        )
-        resolved_project_id = self._space_resolver.resolve_project_id(
-            resolved_config, resolved_workspace_id, project_id
-        )
+        try:
+            resolved_workspace_id = self._space_resolver.resolve_workspace_id(
+                resolved_config, workspace_id
+            )
+            resolved_project_id = self._space_resolver.resolve_project_id(
+                resolved_config, resolved_workspace_id, project_id
+            )
+        except exceptions.WorkspacesNotSupportedError:
+            resolved_workspace_id = None
+            resolved_project_id = None
 
         # 2. Resolve module with workflow defs
         try:

--- a/tests/cli/dorq/workflow/test_submit.py
+++ b/tests/cli/dorq/workflow/test_submit.py
@@ -11,6 +11,7 @@ import pytest
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base.cli._dorq import _repos
+from orquestra.sdk._base.cli._dorq._arg_resolvers import SpacesResolver
 from orquestra.sdk._base.cli._dorq._ui import _presenters, _prompts
 from orquestra.sdk._base.cli._dorq._workflow import _submit
 
@@ -223,7 +224,6 @@ class TestAction:
 
             prompter = create_autospec(_prompts.Prompter)
             presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
             wf_def_repo = create_autospec(_repos.WorkflowDefRepo)
             wf_def_repo.get_worklow_names.side_effect = (
@@ -418,3 +418,56 @@ class TestAction:
 
             # We expect telling the user the wf run ID.
             presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+
+    class TestProjectResolve:
+        # Given
+        module = "my_wfs"
+        name = "sample_wf"
+        config = "cluster_z"
+
+        prompter = create_autospec(_prompts.Prompter)
+        presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+
+        wf_run_id = "wf.test"
+        wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
+        # submit() doesn't raise = no effect of the "--force" flag
+        wf_run_repo.submit.return_value = wf_run_id
+
+        wf_def_repo = create_autospec(_repos.WorkflowDefRepo)
+        wf_def_repo.get_module_from_spec.return_value = module
+        wf_def_sentinel = "<wf def sentinel>"
+        wf_def_repo.get_workflow_def.return_value = wf_def_sentinel
+
+        spaces_resolver = create_autospec(SpacesResolver)
+        spaces_resolver.resolve_workspace_id.return_value = "resolved_ws"
+        spaces_resolver.resolve_project_id.return_value = "resolved_project"
+
+        action = _submit.Action(
+            prompter=prompter,
+            presenter=presenter,
+            wf_run_repo=wf_run_repo,
+            wf_def_repo=wf_def_repo,
+            spaces_resolver=spaces_resolver,
+        )
+
+        # When
+        action.on_cmd_call(module, name, config, None, None, False)
+
+        # Then
+        # We don't expect prompts.
+        prompter.choice.assert_not_called()
+
+        # We expect getting workflow def from the module.
+        wf_def_repo.get_workflow_def.assert_called_with(module, name)
+
+        # We expect submitting the retrieved wf def to the passed config cluster.
+        wf_run_repo.submit.assert_called_with(
+            wf_def_sentinel,
+            config,
+            ignore_dirty_repo=False,
+            workspace_id="resolved_ws",
+            project_id="resolved_project",
+        )
+
+        # We expect telling the user the wf run ID.
+        presenter.show_submitted_wf_run.assert_called_with(wf_run_id)

--- a/tests/cli/dorq/workflow/test_submit.py
+++ b/tests/cli/dorq/workflow/test_submit.py
@@ -420,54 +420,73 @@ class TestAction:
             presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
 
     class TestProjectResolve:
-        # Given
-        module = "my_wfs"
-        name = "sample_wf"
-        config = "cluster_z"
+        @pytest.mark.parametrize("workspace_support", [True, False])
+        def test_workspace_and_project_resolve(self, workspace_support):
+            # Given
+            module = "my_wfs"
+            name = "sample_wf"
+            config = "cluster_z"
 
-        prompter = create_autospec(_prompts.Prompter)
-        presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            prompter = create_autospec(_prompts.Prompter)
+            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
 
-        wf_run_id = "wf.test"
-        wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
-        # submit() doesn't raise = no effect of the "--force" flag
-        wf_run_repo.submit.return_value = wf_run_id
+            wf_run_id = "wf.test"
+            wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
+            # submit() doesn't raise = no effect of the "--force" flag
+            wf_run_repo.submit.return_value = wf_run_id
 
-        wf_def_repo = create_autospec(_repos.WorkflowDefRepo)
-        wf_def_repo.get_module_from_spec.return_value = module
-        wf_def_sentinel = "<wf def sentinel>"
-        wf_def_repo.get_workflow_def.return_value = wf_def_sentinel
+            wf_def_repo = create_autospec(_repos.WorkflowDefRepo)
+            wf_def_repo.get_module_from_spec.return_value = module
+            wf_def_sentinel = "<wf def sentinel>"
+            wf_def_repo.get_workflow_def.return_value = wf_def_sentinel
 
-        spaces_resolver = create_autospec(SpacesResolver)
-        spaces_resolver.resolve_workspace_id.return_value = "resolved_ws"
-        spaces_resolver.resolve_project_id.return_value = "resolved_project"
+            spaces_resolver = create_autospec(SpacesResolver)
+            if workspace_support:
+                spaces_resolver.resolve_workspace_id.return_value = "resolved_ws"
+                spaces_resolver.resolve_project_id.return_value = "resolved_project"
+            else:
+                spaces_resolver.resolve_workspace_id.side_effect = (
+                    exceptions.WorkspacesNotSupportedError()
+                )
+                spaces_resolver.resolve_project_id.side_effect = (
+                    exceptions.WorkspacesNotSupportedError()
+                )
 
-        action = _submit.Action(
-            prompter=prompter,
-            presenter=presenter,
-            wf_run_repo=wf_run_repo,
-            wf_def_repo=wf_def_repo,
-            spaces_resolver=spaces_resolver,
-        )
+            action = _submit.Action(
+                prompter=prompter,
+                presenter=presenter,
+                wf_run_repo=wf_run_repo,
+                wf_def_repo=wf_def_repo,
+                spaces_resolver=spaces_resolver,
+            )
 
-        # When
-        action.on_cmd_call(module, name, config, None, None, False)
+            # When
+            action.on_cmd_call(module, name, config, None, None, False)
 
-        # Then
-        # We don't expect prompts.
-        prompter.choice.assert_not_called()
+            # Then
+            # We don't expect prompts.
+            prompter.choice.assert_not_called()
 
-        # We expect getting workflow def from the module.
-        wf_def_repo.get_workflow_def.assert_called_with(module, name)
+            # We expect getting workflow def from the module.
+            wf_def_repo.get_workflow_def.assert_called_with(module, name)
 
-        # We expect submitting the retrieved wf def to the passed config cluster.
-        wf_run_repo.submit.assert_called_with(
-            wf_def_sentinel,
-            config,
-            ignore_dirty_repo=False,
-            workspace_id="resolved_ws",
-            project_id="resolved_project",
-        )
+            # We expect submitting the retrieved wf def to the passed config cluster.
+            if workspace_support:
+                wf_run_repo.submit.assert_called_with(
+                    wf_def_sentinel,
+                    config,
+                    ignore_dirty_repo=False,
+                    workspace_id="resolved_ws",
+                    project_id="resolved_project",
+                )
+            else:
+                wf_run_repo.submit.assert_called_with(
+                    wf_def_sentinel,
+                    config,
+                    ignore_dirty_repo=False,
+                    workspace_id=None,
+                    project_id=None,
+                )
 
-        # We expect telling the user the wf run ID.
-        presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+            # We expect telling the user the wf run ID.
+            presenter.show_submitted_wf_run.assert_called_with(wf_run_id)

--- a/tests/cli/dorq/workflow/test_submit.py
+++ b/tests/cli/dorq/workflow/test_submit.py
@@ -461,7 +461,9 @@ class TestAction:
             )
 
             # When
-            action.on_cmd_call(module, name, config, None, None, False)
+            action.on_cmd_call(
+                module, name, config, workspace_id=None, project_id=None, force=False
+            )
 
             # Then
             # We don't expect prompts.

--- a/tests/sdk/v2/test_consistent_return_shapes.py
+++ b/tests/sdk/v2/test_consistent_return_shapes.py
@@ -810,18 +810,7 @@ class TestCLI:
         )
         results_ce = (
             subprocess.run(
-                [
-                    "orq",
-                    "wf",
-                    "results",
-                    "-c",
-                    "CE",
-                    mock_ce_run_multiple,
-                    "-w",
-                    "ws",
-                    "-p",
-                    "p",
-                ],
+                ["orq", "wf", "results", "-c", "CE", mock_ce_run_multiple],
                 check=True,
                 capture_output=True,
             )

--- a/tests/sdk/v2/test_consistent_return_shapes.py
+++ b/tests/sdk/v2/test_consistent_return_shapes.py
@@ -701,7 +701,7 @@ class TestCLI:
             capture_output=True,
         )
         run_ce = subprocess.run(
-            ["orq", "wf", "submit", "-c", "CE", "workflow_defs"],
+            ["orq", "wf", "submit", "-c", "CE", "workflow_defs", "-w", "ws", "-p", "p"],
             check=True,
             capture_output=True,
         )
@@ -776,7 +776,7 @@ class TestCLI:
             capture_output=True,
         )
         run_ce = subprocess.run(
-            ["orq", "wf", "submit", "-c", "CE", "workflow_defs"],
+            ["orq", "wf", "submit", "-c", "CE", "workflow_defs", "-w", "ws", "-p", "p"],
             check=True,
             capture_output=True,
         )
@@ -810,7 +810,18 @@ class TestCLI:
         )
         results_ce = (
             subprocess.run(
-                ["orq", "wf", "results", "-c", "CE", mock_ce_run_multiple],
+                [
+                    "orq",
+                    "wf",
+                    "results",
+                    "-c",
+                    "CE",
+                    mock_ce_run_multiple,
+                    "-w",
+                    "ws",
+                    "-p",
+                    "p",
+                ],
                 check=True,
                 capture_output=True,
             )
@@ -959,7 +970,7 @@ class TestCLIDownloadDir:
             capture_output=True,
         )
         subprocess.run(
-            ["orq", "wf", "submit", "-c", "CE", "workflow_defs"],
+            ["orq", "wf", "submit", "-c", "CE", "workflow_defs", "-w", "ws", "-p", "p"],
             check=True,
             capture_output=True,
         )


### PR DESCRIPTION
# The problem

All commands related to WF were printing for WS and Project, but submit command was left out

# This PR's solution

Prompt for WS and Project in orq wf submit

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
