### PR TITLE
Internal: Use external URI when using auto config on cluster instead of internal one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 🐛 *Bug Fixes*
 * Secrets with workspaces now work inside workflow functions and for personal access tokens in `GithubImport`.
-* list_workspaces and list_projects work inside studio with `auto` config
+* `list_workspaces` and `list_projects` work inside studio with `auto` config
 
 💅 *Improvements*
 * Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly
 
 🥷 *Internal*
+* Use external URI to cluster when using `auto` config inside studio
 
 📃 *Docs*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,12 @@
 
 🐛 *Bug Fixes*
 * Secrets with workspaces now work inside workflow functions and for personal access tokens in `GithubImport`.
+* list_workspaces and list_projects work inside studio with `auto` config
 
 💅 *Improvements*
 * Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly
 
 🥷 *Internal*
-* Use external URI to cluster when using `auto` config inside studio
 
 📃 *Docs*
 

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -211,14 +211,13 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
 
     runtime_config = SPECIAL_CONFIG_NAME_DICT[config_name]
 
-    uri: str = ""
     try:
         uri = os.environ[CURRENT_CLUSTER_ENV]
     except KeyError:
         raise EnvironmentError(
             f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
             "Unable to deduce cluster's URI")
-
+    breakpoint()
     runtime_config.runtime_options = {
         "uri": uri,
         "token": passport_token,

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -212,12 +212,13 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
     runtime_config = SPECIAL_CONFIG_NAME_DICT[config_name]
 
     try:
-        uri = os.environ[CURRENT_CLUSTER_ENV]
+        path = os.environ[CURRENT_CLUSTER_ENV]
     except KeyError:
         raise EnvironmentError(
             f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
             "Unable to deduce cluster's URI")
-    breakpoint()
+    uri = urlparse(path, scheme="https").geturl()
+
     runtime_config.runtime_options = {
         "uri": uri,
         "token": passport_token,

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -217,7 +217,7 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
         raise EnvironmentError(
             f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
             "Unable to deduce cluster's URI")
-    uri = ParseResult("https", netloc)
+    uri = ParseResult("https", netloc, "", "", "", "").geturl()
     breakpoint()
     runtime_config.runtime_options = {
         "uri": uri,

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -9,7 +9,7 @@ import os
 import pathlib
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Tuple, Union
-from urllib.parse import urlparse
+from urllib.parse import urlparse, ParseResult
 
 import filelock
 from pydantic.error_wrappers import ValidationError
@@ -212,12 +212,12 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
     runtime_config = SPECIAL_CONFIG_NAME_DICT[config_name]
 
     try:
-        path = os.environ[CURRENT_CLUSTER_ENV]
+        netloc = os.environ[CURRENT_CLUSTER_ENV]
     except KeyError:
         raise EnvironmentError(
             f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
             "Unable to deduce cluster's URI")
-    uri = urlparse(path, scheme="https").geturl()
+    uri = ParseResult("https", netloc)
     breakpoint()
     runtime_config.runtime_options = {
         "uri": uri,

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -9,7 +9,7 @@ import os
 import pathlib
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Tuple, Union
-from urllib.parse import urlparse, ParseResult
+from urllib.parse import ParseResult, urlparse
 
 import filelock
 from pydantic.error_wrappers import ValidationError
@@ -23,7 +23,7 @@ from orquestra.sdk.schema.configs import (
     RuntimeName,
 )
 
-from ._env import CONFIG_PATH_ENV, PASSPORT_FILE_ENV, CURRENT_CLUSTER_ENV
+from ._env import CONFIG_PATH_ENV, CURRENT_CLUSTER_ENV, PASSPORT_FILE_ENV
 
 # Why JSON?
 #  The Python TOML package is unmaintained as of 2022-02-18.
@@ -216,9 +216,10 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
     except KeyError:
         raise EnvironmentError(
             f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
-            "Unable to deduce cluster's URI")
+            "Unable to deduce cluster's URI"
+        )
     uri = ParseResult("https", netloc, "", "", "", "").geturl()
-    breakpoint()
+
     runtime_config.runtime_options = {
         "uri": uri,
         "token": passport_token,

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -23,7 +23,7 @@ from orquestra.sdk.schema.configs import (
     RuntimeName,
 )
 
-from ._env import CONFIG_PATH_ENV, PASSPORT_FILE_ENV
+from ._env import CONFIG_PATH_ENV, PASSPORT_FILE_ENV, CURRENT_CLUSTER_ENV
 
 # Why JSON?
 #  The Python TOML package is unmaintained as of 2022-02-18.
@@ -60,10 +60,6 @@ SAME_CLUSTER_RUNTIME_CONFIGURATION = RuntimeConfiguration(
     runtime_name=RuntimeName.CE_REMOTE,
     runtime_options={},
 )
-# We assume that we can access the workflow API under a well-known URI if the passport
-# auth is being used. This relies on the DNS configuration on the remote cluster.
-# Works from CE and jupiter-notebook inside Studio
-SAME_CLUSTER_URL = "http://workflow-driver.workflow-driver"
 
 SPECIAL_CONFIG_NAME_DICT = {
     IN_PROCESS_CONFIG_NAME: IN_PROCESS_RUNTIME_CONFIGURATION,
@@ -214,8 +210,17 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
         ) from e
 
     runtime_config = SPECIAL_CONFIG_NAME_DICT[config_name]
+
+    uri: str = ""
+    try:
+        uri = os.environ[CURRENT_CLUSTER_ENV]
+    except KeyError:
+        raise EnvironmentError(
+            f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
+            "Unable to deduce cluster's URI")
+
     runtime_config.runtime_options = {
-        "uri": SAME_CLUSTER_URL,
+        "uri": uri,
         "token": passport_token,
     }
     return runtime_config

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -218,7 +218,7 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
             f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
             "Unable to deduce cluster's URI")
     uri = urlparse(path, scheme="https").geturl()
-
+    breakpoint()
     runtime_config.runtime_options = {
         "uri": uri,
         "token": passport_token,

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -218,7 +218,9 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
             f"{PASSPORT_FILE_ENV} env variable was set, but {CURRENT_CLUSTER_ENV} not. "
             "Unable to deduce cluster's URI"
         )
-    uri = ParseResult("https", netloc, "", "", "", "").geturl()
+    uri = ParseResult(
+        scheme="https", netloc=netloc, path="", params="", query="", fragment=""
+    ).geturl()
 
     runtime_config.runtime_options = {
         "uri": uri,

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -396,6 +396,7 @@ class CERuntime(RuntimeInterface):
             try:
                 # TODO(ORQSDK-684): driver client cannot do filtering via API yet
                 # https://zapatacomputing.atlassian.net/browse/ORQSDK-684?atlOrigin=eyJpIjoiYmNiZjUyMjZiNzg5NDI2YWJmNGU5NzAxZDI1MmJlNzEiLCJwIjoiaiJ9 # noqa: E501
+                breakpoint()
                 paginated_runs = self._client.list_workflow_runs(
                     page_size=page_size,
                     page_token=page_token,

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -396,7 +396,6 @@ class CERuntime(RuntimeInterface):
             try:
                 # TODO(ORQSDK-684): driver client cannot do filtering via API yet
                 # https://zapatacomputing.atlassian.net/browse/ORQSDK-684?atlOrigin=eyJpIjoiYmNiZjUyMjZiNzg5NDI2YWJmNGU5NzAxZDI1MmJlNzEiLCJwIjoiaiJ9 # noqa: E501
-                breakpoint()
                 paginated_runs = self._client.list_workflow_runs(
                     page_size=page_size,
                     page_token=page_token,

--- a/tests/sdk/v2/api/test_config.py
+++ b/tests/sdk/v2/api/test_config.py
@@ -318,12 +318,24 @@ class TestRuntimeConfiguration:
                 pass_file = tmp_path / "pass.port"
                 pass_file.write_text(token)
                 monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
+                monkeypatch.setenv("ORQ_CURRENT_CLUSTER", "cluster.io")
 
                 cfg = api_cfg.RuntimeConfig.load(
                     "auto",
                 )
 
                 assert cfg.token == token
+                assert cfg.uri == "https://cluster.io"
+
+            def test_no_cluster_uri(self, tmp_path, monkeypatch):
+                token = "the best token you have ever seen"
+                pass_file = tmp_path / "pass.port"
+                pass_file.write_text(token)
+                monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
+                with pytest.raises(EnvironmentError):
+                    api_cfg.RuntimeConfig.load(
+                        "auto",
+                    )
 
             def test_on_local_env(self):
                 assert api_cfg.RuntimeConfig.load("auto") == api_cfg.RuntimeConfig.load(


### PR DESCRIPTION
# The problem

There were different internal domains for different services on cluster

# This PR's solution

Just use external cluster's URI for everything

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
