### PR TITLE
docs: some .rst typos and missing link

### DIFF
--- a/docs/guides/workflow-runs.rst
+++ b/docs/guides/workflow-runs.rst
@@ -53,9 +53,9 @@ determines what runtime to use (in-process, local Ray, remote).
 In addition, a configuration contains details required for connection with the runtime, like cluster URL and auth token.
 
 The built-in configurations include:
-* ``in_process``. You can use it via ``sdk.RuntimeConfiguration.in_process()` or by passing `"in_process"` whenever config is required.
-* ``ray``. You can use it via ``sdk.RuntimeConfiguration.ray()` or by passing `"ray"` whenever config is required.
-Configurations for interaction with remote runtime are created by using the CLI for auth flow (<paste tutorial link here>).
+* ``in_process``. You can use it via ``sdk.RuntimeConfiguration.in_process()`` or by passing ``"in_process"`` whenever config is required.
+* ``ray``. You can use it via ``sdk.RuntimeConfiguration.ray()`` or by passing ``"ray"`` whenever config is required.
+Configurations for interaction with remote runtime are created by using the :ref:`CLI for auth flow<cli_remote_login>`.
 
 .. literalinclude:: ../examples/config_management.py
     :start-after: >> Tutorial code snippet: save config

--- a/docs/tutorials/remote.rst
+++ b/docs/tutorials/remote.rst
@@ -9,6 +9,8 @@ Prerequisites
 #. You've :doc:`installed Orquestra Workflow SDK<installing-macos-linux>`.
 #. You have access to remote QE cluster
 
+.. _cli_remote_login:
+
 Log In to Your Orquestra Account
 ================================
 


### PR DESCRIPTION
# The problem

This section currently renders as:
<img width="742" alt="image" src="https://github.com/zapatacomputing/orquestra-workflow-sdk/assets/24617178/5f3fc868-fc51-4ff1-a999-1fc8a9dc8ff1">


# This PR's solution

Updated to correct .rst-style inline code and added a link to the CLI Orquestra Login info. Let me know if there's a better place in the docs that link should go to

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
