### PR TITLE
docs: Update documentation as we disable single node runtime

### DIFF
--- a/docs/guides/custom-images.rst
+++ b/docs/guides/custom-images.rst
@@ -46,9 +46,9 @@ to see how.
 Using the Image on Compute Engine
 ---------------------------------
 
-You can run workflows that use custom images only on Compute Engine and not on Quantum Engine or locally. You
-need to request more than one node for your workflow as Compute Engine supports custom images only on clustered mode
-which is activated when more than one node is requested for a workflow.
+.. note::
+
+    You can run workflows that use custom images only on Compute Engine and not on Quantum Engine or locally.
 
 When you use a custom image, ``nodes`` workflow resource indicates the maximum number of nodes that may be allocated
 with the custom image, if needed. For example, if you use two different custom images for your tasks and specify ``nodes=4``

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -63,13 +63,13 @@ Convention is to use binary prefixes for memory resource requests (``disk`` and 
 Setting Workflow Resources
 --------------------------
 
-Resources can also be configured at the workflow definition level using the same syntax as with tasks, with one difference - the ``sdk.Resources()`` object my additionally specify a number of nodes to be requested for the workflow. The full parameter list is therefore:
+Resources can also be configured at the workflow definition level using the same syntax as with tasks, with one difference - the ``sdk.Resources()`` object may additionally specify a number of nodes to be requested for the workflow. The full parameter list is therefore:
 
 * ``cpu``: number of cores.
 * ``memory``: amount of RAM (bytes).
 * ``disk``: disk space (bytes).
 * ``gpu``: whether access to a gpu unit is required (``1`` if a GPU is required, ``0`` otherwise).
-* ``nodes``: indicates the maximum number of nodes that may be allocated throughout the execution of this workflow - Must be a positive integer and must be greater than 1 node when using custom images in ``sdk.task`` resources. If omitted, it defaults to 1.
+* ``nodes``: indicates the maximum number of nodes that may be allocated throughout the execution of this workflow - Must be a positive integer. If omitted, it defaults to 1.
 
 .. code-block::
     :caption: Workflow resource request example


### PR DESCRIPTION
# The problem

We have disabled single node runtime and by default provision a Ray cluster, even when nodes=1 for the workflow resources. The documentation still mentions that the nodes parameter needing to be set to a value larger than 1, which is no longer the case.

# This PR's solution

Update the documentation to explain the current situation correctly.

# Checklist

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).