### PR TITLE
fix: Skip CE workflows when listing workflows in QE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 🐛 *Bug Fixes*
 * Secrets with workspaces now work inside workflow functions and for personal access tokens in `GithubImport`.
+* Listing workflows on QE no longer fails if there was a CE workflow in the DB
 
 💅 *Improvements*
 * Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly

--- a/src/orquestra/sdk/_base/_db/_migration.py
+++ b/src/orquestra/sdk/_base/_db/_migration.py
@@ -1,6 +1,7 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
+import sqlite3
 from pathlib import Path
 
 
@@ -21,3 +22,19 @@ def migrate_project_db_to_shared_db(project_dir: Path):
         c.close()
 
     old_location.rename(old_location.with_suffix(".old"))
+
+
+def run_migrations(db: sqlite3.Connection):
+    cur = db.cursor()
+    cur.execute("PRAGMA user_version")
+    (user_version,) = cur.fetchone()
+    if user_version < 1:
+        add_is_qe(db)
+
+
+def add_is_qe(db: sqlite3.Connection):
+    cur = db.cursor()
+    cur.execute("BEGIN TRANSACTION")
+    cur.execute("ALTER TABLE workflow_runs ADD COLUMN is_qe")
+    cur.execute("PRAGMA user_version = 1")
+    cur.execute("COMMIT")

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -151,6 +151,7 @@ class CERuntime(RuntimeInterface):
                     workflow_run_id=workflow_run_id,
                     config_name=self._config.config_name,
                     workflow_def=workflow_def,
+                    is_qe=False,
                 )
             )
         return workflow_run_id

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -593,6 +593,7 @@ class QERuntime(RuntimeInterface):
             workflow_run_id=workflow_run_id,
             config_name=self._config.config_name,
             workflow_def=workflow_def,
+            is_qe=True,
         )
         with WorkflowDB.open_project_db(self._project_dir) as db:
             db.save_workflow_run(wf_run)
@@ -618,9 +619,13 @@ class QERuntime(RuntimeInterface):
                 except exceptions.WorkflowNotFoundError:
                     # explicit re-raise
                     raise
-
         except sqlite3.OperationalError as e:
             raise exceptions.WorkflowNotFoundError(workflow_run_id) from e
+
+        if not wf_run.is_qe:
+            raise exceptions.WorkflowRunNotFoundError(
+                f"Workflow {workflow_run_id} not found"
+            )
 
         wf_def = wf_run.workflow_def
         try:
@@ -628,7 +633,9 @@ class QERuntime(RuntimeInterface):
                 json_response = self._client.get_workflow(wf_id=workflow_run_id)
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
-                raise exceptions.WorkflowRunNotFoundError(f"Workflow {workflow_run_id} not found")
+                raise exceptions.WorkflowRunNotFoundError(
+                    f"Workflow {workflow_run_id} not found"
+                )
             raise e
 
         # Load the Argo representation from the response

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -623,8 +623,13 @@ class QERuntime(RuntimeInterface):
             raise exceptions.WorkflowNotFoundError(workflow_run_id) from e
 
         wf_def = wf_run.workflow_def
-        with _http_error_handling():
-            json_response = self._client.get_workflow(wf_id=workflow_run_id)
+        try:
+            with _http_error_handling():
+                json_response = self._client.get_workflow(wf_id=workflow_run_id)
+        except requests.exceptions.HTTPError as e:
+            if e.response.status_code == 404:
+                raise exceptions.WorkflowRunNotFoundError(f"Workflow {workflow_run_id} not found")
+            raise e
 
         # Load the Argo representation from the response
         # TODO/FIXME: Is this a stable interface? Should it be exposed?

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -309,6 +309,7 @@ class RayRuntime(RuntimeInterface):
             workflow_run_id=wf_run_id,
             config_name=self._config.config_name,
             workflow_def=workflow_def,
+            is_qe=False,
         )
         with WorkflowDB.open_project_db(self._project_dir) as db:
             db.save_workflow_run(wf_run)

