### PR TITLE
feat: Force stop workflows runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Compute Engine is now the default when logging in
 
 🔥 *Features*
+* Force stop workflow runs via the CLI or Python API
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -313,9 +313,15 @@ class WorkflowRun:
 
         return status
 
-    def stop(self):
+    def stop(self, *, force: t.Optional[bool] = None):
         """
         Asks the runtime to stop the workflow run.
+
+        Args:
+            force: Asks the runtime to terminate the workflow without waiting for the
+                workflow to gracefully exit.
+                By default, this behavior is up to the runtime, but can be overridden
+                with True/False.
 
         Raises:
             orquestra.sdk.exceptions.UnauthorizedError: when communication with runtime
@@ -324,7 +330,7 @@ class WorkflowRun:
                 attempt failed
         """
         try:
-            self._runtime.stop_workflow_run(self.run_id)
+            self._runtime.stop_workflow_run(self.run_id, force=force)
         except (UnauthorizedError, WorkflowRunCanNotBeTerminated):
             raise
 

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -331,14 +331,16 @@ class CERuntime(RuntimeInterface):
         # https://zapatacomputing.atlassian.net/browse/ORQSDK-694
         return task_run_id.split("@")[-1]
 
-    def stop_workflow_run(self, workflow_run_id: WorkflowRunId) -> None:
+    def stop_workflow_run(
+        self, workflow_run_id: WorkflowRunId, *, force: Optional[bool] = None
+    ) -> None:
         """Stops a workflow run.
 
         Raises:
             WorkflowRunCanNotBeTerminated if workflow run is cannot be terminated.
         """
         try:
-            self._client.terminate_workflow_run(workflow_run_id)
+            self._client.terminate_workflow_run(workflow_run_id, force)
         except _exceptions.WorkflowRunNotFound:
             raise exceptions.WorkflowRunNotFoundError(
                 f"Workflow run with id `{workflow_run_id}` not found"

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -442,9 +442,15 @@ class DriverClient:
 
         return parsed_response.data.to_ir(workflow_def.workflow)
 
-    def terminate_workflow_run(self, wf_run_id: _models.WorkflowRunID):
+    def terminate_workflow_run(
+        self, wf_run_id: _models.WorkflowRunID, force: Optional[bool] = None
+    ):
         """
         Asks the workflow driver to terminate a workflow run
+
+        Args:
+            wf_run_id: the workflow to terminate
+            force: if the workflow should be forcefully terminated
 
         Raises:
             WorkflowRunNotFound: see the exception's docstring
@@ -456,6 +462,7 @@ class DriverClient:
         resp = self._post(
             API_ACTIONS["terminate_workflow_run"].format(wf_run_id),
             body_params=None,
+            query_params=_models.TerminateWorkflowRunRequest(force=force).dict(),
         )
 
         if resp.status_code == codes.NOT_FOUND:

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -132,6 +132,12 @@ class StateResponse(str, Enum):
     SUCCEEDED = "SUCCEEDED"
     TERMINATED = "TERMINATED"
     FAILED = "FAILED"
+    KILLED = "KILLED"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def _missing_(cls, _):
+        return cls.UNKNOWN
 
 
 class RunStatusResponse(pydantic.BaseModel):
@@ -274,6 +280,15 @@ class GetWorkflowRunResponse(pydantic.BaseModel):
     """
 
     data: WorkflowRunResponse
+
+
+class TerminateWorkflowRunRequest(pydantic.BaseModel):
+    """
+    Implements:
+        https://github.com/zapatacomputing/workflow-driver/blob/873437f8157226c451220306a6ce90c80e8c8f9e/openapi/src/resources/workflow-run-terminate.yaml#L12
+    """
+
+    force: Optional[bool]
 
 
 # --- Workflow Artifacts ---

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -260,7 +260,9 @@ class InProcessRuntime(abc.RuntimeInterface):
             ),
         )
 
