### PR TITLE
Feat: Add new public API for WorkflowRun which returns serialized values and artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 🔥 *Features*
 * Force stop workflow runs via the CLI or Python API
 * `WorkflowRun.get_tasks()` supports filtering tasks by state, function name, task run ID and task invocation ID.
+* 2 new methods added to public API of `WorkflowRun`: `get_artifacts_serialized()` and `get_results_serialized()`
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -392,15 +392,15 @@ class WorkflowRun:
         of these. The order is dictated by the return statement in the workflow
         function, for example `return a, b, c` means this function returns (a, b, c).
         See also:
-        https://refactored-disco-d576cb73.pages.github.io/docs/runtime/guides/workflow-syntax.html
+        https://docs.orquestra.io/docs/core/sdk/guides/workflow-syntax.html/workflow-syntax.html
 
         Args:
             wait:  whether or not to wait for workflow run completion.
-                   Uses the default options for waiting, use `wait_until_finished()` for
+                   Uses the default options for waiting, use ``wait_until_finished()`` for
                    more control.
 
         Raises:
-            WorkflowRunNotFinished: when the workflow run has not finished and `wait` is
+            WorkflowRunNotFinished: when the workflow run has not finished and ``wait`` is
                                    False
             WorkflowRunNotSucceeded: when the workflow is no longer executing, but it did not
                 succeed.

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -400,16 +400,12 @@ class WorkflowRun:
 
         return results
 
-    def get_results_serialized(self, wait: bool = False) -> t.Sequence[t.Any]:
+    def get_results_serialized(self, wait: bool = False) -> t.Sequence[WorkflowResult]:
         """
         Retrieves workflow results in serialized form.
 
-        A workflow function is expected to return task outputs
-        (ArtifactFutures) or constants (10, "hello", etc.). This method returns values
-        of these. The order is dictated by the return statement in the workflow
-        function, for example `return a, b, c` means this function returns (a, b, c).
-        See also:
-        https://refactored-disco-d576cb73.pages.github.io/docs/runtime/guides/workflow-syntax.html
+        Result value is a sequence of WorkflowResult objects where each can be
+        deserialized separately
 
         Args:
             wait:  whether or not to wait for workflow run completion.

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -35,6 +35,7 @@ from orquestra.sdk.exceptions import (
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.configs import RuntimeName
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
+from orquestra.sdk.schema.responses import JSONResult
 from orquestra.sdk.schema.workflow_run import RunStatus, State
 from orquestra.sdk.schema.workflow_run import TaskRun as TaskRunModel
 
@@ -526,6 +527,43 @@ class TestWorkflowRun:
             assert results == "woohoo!"
             assert mock_runtime.get_workflow_run_status.call_count == 1
 
+    class TestGetResultsSerialized:
+        @staticmethod
+        def test_raises_exception_if_workflow_not_finished(run):
+            # Given
+            # When
+            with pytest.raises(WorkflowRunNotFinished) as exc_info:
+                run.get_results_serialized()
+            # Then
+            assert (
+                "Workflow run with id wf_pass_tuple-1 has not finished. "
+                "Current state: State.RUNNING"
+            ) in str(exc_info)
+
+        @staticmethod
+        @pytest.mark.slow
+        def test_waits_when_wait_is_true(run, mock_runtime):
+            # Given
+            # When
+            results = run.get_results_serialized(wait=True)
+            # Then
+            assert mock_runtime.get_workflow_run_status.call_count >= 1
+            assert results is not None
+            assert isinstance(results[0], JSONResult)
+            assert results[0].value == '"woohoo!"'
+
+        @staticmethod
+        def test_waits_when_wait_is_explicitly_false(run, mock_runtime):
+            # Remove RUNNING in mock
+            mock_runtime.get_workflow_run_status.side_effect = None
+            # Given
+            # When
+            results = run.get_results_serialized(wait=False)
+            # Then
+            assert results is not None
+            assert isinstance(results[0], JSONResult)
+            assert results[0].value == '"woohoo!"'
+
     class TestGetArtifacts:
         @staticmethod
         def test_handling_n_outputs():
@@ -575,6 +613,33 @@ class TestWorkflowRun:
                 "inv1": 42,
                 "inv2": (21, 38),
             }
+
+    class TestGetArtifactsSerialized:
+        @staticmethod
+        def test_serialized_artifacts():
+            # Given
+            runtime = create_autospec(RuntimeInterface)
+
+            values = {
+                "inv1": serde.result_from_artifact(42, ir.ArtifactFormat.AUTO),
+                "inv2": serde.result_from_artifact((21, 38), ir.ArtifactFormat.AUTO),
+            }
+
+            runtime.get_available_outputs.return_value = values
+
+            wf_def = create_autospec(ir.WorkflowDef)
+
+            wf_run = _api.WorkflowRun(
+                run_id="wf.1",
+                wf_def=wf_def,
+                runtime=runtime,
+            )
+
+            # When
+            artifacts_dict = wf_run.get_artifacts_serialized()
+
+            # Then
+            assert artifacts_dict == values
 
     class TestTaskFilters:
         class TestTaskMatchesSchemaFilters:


### PR DESCRIPTION
# The problem
We need to have public API that returns serialized results and artifacts, as this is used by Workflow-driver-ray

# This PR's solution

Add New APIs

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