--- a/src/orquestra/sdk/schema/local_database.py
+++ b/src/orquestra/sdk/schema/local_database.py
@@ -19,3 +19,4 @@ class StoredWorkflowRun(BaseModel):
     workflow_run_id: WorkflowRunId
     config_name: str
     workflow_def: WorkflowDef
+    is_qe: bool

--- a/tests/runtime/api/test_api_with_qe.py
+++ b/tests/runtime/api/test_api_with_qe.py
@@ -191,6 +191,7 @@ class TestGetWorkflowRunStatus:
                     workflow_run_id="workflow-id",
                     config_name="hello",
                     workflow_def=my_workflow().model,
+                    is_qe=True,
                 )
             ),
         )
@@ -227,6 +228,7 @@ class TestGetWorkflowRunStatus:
                     workflow_run_id="workflow-id",
                     config_name="hello",
                     workflow_def=my_workflow().model,
+                    is_qe=True,
                 )
             ),
         )

--- a/tests/runtime/corq/test_format.py
+++ b/tests/runtime/corq/test_format.py
@@ -64,6 +64,7 @@ def _make_mock_wf_db(wf_run_id, wf_def):
             workflow_run_id=wf_run_id,
             config_name="testing",
             workflow_def=wf_def,
+            is_qe=False,
         )
     )
 

--- a/tests/runtime/db/test_migration.py
+++ b/tests/runtime/db/test_migration.py
@@ -62,6 +62,7 @@ class TestProjectToSharedDBMigration:
                     workflow_run_id="test",
                     config_name="test",
                     workflow_def=workflow_def,
+                    is_qe=False,
                 )
             )
         # When

--- a/tests/runtime/qe/regression/test_regression.py
+++ b/tests/runtime/qe/regression/test_regression.py
@@ -42,6 +42,7 @@ def mock_workflow_db(monkeypatch: pytest.MonkeyPatch):
             workflow_run_id=wf_run_id,
             config_name="hello",
             workflow_def=wf_def,
+            is_qe=True,
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
 

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -605,6 +605,7 @@ class TestGetAvailableOutputs:
                 workflow_run_id=wf_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -640,6 +641,7 @@ class TestGetAvailableOutputs:
                 workflow_run_id=wf_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -675,6 +677,7 @@ class TestGetWorkflowRunStatus:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -744,7 +747,9 @@ class TestGetWorkflowRunStatus:
 
         assert stub_runID in str(exc_info)
 