-    def stop_workflow_run(self, workflow_run_id: WfRunId):
+    def stop_workflow_run(
+        self, workflow_run_id: WfRunId, *, force: t.Optional[bool] = None
+    ):
         if workflow_run_id in self._output_store:
             # Noop. If a client happens to call this method the workflow is already
             # stopped, by definition of the InProcessRuntime. If the user is running

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -823,7 +823,9 @@ class QERuntime(RuntimeInterface):
         env_logs: List[str] = []
         return WorkflowLogs(per_task=task_logs, env_setup=env_logs, other=[])
 
-    def stop_workflow_run(self, run_id: WorkflowRunId) -> None:
+    def stop_workflow_run(
+        self, run_id: WorkflowRunId, *, force: Optional[bool] = None
+    ) -> None:
         """Terminates a workflow run.
 
         Args:

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -113,7 +113,9 @@ class RuntimeInterface(ABC, LogReader):
         raise NotImplementedError()
 
     @abstractmethod
-    def stop_workflow_run(self, workflow_run_id: WorkflowRunId) -> None:
+    def stop_workflow_run(
+        self, workflow_run_id: WorkflowRunId, *, force: t.Optional[bool] = None
+    ) -> None:
         """Stops a workflow run.
 
         Raises:

--- a/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_arg_resolvers.py
@@ -473,9 +473,12 @@ class WFRunFilterResolver:
             # The user has passed in one or more state arguments, iterate through them
             # and check that they're valid states.
             for state in states:
-                try:
-                    _ = State(state)
-                except ValueError:
+                s = State(state)
+
+                # If the state the user passed is not the same as we parsed, then this
+                # is an invalid state.
+                # This allows users to still ask for workflows in UNKNOWN states.
+                if state != s.value:
                     _invalid_states.append(state)
                 else:
                     _selected_states.append(state)

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -105,8 +105,7 @@ selecting a function from the ones available in 'module'.
 @PROJECT_OPTION
 @cloup.option(
     "--force",
-    is_flag=True,
-    default=False,
+    default=None,
     help=(
         "If passed, submits the workflow without confirmation even if there are "
         "uncommitted changes."
@@ -208,15 +207,21 @@ def wf_logs(
 @workflow.command()
 @cloup.argument("wf_run_id", required=False)
 @CONFIG_OPTION
-def stop(wf_run_id: t.Optional[str], config: t.Optional[str]):
+@cloup.option(
+    "--force/--no-force",
+    is_flag=True,
+    default=None,
+    help="Will forcefully terminate a workflow, "
+    "without waiting for it to gracefully exit.",
+)
+def stop(wf_run_id: t.Optional[str], config: t.Optional[str], force: t.Optional[bool]):
     """
     Stops a running workflow.
     """
-
     from ._workflow._stop import Action
 
     action = Action()
-    action.on_cmd_call(wf_run_id, config)
+    action.on_cmd_call(wf_run_id, config, force)
 
 
 @workflow.command()

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -211,8 +211,11 @@ def wf_logs(
     "--force/--no-force",
     is_flag=True,
     default=None,
-    help="Will forcefully terminate a workflow, "
-    "without waiting for it to gracefully exit.",
+    help="""
+Will forcefully terminate a workflow, without waiting for it to gracefully exit.
+If neither `--force` nor `--no-force` is passed, the runtime will determine if the
+workflow should be forcefully stopped.
+    """,
 )
 def stop(wf_run_id: t.Optional[str], config: t.Optional[str], force: t.Optional[bool]):
     """

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -189,7 +189,9 @@ class WorkflowRunRepo:
 
         return wf_run.run_id
 
-    def stop(self, wf_run_id: WorkflowRunId, config_name: ConfigName):
+    def stop(
+        self, wf_run_id: WorkflowRunId, config_name: ConfigName, force: t.Optional[bool]
+    ):
         """
         Raises:
             orquestra.sdk.exceptions.UnauthorizedError: when communication with runtime
@@ -200,7 +202,7 @@ class WorkflowRunRepo:
         wf_run = sdk.WorkflowRun.by_id(wf_run_id, config_name)
 
         try:
-            return wf_run.stop()
+            return wf_run.stop(force=force)
         except (exceptions.UnauthorizedError, exceptions.WorkflowRunCanNotBeTerminated):
             # Other exception types aren't expected to be raised here.
             raise

--- a/src/orquestra/sdk/_base/cli/_dorq/_workflow/_stop.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_workflow/_stop.py
@@ -44,15 +44,21 @@ class Action:
         self._presenter = presenter
 
     def on_cmd_call(
-        self, wf_run_id: t.Optional[WorkflowRunId], config: t.Optional[ConfigName]
+        self,
+        wf_run_id: t.Optional[WorkflowRunId],
+        config: t.Optional[ConfigName],
+        force: t.Optional[bool],
     ):
         try:
-            self._on_cmd_call_with_exceptions(wf_run_id, config)
+            self._on_cmd_call_with_exceptions(wf_run_id, config, force)
         except Exception as e:
             self._presenter.show_error(e)
 
     def _on_cmd_call_with_exceptions(
-        self, wf_run_id: t.Optional[WorkflowRunId], config: t.Optional[ConfigName]
+        self,
+        wf_run_id: t.Optional[WorkflowRunId],
+        config: t.Optional[ConfigName],
+        force: t.Optional[bool],
     ):
         """
         Implementation of the command action. Doesn't catch exceptions.
@@ -63,7 +69,7 @@ class Action:
         resolved_id = self._wf_run_resolver.resolve_id(wf_run_id, resolved_config)
 
         try:
-            self._wf_run_repo.stop(resolved_id, resolved_config)
+            self._wf_run_repo.stop(resolved_id, resolved_config, force)
         except (exceptions.UnauthorizedError, exceptions.WorkflowRunCanNotBeTerminated):
             # Other exception types aren't expected to be raised here.
             raise

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -466,7 +466,9 @@ class RayRuntime(RuntimeInterface):
             )
         )
 
-    def stop_workflow_run(self, workflow_run_id: WorkflowRunId) -> None:
+    def stop_workflow_run(
+        self, workflow_run_id: WorkflowRunId, *, force: t.Optional[bool] = None
+    ) -> None:
         # cancel doesn't throw exceptions on non-existing runs... using this as
         # a workaround to inform client of an error
         try:

--- a/src/orquestra/sdk/schema/workflow_run.py
+++ b/src/orquestra/sdk/schema/workflow_run.py
@@ -28,6 +28,12 @@ class State(enum.Enum):
     TERMINATED = "TERMINATED"
     FAILED = "FAILED"
     ERROR = "ERROR"
+    KILLED = "KILLED"
+    UNKNOWN = "UNKNOWN"
+
+    @classmethod
+    def _missing_(cls, _):
+        return cls.UNKNOWN
 
 
 class RunStatus(BaseModel):

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -354,6 +354,7 @@ class TestWorkflowRunRepo:
                 # Given
                 run_id = "wf.1"
                 config_name = "<config sentinel>"
+                force = False
 
                 wf_run = Mock()
                 wf_run.stop.side_effect = exc
@@ -367,7 +368,7 @@ class TestWorkflowRunRepo:
                 # Validate passing exception
                 with pytest.raises(type(exc)):
                     # When
-                    _ = repo.stop(run_id, config_name)
+                    _ = repo.stop(run_id, config_name, force)
 
                 # Then
                 # Validate passing args

--- a/tests/cli/dorq/workflow/test_stop.py
+++ b/tests/cli/dorq/workflow/test_stop.py
@@ -26,6 +26,7 @@ class TestAction:
         # CLI inputs
         wf_run_id = "<wf run ID sentinel>"
         config = "<config sentinel>"
+        force = False
 
         # Resolved values
         resolved_id = "<resolved ID>"
@@ -49,7 +50,7 @@ class TestAction:
         )
 
         # When
-        action.on_cmd_call(wf_run_id=wf_run_id, config=config)
+        action.on_cmd_call(wf_run_id=wf_run_id, config=config, force=force)
 
         # Then
         # We should pass input CLI args to config resolver.
@@ -59,7 +60,7 @@ class TestAction:
         wf_run_resolver.resolve_id.assert_called_with(wf_run_id, resolved_config)
 
         # We should pass resolved values to run repo.
-        wf_run_repo.stop.assert_called_with(resolved_id, resolved_config)
+        wf_run_repo.stop.assert_called_with(resolved_id, resolved_config, force)
         # We should pass resolved ID to presenter.
         presenter.show_stopped_wf_run.assert_called_with(resolved_id)
 
@@ -70,6 +71,7 @@ class TestAction:
         # CLI inputs
         wf_run_id = "<wf run ID sentinel>"
         config = "<config sentinel>"
+        force = False
 
         # Mocks
         presenter = Mock()
@@ -89,7 +91,7 @@ class TestAction:
         )
 
         # When
-        action.on_cmd_call(wf_run_id, config)
+        action.on_cmd_call(wf_run_id, config, force)
 
         # Then
         # We expect telling the user about the error.

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -653,7 +653,28 @@ class TestWorkflowRun:
             run.stop()
 
             # Then
-            runtime.stop_workflow_run.assert_called_with(run_id)
+            runtime.stop_workflow_run.assert_called_with(run_id, force=None)
+
+        @staticmethod
+        @pytest.mark.parametrize(
+            "force",
+            (True, False),
+        )
+        def test_force_stop(force):
+            # Given
+            run_id = "wf.1"
+            wf_def = Mock()
+            runtime = Mock()
+            config = Mock()
+            run = _api.WorkflowRun(
+                run_id=run_id, wf_def=wf_def, runtime=runtime, config=config
+            )
+
+            # When
+            run.stop(force=force)
+
+            # Then
+            runtime.stop_workflow_run.assert_called_with(run_id, force=force)
 
         @staticmethod
         @pytest.mark.parametrize(

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -861,7 +861,29 @@ class TestStopWorkflowRun:
         # When
         runtime.stop_workflow_run(workflow_run_id)
         # Then
-        mocked_client.terminate_workflow_run.assert_called_once_with(workflow_run_id)
+        mocked_client.terminate_workflow_run.assert_called_once_with(
+            workflow_run_id, None
+        )
+
+    @pytest.mark.parametrize(
+        "force",
+        (True, False),
+    )
+    def test_with_force(
+        self,
+        mocked_client: MagicMock,
+        runtime: _ce_runtime.CERuntime,
+        workflow_run_id: str,
+        force: bool,
+    ):
+        # Given
+        mocked_client.terminate_workflow_run.return_value = None
+        # When
+        runtime.stop_workflow_run(workflow_run_id, force=force)
+        # Then
+        mocked_client.terminate_workflow_run.assert_called_once_with(
+            workflow_run_id, force
+        )
 
     def test_unknown_http(
         self,

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -694,6 +694,32 @@ class TestClient:
                 )
 
             @staticmethod
+            def test_unknown_workflow_state(
+                endpoint_mocker,
+                mock_get_workflow_def,
+                client: DriverClient,
+                workflow_run_id: str,
+                workflow_def_id: str,
+                workflow_run_status: RunStatus,
+                workflow_run_tasks,
+            ):
+                response_json = resp_mocks.make_get_wf_run_response(
+                    id_=workflow_run_id,
+                    workflow_def_id=workflow_def_id,
+                    status=workflow_run_status,
+                    task_runs=workflow_run_tasks,
+                )
+                response_json["data"]["status"]["state"] = "NEW STATE!"
+
+                endpoint_mocker(
+                    json=response_json,
+                )
+
+                wf_run = client.get_workflow_run(workflow_run_id)
+
+                assert wf_run.status.state == State.UNKNOWN
+
+            @staticmethod
             def test_sets_auth(
                 endpoint_mocker,
                 mock_get_workflow_def,


### PR DESCRIPTION
# The problem

A new option was added to force stop workflow runs in CE.

# This PR's solution

* Adds a new option to our public API and CLI.
* Adds a new `State` called `KILLED`, which is the result of a force stopped workflow run.
* Adds default behaviour to `State` enums with `State.UNKNOWN`.

Example:

```
orq workflow stop --force my-wf-run-abcd123
```

or

```
run = WorkflowRun.by_id("...")
run.stop(force=True)
```

A design choice was to make `force` an optional, instead of defaulting to `False`.

This lets us make requests to CE without making a decision on if a workflow should be forcefully stopped.
Deferring the default behaviour to CE will allow this behaviour to change in the future without any changes from the client.
Of course, it's possible to pass both `True` or `False`, explicitly setting the force option. 

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
