### PR TITLE
refactor!: logs datastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 🚨 *Breaking Changes*
+* `WorkflowRun.get_logs()` now returns a data structure with logs split into categories.
 
 🔥 *Features*
 * Add .project property to WorkflowRun to get the info about workspace and project of running workflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ exclude_lines = [
   "raise NotImplementedError",
   "if __name__ == .__main__.:",
   "assert_never",
-  "...",
 ]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ exclude_lines = [
   "raise NotImplementedError",
   "if __name__ == .__main__.:",
   "assert_never",
+  "...",
 ]
 
 [tool.pytest.ini_options]

--- a/src/orquestra/sdk/__init__.py
+++ b/src/orquestra/sdk/__init__.py
@@ -27,6 +27,7 @@ from ._base._dsl import (
     task,
 )
 from ._base._log_adapter import wfprint, workflow_logger
+from ._base._logs._interfaces import WorkflowLogs
 from ._base._spaces._api import list_projects, list_workspaces
 from ._base._spaces._structs import Project, ProjectRef, Workspace
 from ._base._workflow import NotATaskWarning, WorkflowDef, WorkflowTemplate, workflow
@@ -48,6 +49,7 @@ __all__ = [
     "TaskDef",
     "TaskRun",
     "WorkflowDef",
+    "WorkflowLogs",
     "WorkflowRun",
     "WorkflowTemplate",
     "list_workflow_runs",

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -29,9 +29,9 @@ from ...schema.workflow_run import ProjectId, State
 from ...schema.workflow_run import WorkflowRun as WorkflowRunModel
 from ...schema.workflow_run import WorkflowRunId, WorkflowRunMinimal, WorkspaceId
 from .. import serde
+from .._logs._interfaces import WorkflowLogs
 from .._spaces._resolver import resolve_studio_project_ref
 from ..abc import RuntimeInterface
-from .._logs._interfaces import WorkflowLogs
 from ._config import RuntimeConfig, _resolve_config
 from ._task_run import TaskRun
 

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -25,12 +25,13 @@ from ...exceptions import (
 from ...schema import ir
 from ...schema.configs import ConfigName
 from ...schema.local_database import StoredWorkflowRun
-from ...schema.workflow_run import ProjectId, State, TaskInvocationId
+from ...schema.workflow_run import ProjectId, State
 from ...schema.workflow_run import WorkflowRun as WorkflowRunModel
 from ...schema.workflow_run import WorkflowRunId, WorkflowRunMinimal, WorkspaceId
 from .. import serde
 from .._spaces._resolver import resolve_studio_project_ref
 from ..abc import RuntimeInterface
+from .._logs._interfaces import WorkflowLogs
 from ._config import RuntimeConfig, _resolve_config
 from ._task_run import TaskRun
 
@@ -359,19 +360,12 @@ class WorkflowRun:
             for inv_id, inv_output in inv_outputs.items()
         }
 
-    def get_logs(self) -> t.Mapping[TaskInvocationId, t.List[str]]:
+    def get_logs(self) -> WorkflowLogs:
         """
         Unstable: this API will change.
 
-        Returns logs produced by all task runs in this workflow. If you're interested in
-        only subset of tasks, consider using ``WorkflowRun.get_tasks()`` and
-        ``TaskRun.get_logs()``.
-
-        Returns:
-            A dictionary where each key-value entry corresponds to a single task run.
-            The key identifies a task invocation, a single node in the workflow graph.
-            The value is a list of log lines produced by the corresponding task
-            invocation while running this workflow.
+        Returns logs produced this workflow. See ``WorkflowLogs`` attributes for log
+        categories or ``TaskRun.get_logs()`` for logs related to only a single task.
         """
         return self._runtime.get_workflow_logs(wf_run_id=self.run_id)
 

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -11,8 +11,8 @@ from typing import Dict, List, Optional, Sequence, Union
 
 from orquestra.sdk import Project, ProjectRef, Workspace, exceptions
 from orquestra.sdk._base import _retry, serde
-from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._db import WorkflowDB
+from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base.abc import RuntimeInterface
 from orquestra.sdk.kubernetes.quantity import parse_quantity
 from orquestra.sdk.schema.configs import RuntimeConfiguration

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -11,6 +11,7 @@ from typing import Dict, List, Optional, Sequence, Union
 
 from orquestra.sdk import Project, ProjectRef, Workspace, exceptions
 from orquestra.sdk._base import _retry, serde
+from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._db import WorkflowDB
 from orquestra.sdk._base.abc import RuntimeInterface
 from orquestra.sdk.kubernetes.quantity import parse_quantity
@@ -418,11 +419,9 @@ class CERuntime(RuntimeInterface):
 
         return runs
 
-    def get_workflow_logs(
-        self, wf_run_id: WorkflowRunId
-    ) -> Dict[TaskInvocationId, List[str]]:
+    def get_workflow_logs(self, wf_run_id: WorkflowRunId) -> WorkflowLogs:
         """
-        Get the workflow logs.
+        Get all logs produced during the execution of this workflow run.
 
         Args:
             wf_run_id: the ID of a workflow run
@@ -431,10 +430,6 @@ class CERuntime(RuntimeInterface):
             WorkflowRunNotFound: if the workflow run cannot be found
             UnauthorizedError: if the remote cluster rejects the token
             ...
-
-        Returns:
-            A dictionary whose keys are the task invocation ids, and whose values are a
-                list of log lines corresponding to that invocation.
         """
         try:
             logs: List[str] = self._client.get_workflow_run_logs(wf_run_id)
@@ -453,7 +448,10 @@ class CERuntime(RuntimeInterface):
                 "Please report this as a bug."
             ) from e
 
