### PR TITLE
feat: secret with workspaces in IR and GithubImport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
+* Secrets with workspaces now work inside workflow functions and for personal access tokens in `GithubImport`.
 
 💅 *Improvements*
 * Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -83,6 +83,9 @@ class Secret(NamedTuple):
     # This matches the behaviour of `sdk.secrets.get` where the config name is used to
     # get a secret when running locally.
     config_name: Optional[str] = None
+    # Workspace ID is used by local and remote runtimes to fetch a secret from a specfic
+    # workspace.
+    workspace_id: Optional[str] = None
 
 
 @dataclass(frozen=True, eq=True)

--- a/src/orquestra/sdk/_base/_git_url_utils.py
+++ b/src/orquestra/sdk/_base/_git_url_utils.py
@@ -41,7 +41,9 @@ def build_git_url(url: GitURL, protocol_override: Optional[str] = None) -> str:
     # Dereference secret used as password
     if url.password is not None:
         secret = secrets.get(
-            url.password.secret_name, config_name=url.password.secret_config
+            url.password.secret_name,
+            config_name=url.password.secret_config,
+            workspace_id=url.password.workspace_id,
         )
         password = f":{secret}"
     else:

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -151,7 +151,9 @@ class InProcessRuntime(abc.RuntimeInterface):
         }
         for id, secret in workflow_def.secret_nodes.items():
             consts[id] = secrets.get(
-                secret.secret_name, config_name=secret.secret_config
+                secret.secret_name,
+                config_name=secret.secret_config,
+                workspace_id=secret.workspace_id,
             )
         # We'll store artifacts for this run here.
         self._artifact_store[run_id] = {}

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -295,7 +295,9 @@ def parametrized_wf(a: int):
 
 @sdk.workflow
 def wf_with_secrets():
-    secret = sdk.secrets.get("some-secret", config_name="test_config_default")
+    secret = sdk.secrets.get(
+        "some-secret", config_name="test_config_default", workspace_id="test_workspace"
+    )
     return capitalize_inline(secret)
 
 

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -258,6 +258,7 @@ class GraphTraversal:
                     id=f"secret-{secret_counter}",
                     secret_name=n.name,
                     secret_config=n.config_name,
+                    workspace_id=n.workspace_id,
                 )
                 secret_counter += 1
             else:
@@ -402,6 +403,7 @@ def _make_import_model(imp: _dsl.Import):
                 id=f"secret-{id_}",
                 secret_name=imp.auth_secret.name,
                 secret_config=imp.auth_secret.config_name,
+                workspace_id=imp.auth_secret.workspace_id,
             )
         return ir.GitImport(
             id=id_,

--- a/src/orquestra/sdk/_base/dispatch.py
+++ b/src/orquestra/sdk/_base/dispatch.py
@@ -252,7 +252,10 @@ def exec_task_fn(
                 embedded_value = serde.value_from_result_dict(yaml_value)
                 keyword_args[yaml_input_name] = embedded_value
             elif isinstance(yaml_value, t.Mapping) and SECRET_MAGIC_KEY in yaml_value:
-                embedded_value = secrets.get(yaml_value[SECRET_MAGIC_KEY])
+                embedded_value = secrets.get(
+                    yaml_value[SECRET_MAGIC_KEY],
+                    workspace_id=yaml_value.get("workspace_id"),
+                )
                 keyword_args[yaml_input_name] = embedded_value
 
         # --- Phase 2.3: make some **kwargs work as *args ---

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -118,7 +118,11 @@ class ArgumentUnwrapper:
             return serde.deserialize(arg) if self._deserialize else arg
         elif isinstance(arg, ir.SecretNode):
             return (
-                secrets.get(arg.secret_name, config_name=arg.secret_config)
+                secrets.get(
+                    arg.secret_name,
+                    config_name=arg.secret_config,
+                    workspace_id=arg.workspace_id,
+                )
                 if self._deserialize
                 else arg
             )

--- a/src/orquestra/sdk/schema/ir.py
+++ b/src/orquestra/sdk/schema/ir.py
@@ -34,6 +34,10 @@ class SecretNode(BaseModel):
     # runtimes.
     secret_config: t.Optional[str] = None
 
+    # Workspace ID
+    # This is used locally and remotely to get a secret from a specific workspace
+    workspace_id: t.Optional[str] = None
+
 
 class GitURL(BaseModel):
     original_url: str

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -51,7 +51,10 @@ def get(
             secret at execution time.
     """
     if _exec_ctx.global_context == _exec_ctx.ExecContext.WORKFLOW_BUILD:
-        return t.cast(str, _dsl.Secret(name=name, config_name=config_name))
+        return t.cast(
+            str,
+            _dsl.Secret(name=name, config_name=config_name, workspace_id=workspace_id),
+        )
 
     try:
         client = _auth.authorized_client(config_name)

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -332,7 +332,7 @@ class TestArgumentUnwrapper:
 
             # Then
             mock_secret_get.assert_called_with(
-                secret_node.secret_name, config_name=None
+                secret_node.secret_name, config_name=None, workspace_id=None
             )
             fn.assert_called_with(expected_arg)
 

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -385,7 +385,10 @@ class TestTaskRun:
                     "wf_single_task_with_secret_parent",
                     [
                         ir.SecretNode(
-                            id="secret-0", secret_name="test", secret_config=None
+                            id="secret-0",
+                            secret_name="test",
+                            secret_config=None,
+                            workspace_id=None,
                         )
                     ],
                     {},

--- a/tests/sdk/v2/test_git_url_utils.py
+++ b/tests/sdk/v2/test_git_url_utils.py
@@ -85,8 +85,12 @@ class TestBuildGitURL:
 
         secret_name = "my_secret"
         secret_config = "secret config"
+        secret_workspace = "secret workspace"
         git_url.password = SecretNode(
-            id="mocked secret", secret_name=secret_name, secret_config=secret_config
+            id="mocked secret",
+            secret_name=secret_name,
+            secret_config=secret_config,
+            workspace_id=secret_workspace,
         )
 
         url = _git_url_utils.build_git_url(git_url)
@@ -94,7 +98,9 @@ class TestBuildGitURL:
             "https://git:<mocked secret>@github.com"
             "/zapatacomputing/orquestra-workflow-sdk"
         )
-        secrets_get.assert_called_once_with(secret_name, config_name=secret_config)
+        secrets_get.assert_called_once_with(
+            secret_name, config_name=secret_config, workspace_id=secret_workspace
+        )
 
     def test_unknown_protocol_in_original(self, git_url: GitURL):
         git_url.original_url = "custom_protocol://<blah>"


### PR DESCRIPTION
# The problem

We missed some places where secrets can be used when adding workspace support.

# This PR's solution

* Update `orquestra.sdk.Secret` to take `workspace_id` as an argument.
* Update `orquestra.sdk.schema.ir.SecretNode` to take `workspace_id` as an argument.
* Update in-process runtime to handle `workspace_id`.
* Update Ray runtime to handle `workspace_id`.
* Update graph traversal to handle `workspace_id`.
* Update in-workflow `orquestra.sdk.secrets.get()` handle `workspace_id`.
* Update `dispatch.py` to handle `workspace_id`.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