-    def test_get_workflow_run_status_not_found(self, monkeypatch, runtime, mocked_responses):
+    def test_get_workflow_run_status_in_db_but_not_qe(
+        self, monkeypatch, runtime, mock_workflow_db_location
+    ):
         workflow_run_id = "hello-there-abc123-r000"
         # Given
         _get_workflow_run = Mock(
@@ -752,6 +757,29 @@ class TestGetWorkflowRunStatus:
                 workflow_run_id=workflow_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=False,
+            )
+        )
+        monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
+
+        # When
+        with pytest.raises(exceptions.WorkflowRunNotFoundError) as exc_info:
+            _ = runtime.get_workflow_run_status("hello-there-abc123-r000")
+
+        # Then
+        assert workflow_run_id in str(exc_info)
+
+    def test_get_workflow_run_status_not_found(
+        self, monkeypatch, runtime, mocked_responses
+    ):
+        workflow_run_id = "hello-there-abc123-r000"
+        # Given
+        _get_workflow_run = Mock(
+            return_value=StoredWorkflowRun(
+                workflow_run_id=workflow_run_id,
+                config_name="hello",
+                workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -768,13 +796,13 @@ class TestGetWorkflowRunStatus:
         # Then
         assert workflow_run_id in str(exc_info)
 
-
     def test_task_waiting_with_message(self, monkeypatch, runtime, mocked_responses):
         _get_workflow_run = Mock(
             return_value=StoredWorkflowRun(
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -797,6 +825,7 @@ class TestGetWorkflowRunStatus:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -826,6 +855,7 @@ class TestGetWorkflowRunStatus:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -885,6 +915,7 @@ class TestGetWorkflowRunStatus:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -915,6 +946,7 @@ class TestGetWorkflowRunOutputsNonBlocking:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -959,6 +991,7 @@ class TestGetWorkflowRunOutputsNonBlocking:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -978,6 +1011,7 @@ class TestGetWorkflowRunOutputsNonBlocking:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         _empty_tgz = Mock(side_effect=IndexError)
@@ -1002,6 +1036,7 @@ class TestGetWorkflowRunOutputsNonBlocking:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1024,6 +1059,7 @@ class TestGetWorkflowRunOutputsNonBlocking:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1054,6 +1090,7 @@ class TestGetWorkflowLogs:
                 workflow_run_id=wf_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1103,6 +1140,7 @@ class TestGetTaskLogs:
                 workflow_run_id=wf_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1136,6 +1174,7 @@ class TestGetTaskLogs:
                 workflow_run_id=wf_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1181,6 +1220,7 @@ class TestGetTaskLogs:
                 workflow_run_id=wf_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1203,6 +1243,7 @@ class TestGetTaskLogs:
                 workflow_run_id=wf_run_id,
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1262,21 +1303,25 @@ class TestListWorkflowRuns:
                     workflow_run_id="hello-there-abc123-r000",
                     config_name="hello",
                     workflow_def=TEST_WORKFLOW,
+                    is_qe=True,
                 ),
                 StoredWorkflowRun(
                     workflow_run_id="hello-there-abc123-r000",
                     config_name="hello",
                     workflow_def=TEST_WORKFLOW,
+                    is_qe=True,
                 ),
                 StoredWorkflowRun(
                     workflow_run_id="hello-there-abc123-r000",
                     config_name="hello",
                     workflow_def=TEST_WORKFLOW,
+                    is_qe=True,
                 ),
                 StoredWorkflowRun(
                     workflow_run_id="hello-there-abc123-r000",
                     config_name="hello",
                     workflow_def=TEST_WORKFLOW,
+                    is_qe=True,
                 ),
             ]
         )
@@ -1456,6 +1501,7 @@ class TestHTTPErrors:
                 workflow_run_id="hello-there-abc123-r000",
                 config_name="hello",
                 workflow_def=TEST_WORKFLOW,
+                is_qe=True,
             )
         )
         monkeypatch.setattr(_db.WorkflowDB, "get_workflow_run", _get_workflow_run)
@@ -1488,6 +1534,7 @@ class TestHTTPErrors:
                         workflow_run_id="hello-there-abc123-r000",
                         config_name="hello",
                         workflow_def=TEST_WORKFLOW,
+                        is_qe=True,
                     )
                 ]
             ),
@@ -1502,6 +1549,7 @@ class TestHTTPErrors:
                     workflow_run_id="hello-there-abc123-r000",
                     config_name="hello",
                     workflow_def=TEST_WORKFLOW,
+                    is_qe=True,
                 )
             ),
         )
@@ -1532,6 +1580,7 @@ class TestHTTPErrors:
                     workflow_run_id="hello-there-abc123-r000",
                     config_name="hello",
                     workflow_def=TEST_WORKFLOW,
+                    is_qe=True,
                 )
             ),
         )

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -305,6 +305,7 @@ class TestWorkflowRun:
                                 workflow_run_id=run_id,
                                 config_name=config_name,
                                 workflow_def=wf_pass_tuple().model,
+                                is_qe=False,
                             )
                         ),
                     )


### PR DESCRIPTION
# The problem

Listing workflows in QE failed when there was CE workflows with the same config name.

# This PR's solution

* Skip over CE workflows when listing workflows on QE
* Add a `is_qe` column to the `workflows.db` to short circuit when loading workflows in QE.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