-        return {"UNKNOWN TASK INV ID": logs}
+        return WorkflowLogs(
+            per_task={"UNKNOWN TASK INV ID": logs},
+            env_setup=[],
+        )
 
     def get_task_logs(self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId):
         raise NotImplementedError()

--- a/src/orquestra/sdk/_base/_logs/_interfaces.py
+++ b/src/orquestra/sdk/_base/_logs/_interfaces.py
@@ -7,9 +7,8 @@ Logs-related interfaces.
 import typing as t
 from dataclasses import dataclass
 
-from orquestra.sdk.schema.workflow_run import WorkflowRunId
-
 from orquestra.sdk.schema.ir import TaskInvocationId
+from orquestra.sdk.schema.workflow_run import WorkflowRunId
 
 
 @dataclass(frozen=True)

--- a/src/orquestra/sdk/_base/_logs/_interfaces.py
+++ b/src/orquestra/sdk/_base/_logs/_interfaces.py
@@ -1,0 +1,44 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Logs-related interfaces.
+"""
+import typing as t
+
+from orquestra.sdk.schema.workflow_run import WorkflowRunId
+
+from orquestra.sdk.schema.ir import TaskInvocationId
+
+
+class LogReader(t.Protocol):
+    """
+    A component that reads logs produced by tasks and workflows.
+    """
+
+    def get_task_logs(
+        self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId
+    ) -> t.List[str]:
+        """
+        Reads all available logs, specific to a single task invocation/run.
+
+        Returns:
+            Log lines printed when running this task invocation. If the task didn't
+            produce any logs this should be an empty list.
+        """
+        ...
+
+    def get_workflow_logs(
+        self, wf_run_id: WorkflowRunId
+    ) -> t.Dict[TaskInvocationId, t.List[str]]:
+        """
+        Reads all available logs printed during execution of this workflow run.
+
+        Returns:
+            A mapping with task logs. Each key-value pair corresponds to one task
+            invocation.
+            - key: task invocation ID (see
+                orquestra.sdk._base.ir.WorkflowDef.task_invocations)
+            - value: log lines from running this task invocation
+        """
+        ...

--- a/src/orquestra/sdk/_base/_logs/_interfaces.py
+++ b/src/orquestra/sdk/_base/_logs/_interfaces.py
@@ -5,10 +5,25 @@
 Logs-related interfaces.
 """
 import typing as t
+from dataclasses import dataclass
 
 from orquestra.sdk.schema.workflow_run import WorkflowRunId
 
 from orquestra.sdk.schema.ir import TaskInvocationId
+
+
+@dataclass(frozen=True)
+class WorkflowLogs:
+    per_task: t.Mapping[TaskInvocationId, t.Sequence[str]]
+    """
+    A mapping with task logs. Each key-value pair corresponds to one task
+    invocation.
+    - key: task invocation ID (see
+        orquestra.sdk._base.ir.WorkflowDef.task_invocations)
+    - value: log lines from running this task invocation
+    """
+
+    env_setup: t.Sequence[str]
 
 
 class LogReader(t.Protocol):
@@ -28,17 +43,8 @@ class LogReader(t.Protocol):
         """
         ...
 
-    def get_workflow_logs(
-        self, wf_run_id: WorkflowRunId
-    ) -> t.Dict[TaskInvocationId, t.List[str]]:
+    def get_workflow_logs(self, wf_run_id: WorkflowRunId) -> WorkflowLogs:
         """
         Reads all available logs printed during execution of this workflow run.
