### PR TITLE
imp: re-export State in the base package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 💅 *Improvements*
 * Add prompters to `orq wf submit` command for CE runtime if workspace and project weren't passed explicitly
 * `orquestra-sdk-base` CPU container image has a 20% size reduction.
+* Added `State` enum to the base `orquestra.sdk` package for easier filtering task runs.
 
 🥷 *Internal*
 

--- a/src/orquestra/sdk/__init__.py
+++ b/src/orquestra/sdk/__init__.py
@@ -32,6 +32,10 @@ from ._base._spaces._api import list_projects, list_workspaces
 from ._base._spaces._structs import Project, ProjectRef, Workspace
 from ._base._workflow import NotATaskWarning, WorkflowDef, WorkflowTemplate, workflow
 
+# It's already in a public module, but we'll re-export it under `orquestra.sdk.*` anyway
+# because it's commonly used to filter task runs.
+from .schema.workflow_run import State
+
 __all__ = [
     "ArtifactFuture",
     "DataAggregation",
@@ -63,5 +67,6 @@ __all__ = [
     "wfprint",
     "Project",
     "ProjectRef",
+    "State",
     "Workspace",
 ]


### PR DESCRIPTION
# The problem

Inspired by @max-radin's presentation last Friday.

Filtering task runs by state requires finding the appropriate module to import it from (`orquestra.sdk.schema.workflow_run`) which is "far" from the place where `TaskRun` is available for the user (top-level `orquestra.sdk`).

For example, let's say I ran a workflow and one of the tasks failed. I want to access the failing `TaskRun` via our Python API.

```python
from orquestra import sdk
from orquestra.sdk.schema.workflow_run import State

wf_run = sdk.WorkflowRun.by_id("abc")

for task_run in wf_run.get_tasks():
    if task_run.get_state() == State.FAILED:
        # Here's my failure inspection code
        ...
```


# This PR's solution

Re-exports `State` under the base package. It allows using simplified imports like in the snippets below.


```python
from orquestra import sdk

wf_run = sdk.WorkflowRun.by_id("abc")

for task_run in wf_run.get_tasks():
    if task_run.get_state() == sdk.State.FAILED:
        # Here's my failure inspection code
        ...
```

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