-
-        Returns:
-            A mapping with task logs. Each key-value pair corresponds to one task
-            invocation.
-            - key: task invocation ID (see
-                orquestra.sdk._base.ir.WorkflowDef.task_invocations)
-            - value: log lines from running this task invocation
         """
         ...

--- a/src/orquestra/sdk/_base/_logs/_interfaces.py
+++ b/src/orquestra/sdk/_base/_logs/_interfaces.py
@@ -32,7 +32,7 @@ class LogReader(t.Protocol):
 
     def get_task_logs(
         self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId
-    ) -> t.List[str]:
+    ) -> t.List[str]:  # pragma: no cover
         """
         Reads all available logs, specific to a single task invocation/run.
 
@@ -40,9 +40,12 @@ class LogReader(t.Protocol):
             Log lines printed when running this task invocation. If the task didn't
             produce any logs this should be an empty list.
         """
+        # pragma: no cover
         ...
 
-    def get_workflow_logs(self, wf_run_id: WorkflowRunId) -> WorkflowLogs:
+    def get_workflow_logs(
+        self, wf_run_id: WorkflowRunId
+    ) -> WorkflowLogs:  # pragma: no cover
         """
         Reads all available logs printed during execution of this workflow run.
         """

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -808,7 +808,7 @@ class QERuntime(RuntimeInterface):
         # At the moment we don't have a clear way to separate the env setup vs task logs
         # and we probably won't implement it. QE is going to be deprecated _soon_
         # anyway.
-        env_logs = []
+        env_logs: List[str] = []
         return WorkflowLogs(per_task=task_logs, env_setup=env_logs)
 
     def stop_workflow_run(self, run_id: WorkflowRunId) -> None:

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -178,22 +178,6 @@ class RuntimeInterface(ABC):
         """
         raise NotImplementedError()
 
-    def get_task_logs(
-        self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId
-    ) -> t.List[str]:
-        """
-        See LogReader.get_task_logs()
-        """
-        raise NotImplementedError()
-
-    def get_workflow_logs(
-        self, wf_run_id: WorkflowRunId
-    ) -> t.Dict[TaskInvocationId, t.List[str]]:
-        """
-        See LogReader.get_task_logs()
-        """
-        raise NotImplementedError()
-
     @abstractmethod
     def get_workflow_project(self, wf_run_id: WorkflowRunId):
         """

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -31,39 +31,6 @@ from orquestra.sdk.schema.workflow_run import (
 )
 
 
-class LogReader(t.Protocol):
-    """
-    A component that reads logs produced by tasks and workflows.
-    """
-
-    def get_task_logs(
-        self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId
-    ) -> t.List[str]:
-        """
-        Reads all available logs, specific to a single task invocation/run.
-
-        Returns:
-            Log lines printed when running this task invocation. If the task didn't
-            produce any logs this should be an empty list.
-        """
-        ...
-
-    def get_workflow_logs(
-        self, wf_run_id: WorkflowRunId
-    ) -> t.Dict[TaskInvocationId, t.List[str]]:
-        """
-        Reads all available logs printed during execution of this workflow run.
-
-        Returns:
-            A mapping with task logs. Each key-value pair corresponds to one task
-            invocation.
-            - key: task invocation ID (see
-                orquestra.sdk._base.ir.WorkflowDef.task_invocations)
-            - value: log lines from running this task invocation
-        """
-        ...
-
-
 # A typealias that hints where we expect raw artifact values.
 ArtifactValue = t.Any
 

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -15,13 +15,14 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 from pathlib import Path
 
-from orquestra.sdk._base._spaces._structs import Project, ProjectRef, Workspace
-from orquestra.sdk.exceptions import WorkspacesNotSupportedError
-from orquestra.sdk.schema.configs import RuntimeConfiguration
-from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
-from orquestra.sdk.schema.local_database import StoredWorkflowRun
-from orquestra.sdk.schema.responses import WorkflowResult
-from orquestra.sdk.schema.workflow_run import (
+from ._logs._interfaces import LogReader, WorkflowLogs
+from ._spaces._structs import Project, ProjectRef, Workspace
+from ..exceptions import WorkspacesNotSupportedError
+from ..schema.configs import RuntimeConfiguration
+from ..schema.ir import TaskInvocationId, WorkflowDef
+from ..schema.local_database import StoredWorkflowRun
+from ..schema.responses import WorkflowResult
+from ..schema.workflow_run import (
     ProjectId,
     State,
     WorkflowRun,
@@ -34,7 +35,7 @@ from orquestra.sdk.schema.workflow_run import (
 ArtifactValue = t.Any
 
 
-class RuntimeInterface(ABC):
+class RuntimeInterface(ABC, LogReader):
     """
     The main abstraction for managing Orquestra workflows. Allows swapping the
     implementations related to local vs remote runs.
@@ -162,6 +163,16 @@ class RuntimeInterface(ABC):
         List workspaces available to a user. Works only on CE
         """
         raise WorkspacesNotSupportedError()
+
+    @abstractmethod
+    def get_task_logs(
+        self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId
+    ) -> t.List[str]:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def get_workflow_logs(self, wf_run_id: WorkflowRunId) -> WorkflowLogs:
+        raise NotImplementedError()
 
 
 class WorkflowRepo(ABC):

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -15,8 +15,6 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 from pathlib import Path
 
-from ._logs._interfaces import LogReader, WorkflowLogs
-from ._spaces._structs import Project, ProjectRef, Workspace
 from ..exceptions import WorkspacesNotSupportedError
 from ..schema.configs import RuntimeConfiguration
 from ..schema.ir import TaskInvocationId, WorkflowDef
@@ -30,6 +28,8 @@ from ..schema.workflow_run import (
     WorkflowRunMinimal,
     WorkspaceId,
 )
+from ._logs._interfaces import LogReader, WorkflowLogs
+from ._spaces._structs import Project, ProjectRef, Workspace
 
 # A typealias that hints where we expect raw artifact values.
 ArtifactValue = t.Any

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -30,7 +30,6 @@ from orquestra.sdk.schema.workflow_run import (
     WorkspaceId,
 )
 
-
 # A typealias that hints where we expect raw artifact values.
 ArtifactValue = t.Any
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -390,9 +390,11 @@ class WorkflowRunRepo:
             # While this method can also raise WorkflowRunNotStarted error we don't ever
             # expect it to happen, because we're getting workflow run by ID. Workflows
             # get their IDs at the start time.
-            return wf_run.get_logs()
+            logs = wf_run.get_logs()
         except (ConnectionError, exceptions.UnauthorizedError):
             raise
+
+        return logs.per_task
 
     def get_task_logs(
         self,

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -24,9 +24,9 @@ from .. import exceptions
 from .._base import _services, serde
 from .._base._db import WorkflowDB
 from .._base._env import RAY_GLOBAL_WF_RUN_ID_ENV
+from .._base._logs._interfaces import LogReader
 from .._base._spaces._structs import ProjectRef
 from .._base.abc import RuntimeInterface
-from .._base._logs._interfaces import LogReader
 from ..schema import ir
 from ..schema.configs import RuntimeConfiguration
 from ..schema.local_database import StoredWorkflowRun

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -25,7 +25,8 @@ from .._base import _services, serde
 from .._base._db import WorkflowDB
 from .._base._env import RAY_GLOBAL_WF_RUN_ID_ENV
 from .._base._spaces._structs import ProjectRef
-from .._base.abc import LogReader, RuntimeInterface
+from .._base.abc import RuntimeInterface
+from .._base._logs._interfaces import LogReader
 from ..schema import ir
 from ..schema.configs import RuntimeConfiguration
 from ..schema.local_database import StoredWorkflowRun

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -144,7 +144,7 @@ class DirectRayReader:
 
         # TODO: read env setup logs for local Ray
         # https://zapatacomputing.atlassian.net/browse/ORQSDK-643
-        env_setup = []
+        env_setup: t.List[str] = []
 
         return WorkflowLogs(
             per_task=logs_dict,

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -21,6 +21,7 @@ from orquestra.sdk import exceptions
 from orquestra.sdk._base import _db
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._qe._client import QEClient
+from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base._testing import _example_wfs
 from orquestra.sdk._base.cli._dorq import _repos
@@ -725,7 +726,7 @@ class TestWorkflowRunRepo:
                     "inv2": ["and another one"],
                 }
 
-                mock_wf_run.get_logs.return_value = logs_dict
+                mock_wf_run.get_logs.return_value = WorkflowLogs(per_task=logs_dict, env_setup=[])
 
                 repo = _repos.WorkflowRunRepo()
 

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -20,8 +20,8 @@ from orquestra import sdk
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _db
 from orquestra.sdk._base._driver._client import DriverClient
-from orquestra.sdk._base._qe._client import QEClient
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
+from orquestra.sdk._base._qe._client import QEClient
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base._testing import _example_wfs
 from orquestra.sdk._base.cli._dorq import _repos
@@ -726,7 +726,9 @@ class TestWorkflowRunRepo:
                     "inv2": ["and another one"],
                 }
 
-                mock_wf_run.get_logs.return_value = WorkflowLogs(per_task=logs_dict, env_setup=[])
+                mock_wf_run.get_logs.return_value = WorkflowLogs(
+                    per_task=logs_dict, env_setup=[]
+                )
 
                 repo = _repos.WorkflowRunRepo()
 

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -21,8 +21,8 @@ from orquestra.sdk._base._conversions._yaml_exporter import (
     pydantic_to_yaml,
     workflow_to_yaml,
 )
-from orquestra.sdk._base._qe import _qe_runtime
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
+from orquestra.sdk._base._qe import _qe_runtime
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base._testing._example_wfs import my_workflow
 from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -22,6 +22,7 @@ from orquestra.sdk._base._conversions._yaml_exporter import (
     workflow_to_yaml,
 )
 from orquestra.sdk._base._qe import _qe_runtime
+from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base._testing._example_wfs import my_workflow
 from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
@@ -1047,16 +1048,19 @@ class TestGetWorkflowLogs:
         logs = runtime.get_workflow_logs(wf_run_id)
 
         # Then
-        assert logs == {
-            "invocation-1-task-multi-output-test": [
-                "a couple of mocked out lines",
-                "joined with newline separator",
-            ],
-            "invocation-0-task-make-greeting-message": [
-                "a couple of mocked out lines",
-                "joined with newline separator",
-            ],
-        }
+        assert logs == WorkflowLogs(
+            per_task={
+                "invocation-1-task-multi-output-test": [
+                    "a couple of mocked out lines",
+                    "joined with newline separator",
+                ],
+                "invocation-0-task-make-greeting-message": [
+                    "a couple of mocked out lines",
+                    "joined with newline separator",
+                ],
+            },
+            env_setup=[],
+        )
 
     def test_invalid_id(self, monkeypatch, runtime, mocked_responses):
         _get_workflow_run = Mock(side_effect=exceptions.NotFoundError)

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -308,7 +308,12 @@ class TestDirectRayReader:
         @pytest.mark.parametrize(
             "wf_run_id,parsed_logs,expected",
             [
-                pytest.param("wf.1", [], WorkflowLogs(per_task={}, env_setup=[]), id="no_parsed_logs"),
+                pytest.param(
+                    "wf.1",
+                    [],
+                    WorkflowLogs(per_task={}, env_setup=[]),
+                    id="no_parsed_logs",
+                ),
                 pytest.param(
                     "wf.1",
                     [

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -11,6 +11,7 @@ from unittest.mock import Mock
 import pytest
 
 from orquestra.sdk._ray import _ray_logs
+from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 
 INFO_LOG = _ray_logs.WFLog(
     timestamp=datetime(2023, 2, 9, 11, 26, 7, 98413, tzinfo=timezone.utc),
@@ -307,7 +308,7 @@ class TestDirectRayReader:
         @pytest.mark.parametrize(
             "wf_run_id,parsed_logs,expected",
             [
-                pytest.param("wf.1", [], {}, id="no_parsed_logs"),
+                pytest.param("wf.1", [], WorkflowLogs({}, []), id="no_parsed_logs"),
                 pytest.param(
                     "wf.1",
                     [
@@ -339,15 +340,18 @@ class TestDirectRayReader:
                             task_run_id="wf.1@inv2",
                         ),
                     ],
-                    {
-                        "inv1": [
-                            '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf.1", "task_inv_id": "inv1", "task_run_id": "wf.1@inv1"}',  # noqa: E501
-                            '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "general kenobi!", "wf_run_id": "wf.1", "task_inv_id": "inv1", "task_run_id": "wf.1@inv1"}',  # noqa: E501
-                        ],
-                        "inv2": [
-                            '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "and another one", "wf_run_id": "wf.1", "task_inv_id": "inv2", "task_run_id": "wf.1@inv2"}',  # noqa: E501
-                        ],
-                    },
+                    WorkflowLogs(
+                        {
+                            "inv1": [
+                                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "hello there!", "wf_run_id": "wf.1", "task_inv_id": "inv1", "task_run_id": "wf.1@inv1"}',  # noqa: E501
+                                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "general kenobi!", "wf_run_id": "wf.1", "task_inv_id": "inv1", "task_run_id": "wf.1@inv1"}',  # noqa: E501
+                            ],
+                            "inv2": [
+                                '{"timestamp": "2023-02-09T11:26:07.099382+00:00", "level": "INFO", "filename": "_log_adapter.py:138", "message": "and another one", "wf_run_id": "wf.1", "task_inv_id": "inv2", "task_run_id": "wf.1@inv2"}',  # noqa: E501
+                            ],
+                        },
+                        [],
+                    ),
                     id="matching_wf_run",
                 ),
                 pytest.param(
@@ -363,7 +367,7 @@ class TestDirectRayReader:
                             task_run_id=None,
                         )
                     ],
-                    {},
+                    WorkflowLogs({}, []),
                     id="no_task_ids",
                 ),
                 pytest.param(
@@ -379,7 +383,7 @@ class TestDirectRayReader:
                             task_run_id="wf.2@inv2",
                         )
                     ],
-                    {},
+                    WorkflowLogs({}, []),
                     id="other_wf_run",
                 ),
             ],

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -308,7 +308,7 @@ class TestDirectRayReader:
         @pytest.mark.parametrize(
             "wf_run_id,parsed_logs,expected",
             [
-                pytest.param("wf.1", [], WorkflowLogs({}, []), id="no_parsed_logs"),
+                pytest.param("wf.1", [], WorkflowLogs(per_task={}, env_setup=[]), id="no_parsed_logs"),
                 pytest.param(
                     "wf.1",
                     [
@@ -367,7 +367,7 @@ class TestDirectRayReader:
                             task_run_id=None,
                         )
                     ],
-                    WorkflowLogs({}, []),
+                    WorkflowLogs(per_task={}, env_setup=[]),
                     id="no_task_ids",
                 ),
                 pytest.param(
@@ -383,7 +383,7 @@ class TestDirectRayReader:
                             task_run_id="wf.2@inv2",
                         )
                     ],
-                    WorkflowLogs({}, []),
+                    WorkflowLogs(per_task={}, env_setup=[]),
                     id="other_wf_run",
                 ),
             ],

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -10,8 +10,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from orquestra.sdk._ray import _ray_logs
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
+from orquestra.sdk._ray import _ray_logs
 
 INFO_LOG = _ray_logs.WFLog(
     timestamp=datetime(2023, 2, 9, 11, 26, 7, 98413, tzinfo=timezone.utc),

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -735,12 +735,12 @@ class TestDirectRayReader:
         reader = _ray_logs.DirectRayReader(Path(ray_params._temp_dir))
 
         # When
-        logs_dict = reader.get_workflow_logs(wf_run_id=wf_run_id)
+        logs = reader.get_workflow_logs(wf_run_id=wf_run_id)
 
         # Then
         log_lines_joined = "".join(
             log_line
-            for task_log_lines in logs_dict.values()
+            for task_log_lines in logs.per_task.values()
             for log_line in task_log_lines
         )
 
@@ -793,13 +793,13 @@ def test_ray_direct_reader_no_duplicate_lines(
     _wait_to_finish_wf(run_id, runtime)
 
     # When
-    logs_dict = reader.get_workflow_logs(wf_run_id=run_id)
+    logs = reader.get_workflow_logs(wf_run_id=run_id)
 
     # Then
     # First check for the tell_tale in all log lines
     matches = [
         tell_tale in log_line
-        for task_log_lines in logs_dict.values()
+        for task_log_lines in logs.per_task.values()
         for log_line in task_log_lines
     ]
 

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -12,8 +12,8 @@ import pytest
 
 import orquestra.sdk as sdk
 from orquestra.sdk._base import _api, _workflow, serde
-from orquestra.sdk._base.abc import RuntimeInterface
 from orquestra.sdk._base._logs._interfaces import LogReader
+from orquestra.sdk._base.abc import RuntimeInterface
 from orquestra.sdk._ray import _dag
 from orquestra.sdk.exceptions import TaskRunNotFound
 from orquestra.sdk.schema import ir

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -6,13 +6,14 @@ Tests for orquestra.sdk._base._api._task_run.
 """
 
 import typing as t
-from unittest.mock import MagicMock, Mock, create_autospec
+from unittest.mock import Mock, create_autospec
 
 import pytest
 
 import orquestra.sdk as sdk
 from orquestra.sdk._base import _api, _workflow, serde
 from orquestra.sdk._base.abc import RuntimeInterface
+from orquestra.sdk._base._logs._interfaces import LogReader
 from orquestra.sdk._ray import _dag
 from orquestra.sdk.exceptions import TaskRunNotFound
 from orquestra.sdk.schema import ir
@@ -40,7 +41,7 @@ class TestTaskRun:
     @staticmethod
     @pytest.fixture
     def mock_runtime(sample_wf_def):
-        runtime = MagicMock(RuntimeInterface)
+        runtime = create_autospec(RuntimeInterface)
 
         wf_def_model = sample_wf_def.model
         task_invs = list(wf_def_model.task_invocations.values())
@@ -50,17 +51,17 @@ class TestTaskRun:
             TaskRunModel(
                 id="task_run1",
                 invocation_id=task_invs[0].id,
-                status=RunStatus(state=State.SUCCEEDED),
+                status=RunStatus(state=State.SUCCEEDED, start_time=None, end_time=None),
             ),
             TaskRunModel(
                 id="task_run2",
                 invocation_id=task_invs[1].id,
-                status=RunStatus(state=State.FAILED),
+                status=RunStatus(state=State.FAILED, start_time=None, end_time=None),
             ),
             TaskRunModel(
                 id="task_run3",
                 invocation_id=task_invs[2].id,
-                status=RunStatus(state=State.FAILED),
+                status=RunStatus(state=State.FAILED, start_time=None, end_time=None),
             ),
         ]
         runtime.get_workflow_run_status.return_value = wf_run_model
@@ -156,18 +157,21 @@ class TestTaskRun:
 
     class TestGetLogs:
         @staticmethod
-        def test_returns_plain_list(task_runs: t.Sequence[_api.TaskRun], mock_runtime):
+        def test_returns_plain_list(task_runs: t.Sequence[_api.TaskRun]):
             """
             Methods in RuntimeInterface return logs nested in dictionaries.
             _api.TaskRun.get_logs() should return a list of log lines.
             """
             # Given
-            mock_runtime.get_task_logs.side_effect = [
+            reader = create_autospec(LogReader)
+            reader.get_task_logs.side_effect = [
                 ["woohoo!"],
                 ["another", "line"],
                 # This task invocation was executed, but it produced no logs.
                 [],
             ]
+            for task_run in task_runs:
+                task_run._runtime = reader
 
             # When
             log_lists = [task_run.get_logs() for task_run in task_runs]
@@ -459,7 +463,7 @@ class TestTaskRun:
             # find the task with 1 arg and 1 kwarg. 2nd task that finished
             second_inv_2 = self._find_task_by_args_and_kwargs_number(1, 1, wf_def)
 
-            runtime = MagicMock(RuntimeInterface)
+            runtime = create_autospec(RuntimeInterface)
             runtime_outputs = {
                 first_inv_id: serde.result_from_artifact(15, ir.ArtifactFormat.AUTO),
                 second_inv_2: serde.result_from_artifact(25, ir.ArtifactFormat.AUTO),
@@ -504,7 +508,7 @@ class TestTaskRun:
             # find the task with 1 arg and 1 kwarg args. 2nd task with that finished
             second_inv_id = self._find_task_by_args_and_kwargs_number(1, 0, wf_def)
 
-            runtime = MagicMock(RuntimeInterface)
+            runtime = create_autospec(RuntimeInterface)
             runtime_outputs = {
                 first_inv_id: serde.result_from_artifact(
                     (21, 36), ir.ArtifactFormat.AUTO

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -18,6 +18,7 @@ import pytest
 
 from orquestra.sdk._base import _api, _workflow, serde
 from orquestra.sdk._base._env import CURRENT_PROJECT_ENV, CURRENT_WORKSPACE_ENV
+from orquestra.sdk._base._logs._interfaces import LogReader, WorkflowLogs
 from orquestra.sdk._base._in_process_runtime import InProcessRuntime
 from orquestra.sdk._base._spaces._api import list_projects, list_workspaces
 from orquestra.sdk._base._spaces._structs import ProjectRef, Workspace
@@ -122,7 +123,14 @@ class TestWorkflowRun:
 
     @staticmethod
     @pytest.fixture
-    def mock_runtime(sample_wf_def):
+    def sample_task_inv_ids(sample_wf_def) -> t.List[ir.TaskInvocationId]:
+        wf_def_model = sample_wf_def.model
+        task_invs = wf_def_model.task_invocations.values()
+        return [inv.id for inv in task_invs]
+
+    @staticmethod
+    @pytest.fixture
+    def mock_runtime(sample_task_inv_ids):
         runtime = create_autospec(RuntimeInterface, name="runtime")
         # For getting workflow ID
         runtime.create_workflow_run.return_value = "wf_pass_tuple-1"
@@ -162,31 +170,22 @@ class TestWorkflowRun:
         runtime.get_workflow_project.return_value = ProjectRef(
             workspace_id="ws", project_id="proj"
         )
-        wf_def_model = sample_wf_def.model
-        task_invs = list(wf_def_model.task_invocations.values())
-        # Get logs, the runtime interface returns invocation IDs
-        runtime.get_workflow_logs.return_value = {
-            task_invs[0].id: ["woohoo!\n"],
-            task_invs[1].id: ["another\n", "line\n"],
-            # This task invocation was executed, but it produced no logs.
-            task_invs[2].id: [],
-            # There's also 4th task invocation in the workflow def, it wasn't executed
-            # yet, so we don't return it.
-        }
+        invs = sample_task_inv_ids
+
         running_wf_run_model.task_runs = [
             TaskRunModel(
                 id="task_run1",
-                invocation_id=task_invs[0].id,
+                invocation_id=invs[0],
                 status=RunStatus(state=State.SUCCEEDED),
             ),
             TaskRunModel(
                 id="task_run2",
-                invocation_id=task_invs[1].id,
+                invocation_id=invs[1],
                 status=RunStatus(state=State.FAILED),
             ),
             TaskRunModel(
                 id="task_run3",
-                invocation_id=task_invs[2].id,
+                invocation_id=invs[2],
                 status=RunStatus(state=State.FAILED),
             ),
         ]
@@ -568,17 +567,34 @@ class TestWorkflowRun:
 
     class TestGetLogs:
         @staticmethod
-        def test_happy_path(run):
+        def test_happy_path(run: _api.WorkflowRun, sample_task_inv_ids):
             # Given
+            invs = sample_task_inv_ids
+            log_reader = create_autospec(LogReader)
+            log_reader.get_workflow_logs.return_value = WorkflowLogs(
+                {
+                    invs[0]: ["woohoo!\n"],
+                    invs[1]: ["another\n", "line\n"],
+                    # This task invocation was executed, but it produced no logs.
+                    invs[2]: [],
+                    # There's also 4th task invocation in the workflow def, it wasn't
+                    # executed yet, so we don't return it.
+                },
+                [],
+            )
+
+            run._runtime = log_reader
+
             # When
             logs = run.get_logs()
 
             # Then
-            assert len(logs) == 3
+            assert len(logs.per_task) == 3
+
             expected_inv = "invocation-0-task-capitalize"
-            assert expected_inv in logs
-            assert len(logs[expected_inv]) == 1
-            assert logs[expected_inv][0] == "woohoo!\n"
+            assert expected_inv in logs.per_task
+            assert len(logs.per_task[expected_inv]) == 1
+            assert logs.per_task[expected_inv][0] == "woohoo!\n"
 
     class TestGetConfig:
         @staticmethod

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -18,8 +18,8 @@ import pytest
 
 from orquestra.sdk._base import _api, _workflow, serde
 from orquestra.sdk._base._env import CURRENT_PROJECT_ENV, CURRENT_WORKSPACE_ENV
-from orquestra.sdk._base._logs._interfaces import LogReader, WorkflowLogs
 from orquestra.sdk._base._in_process_runtime import InProcessRuntime
+from orquestra.sdk._base._logs._interfaces import LogReader, WorkflowLogs
 from orquestra.sdk._base._spaces._api import list_projects, list_workspaces
 from orquestra.sdk._base._spaces._structs import ProjectRef, Workspace
 from orquestra.sdk._base.abc import RuntimeInterface

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -8,6 +8,7 @@ import pytest
 
 from orquestra.sdk import Project, Workspace, exceptions
 from orquestra.sdk._base._driver import _ce_runtime, _client, _exceptions, _models
+from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._testing._example_wfs import (
     my_workflow,
     workflow_parametrised_with_resources,
@@ -1143,14 +1144,17 @@ class TestGetWorkflowLogs:
 
         # Then
         mocked_client.get_workflow_run_logs.assert_called_once_with(workflow_run_id)
-        assert logs == {
-            "UNKNOWN TASK INV ID": [
-                "<message sentinel 1>",
-                "<message sentinel 2>",
-                "<message sentinel 3>",
-                "<message sentinel 4>",
-            ]
-        }
+        assert logs == WorkflowLogs(
+            {
+                "UNKNOWN TASK INV ID": [
+                    "<message sentinel 1>",
+                    "<message sentinel 2>",
+                    "<message sentinel 3>",
+                    "<message sentinel 4>",
+                ]
+            },
+            [],
+        )
 
     @pytest.mark.parametrize(
         "exception, expected_exception",

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -1145,7 +1145,7 @@ class TestGetWorkflowLogs:
         # Then
         mocked_client.get_workflow_run_logs.assert_called_once_with(workflow_run_id)
         assert logs == WorkflowLogs(
-            {
+            per_task={
                 "UNKNOWN TASK INV ID": [
                     "<message sentinel 1>",
                     "<message sentinel 2>",
@@ -1153,7 +1153,7 @@ class TestGetWorkflowLogs:
                     "<message sentinel 4>",
                 ]
             },
-            [],
+            env_setup=[],
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
# The problem

There are multiple categories of logs we'll want to return. In the close future we'll implement returning venv setup logs, per task logs, and system logs. We'd like to parallelize working on the implementation, if possible.

# This PR's solution

* Changes the type returned from `WorkflowRun.get_logs()` from a [task invocation ID] ↔ [log lines] dict into a `WorkflowLogs` data structure.
* Moves the `LogReader` protocol to a separate file. I'm continuing a pattern for code organization we started recently with `orquestra.sdk._base._spaces` where we prefer to group our code by the "topic" or "concerns". Other differences like interfaces, utilities, etc are nested one level deeper.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/internal/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
