### PR TITLE
Feat!: Remove last bits of default config in our code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 🚨 *Breaking Changes*
+* Removed `RuntimeConfig.load_default()`
+* Removed any support for default configuration
+* `sdk.secret` functions will no longer use default configuration from local runtimes. Config has to be passed explicitly unless running on remote cluster
 
 🔥 *Features*
 

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -241,21 +241,9 @@ class RuntimeConfig:
             runtime_options=runtime_options,
         )
 
-        try:
-            return build_runtime_from_config(
-                project_dir=_project_dir, config=runtime_configuration
-            )
-        except KeyError as e:
-            outstr = (
-                f"Runtime configuration '{runtime_configuration.config_name}' "
-                f"lacks the required field '{e}'."
-            )
-            if e == "temp_dir":
-                outstr += (
-                    " You may need to migrate your config file using "
-                    "`sdk.migrate_config_file()`"
-                )
-            raise RuntimeConfigError(outstr) from e
+        return build_runtime_from_config(
+            project_dir=_project_dir, config=runtime_configuration
+        )
 
     # region LOADING FROM FILE
     @classmethod

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -10,6 +10,8 @@ from pathlib import Path
 
 from packaging.version import parse as parse_version
 
+from orquestra.sdk._base._factory import build_runtime_from_config
+
 from ...exceptions import (
     ConfigFileNotFoundError,
     ConfigNameNotFoundError,
@@ -234,14 +236,27 @@ class RuntimeConfig:
             except AttributeError:
                 continue
 
-        return _build_runtime(
-            _project_dir,
-            RuntimeConfiguration(
-                config_name=str(self._name),
-                runtime_name=self._runtime_name,
-                runtime_options=runtime_options,
-            ),
+        runtime_configuration = RuntimeConfiguration(
+            config_name=str(self._name),
+            runtime_name=self._runtime_name,
+            runtime_options=runtime_options,
         )
+
+        try:
+            return build_runtime_from_config(
+                project_dir=project_dir, config=runtime_configuration
+            )
+        except KeyError as e:
+            outstr = (
+                f"Runtime configuration '{runtime_configuration.config_name}' "
+                f"lacks the required field '{e}'."
+            )
+            if e == "temp_dir":
+                outstr += (
+                    " You may need to migrate your config file using "
+                    "`sdk.migrate_config_file()`"
+                )
+            raise RuntimeConfigError(outstr) from e
 
     # region LOADING FROM FILE
     @classmethod
@@ -249,10 +264,6 @@ class RuntimeConfig:
         cls,
     ) -> list:
         """List previously saved configurations.
-
-        Args:
-            config_save_file: The path to the config file from which to read. If
-                omitted, the default config file will be used.
 
         Returns:
             list: list of configurations within the save file.
@@ -329,23 +340,6 @@ class RuntimeConfig:
         config._config_save_file = _config_save_file
 
         return config
-
-    @classmethod
-    def load_default(
-        cls,
-    ) -> "RuntimeConfig":
-        """Load the default configuration from a file.
-
-        Args:
-            config_save_file (optional): The path to the file in which configurations
-                are stored. If omitted, the default file location is used.
-
-        Returns:
-            RuntimeConfig: The configuration as loaded from the file.
-        """
-
-        config_data: RuntimeConfiguration = _config.read_config(None)
-        return cls._config_from_runtimeconfiguration(config_data)
 
     @classmethod
     def _config_from_runtimeconfiguration(
@@ -487,33 +481,6 @@ def migrate_config_file():
     )
     for config_name in changed:
         print(f" - {config_name}")
-
-
-def _build_runtime(
-    project_dir: Path, runtime_configuration: RuntimeConfiguration
-) -> RuntimeInterface:  # pragma: no cover - tested in runtime repo.
-    """
-    Extracted from RuntimeConfig._get_runtime() to be able to mock in unit tests.
-
-    Hopefully we'll be able to get rid of this when we merge SDK and Runtime repos.
-    """
-    import orquestra.sdk._base._factory  # type: ignore
-
-    try:
-        return orquestra.sdk._base._factory.build_runtime_from_config(
-            project_dir=project_dir, config=runtime_configuration
-        )
-    except KeyError as e:
-        outstr = (
-            f"Runtime configuration '{runtime_configuration.config_name}' "
-            f"lacks the required field '{e}'."
-        )
-        if e == "temp_dir":
-            outstr += (
-                " You may need to migrate your config file using "
-                "`sdk.migrate_config_file()`"
-            )
-        raise RuntimeConfigError(outstr) from e
 
 
 def _resolve_config(

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -226,7 +226,6 @@ class RuntimeConfig:
         Returns:
             Runtime: The runtime specified by the configuration.
         """
-
         _project_dir: Path = Path(project_dir or Path.cwd())
 
         runtime_options = {}
@@ -244,7 +243,7 @@ class RuntimeConfig:
 
         try:
             return build_runtime_from_config(
-                project_dir=project_dir, config=runtime_configuration
+                project_dir=_project_dir, config=runtime_configuration
             )
         except KeyError as e:
             outstr = (

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -368,7 +368,7 @@ def save_or_update(config_name, runtime_name, runtime_options):
 
 
 def write_config(
-    config_name: Optional[str],
+    config_name: str,
     runtime_name: Union[RuntimeName, str],
     runtime_options: dict,
 ) -> Tuple[RuntimeConfiguration, Path]:

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -596,7 +596,7 @@ class QERuntime(RuntimeInterface):
             workflow_def=workflow_def,
             is_qe=True,
         )
-        with WorkflowDB.open_project_db(self._project_dir) as db:
+        with WorkflowDB.open_db() as db:
             db.save_workflow_run(wf_run)
 
         return workflow_run_id
@@ -614,7 +614,7 @@ class QERuntime(RuntimeInterface):
                 found in the local database.
         """
         try:
-            with WorkflowDB.open_project_db(self._project_dir) as db:
+            with WorkflowDB.open_db() as db:
                 try:
                     wf_run = db.get_workflow_run(workflow_run_id)
                 except exceptions.WorkflowNotFoundError:
@@ -666,7 +666,7 @@ class QERuntime(RuntimeInterface):
             A list of objects given by the "output_ids" inside the workflow definition
         """
         try:
-            with WorkflowDB.open_project_db(self._project_dir) as db:
+            with WorkflowDB.open_db() as db:
                 wf_run = db.get_workflow_run(workflow_run_id)
         except sqlite3.OperationalError as e:
             raise exceptions.NotFoundError(workflow_run_id) from e
@@ -721,7 +721,7 @@ class QERuntime(RuntimeInterface):
              a dictionary of:
                  task invocation IDs: value returned from each invocation
         """
-        with WorkflowDB.open_project_db(self._project_dir) as db:
+        with WorkflowDB.open_db() as db:
             wf_run = db.get_workflow_run(workflow_run_id)
         wf_def = wf_run.workflow_def
         # Return dict contains return values for task invocation
@@ -888,7 +888,7 @@ class QERuntime(RuntimeInterface):
         now = datetime.now(timezone.utc)
 
         # Grab the workflows we know about from the DB
-        with WorkflowDB.open_project_db(self._project_dir) as db:
+        with WorkflowDB.open_db() as db:
             stored_runs = db.get_workflow_runs_list(
                 config_name=self._config.config_name
             )

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -596,7 +596,7 @@ class QERuntime(RuntimeInterface):
             workflow_def=workflow_def,
             is_qe=True,
         )
-        with WorkflowDB.open_db() as db:
+        with WorkflowDB.open_project_db(self._project_dir) as db:
             db.save_workflow_run(wf_run)
 
         return workflow_run_id
@@ -614,7 +614,7 @@ class QERuntime(RuntimeInterface):
                 found in the local database.
         """
         try:
-            with WorkflowDB.open_db() as db:
+            with WorkflowDB.open_project_db(self._project_dir) as db:
                 try:
                     wf_run = db.get_workflow_run(workflow_run_id)
                 except exceptions.WorkflowNotFoundError:
@@ -666,7 +666,7 @@ class QERuntime(RuntimeInterface):
             A list of objects given by the "output_ids" inside the workflow definition
         """
         try:
-            with WorkflowDB.open_db() as db:
+            with WorkflowDB.open_project_db(self._project_dir) as db:
                 wf_run = db.get_workflow_run(workflow_run_id)
         except sqlite3.OperationalError as e:
             raise exceptions.NotFoundError(workflow_run_id) from e
@@ -721,7 +721,7 @@ class QERuntime(RuntimeInterface):
              a dictionary of:
                  task invocation IDs: value returned from each invocation
         """
-        with WorkflowDB.open_db() as db:
+        with WorkflowDB.open_project_db(self._project_dir) as db:
             wf_run = db.get_workflow_run(workflow_run_id)
         wf_def = wf_run.workflow_def
         # Return dict contains return values for task invocation
@@ -888,7 +888,7 @@ class QERuntime(RuntimeInterface):
         now = datetime.now(timezone.utc)
 
         # Grab the workflows we know about from the DB
-        with WorkflowDB.open_db() as db:
+        with WorkflowDB.open_project_db(self._project_dir) as db:
             stored_runs = db.get_workflow_runs_list(
                 config_name=self._config.config_name
             )

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -160,7 +160,7 @@ class WorkflowDef(Generic[_R]):
 
     def run(
         self,
-        config: Optional[Union[_api.RuntimeConfig, str]] = None,
+        config: Union[_api.RuntimeConfig, str],
         project_dir: Optional[Union[str, Path]] = None,
         workspace_id: Optional[WorkspaceId] = None,
         project_id: Optional[ProjectId] = None,
@@ -184,19 +184,6 @@ class WorkflowDef(Generic[_R]):
             ProjectInvalidError: when only 1 out of project and workspace is passed
 
         """
-        # This exists for users who have gotten used to doing `run()`. Once this has
-        # been released, the following release should make config a required argument
-        # and remove this check.
-        if config is None:
-            raise FutureWarning(
-                "Please specify the runtime configuration for this run. "
-                "The built in `local` and `in_process` configurations can be used by "
-                'calling `run("local")` and `run("in_process")` respectively. '
-                "User defined configurations can be specified by providing the name "
-                "under which they are saved, or passing in the RuntimeConfig object "
-                "directly. "
-            )
-
         _config: _api.RuntimeConfig
         if isinstance(config, _api.RuntimeConfig):
             _config = config

--- a/src/orquestra/sdk/secrets/_auth.py
+++ b/src/orquestra/sdk/secrets/_auth.py
@@ -25,7 +25,7 @@ def _authorize_with_passport() -> t.Optional[SecretsClient]:
     return SecretsClient.from_token(base_uri=BASE_URI, token=passport_token)
 
 
-def _read_config_opts(config_name: t.Optional[ConfigName]):
+def _read_config_opts(config_name: ConfigName):
     try:
         cfg = _config.read_config(config_name=config_name)
     except exceptions.ConfigNameNotFoundError:
@@ -35,7 +35,7 @@ def _read_config_opts(config_name: t.Optional[ConfigName]):
 
 
 def _authorize_with_config(
-    config_name: t.Optional[ConfigName],
+    config_name: ConfigName,
 ) -> SecretsClient:
     try:
         opts = _read_config_opts(config_name)
@@ -56,6 +56,11 @@ def authorized_client(config_name: t.Optional[ConfigName]) -> SecretsClient:
     # added here.
     if (passport_client := _authorize_with_passport()) is not None:
         return passport_client
+
+    if config_name is None:
+        raise exceptions.ConfigNameNotFoundError(
+            "Please provide config name while accessing the secrets locally"
+        )
 
     try:
         return _authorize_with_config(config_name)

--- a/tests/runtime/test_config.py
+++ b/tests/runtime/test_config.py
@@ -24,23 +24,6 @@ from orquestra.sdk._base import _config
 from orquestra.sdk.schema.configs import RuntimeName
 
 
-class TestSavePartialConfig:
-    """
-    Tests for _config.save_partial_config()
-    """
-
-    def test_saving_local(self, monkeypatch, patch_config_location):
-        # We wanna ensure the 'local' was resolved
-        monkeypatch.setattr(_config, "_resolve_config_name", Mock("local"))
-
-        with pytest.raises(ValueError):
-            _config.update_config(
-                config_name="w/e",
-                runtime_name=None,
-                new_runtime_options=None,
-            )
-
-
 class TestProperties:
     """
     Tests focused on testing properties of the config, not specific output values.

--- a/tests/runtime/test_config.py
+++ b/tests/runtime/test_config.py
@@ -35,7 +35,7 @@ class TestSavePartialConfig:
 
         with pytest.raises(ValueError):
             _config.update_config(
-                config_name=None,
+                config_name="w/e",
                 runtime_name=None,
                 new_runtime_options=None,
             )

--- a/tests/sdk/v2/api/test_config.py
+++ b/tests/sdk/v2/api/test_config.py
@@ -349,38 +349,6 @@ class TestRuntimeConfiguration:
                         "auto",
                     )
 
-    class TestLoadDefault:
-        @staticmethod
-        def test_with_default_file_path(tmp_default_config_json):
-            config = api_cfg.RuntimeConfig.load_default()
-
-            default_config_params = TEST_CONFIGS_DICT[
-                TEST_CONFIG_JSON["default_config_name"]
-            ]
-            assert config.name == default_config_params["config_name"]
-            assert config._runtime_name == default_config_params["runtime_name"]
-
-            config_uri = config.uri  # type: ignore
-            assert config_uri == default_config_params["runtime_options"]["uri"]
-
-            assert config.token == default_config_params["runtime_options"]["token"]
-
-        @staticmethod
-        def test_with_custom_file_path(tmp_config_json, monkeypatch):
-            monkeypatch.setenv("ORQ_CONFIG_PATH", str(tmp_config_json))
-            config = api_cfg.RuntimeConfig.load_default()
-
-            default_config_params = TEST_CONFIGS_DICT[
-                TEST_CONFIG_JSON["default_config_name"]
-            ]
-            assert config.name == default_config_params["config_name"]
-            assert config._runtime_name == default_config_params["runtime_name"]
-
-            config_uri = config.uri  # type: ignore
-            assert config_uri == default_config_params["runtime_options"]["uri"]
-
-            assert config.token == default_config_params["runtime_options"]["token"]
-
 
 @pytest.mark.parametrize(
     "input_config_file, expected_output_config_file, expected_stdout",

--- a/tests/sdk/v2/api/test_wf_run.py
+++ b/tests/sdk/v2/api/test_wf_run.py
@@ -912,11 +912,6 @@ class TestWorkflowRun:
 
             assert wf.config == config
 
-        @staticmethod
-        def test_no_config_run():
-            with pytest.raises(FutureWarning):
-                wf_pass_tuple().run()
-
     class TestStop:
         @staticmethod
         def test_happy_path():

--- a/tests/sdk/v2/secrets/test_auth.py
+++ b/tests/sdk/v2/secrets/test_auth.py
@@ -132,11 +132,8 @@ class TestAuthorizedClient:
             there's no passport env variable.
             """
             # When
-            client = _auth.authorized_client(config_name=None)
-
-            # Then
-            assert client._base_uri == uri
-            assert client._session.headers["Authorization"] == f"Bearer {token}"
+            with pytest.raises(exceptions.ConfigNameNotFoundError):
+                _auth.authorized_client(config_name=None)
 
         @staticmethod
         def test_missing_config_name(patch_config_location):

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -64,6 +64,14 @@ class TestResolveRuntimeNameForWriting:
         assert resolved_runtime_name == stub_prev_config.runtime_name
 
 
+class TestSaveOrUpdate:
+    @staticmethod
+    @pytest.mark.parametrize("config_name", ["in_process", "ray"])
+    def test_throws_when_special_config_used(config_name):
+        with pytest.raises(ValueError):
+            _config.save_or_update(config_name, "w/e", {})
+
+
 class TestResolveConfigFileForReading:
     @staticmethod
     def test_returns_none_for_nonexistant_file_default_location(patch_config_location):

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -45,7 +45,7 @@ class TestSavePartialConfig:
 
         with pytest.raises(ValueError):
             _config.update_config(
-                config_name=None,
+                config_name="w/e",
                 runtime_name=None,
                 new_runtime_options=None,
             )

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -32,25 +32,6 @@ from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
 from .data.configs import TEST_CONFIG_JSON
 
 
-class TestSavePartialConfig:
-    """
-    Tests for _config.save_partial_config()
-    """
-
-    @staticmethod
-    @pytest.mark.parametrize("resolved_config_name", ["local", "in_process", "ray"])
-    def test_saving_local(resolved_config_name, monkeypatch, patch_config_location):
-        # We want to ensure the 'local' and 'in_process' configs are resolved
-        monkeypatch.setattr(_config, "_resolve_config_name", Mock(resolved_config_name))
-
-        with pytest.raises(ValueError):
-            _config.update_config(
-                config_name="w/e",
-                runtime_name=None,
-                new_runtime_options=None,
-            )
-
-
 class TestResolveRuntimeOptionsForWriting:
     @staticmethod
     def test_returns_builtins_if_name_is_builtin():
@@ -81,16 +62,6 @@ class TestResolveRuntimeNameForWriting:
         )
 
         assert resolved_runtime_name == stub_prev_config.runtime_name
-
-
-class TestResolveConfigNameForWriting:
-    @staticmethod
-    def test_raises_exception_if_name_is_builtin():
-        builtin_name = _config.BUILT_IN_CONFIG_NAME
-
-        with pytest.raises(ValueError) as exc_info:
-            _config._resolve_config_name_for_writing(builtin_name)
-        assert f"Can't write {builtin_name}, it's a reserved name" in str(exc_info)
 
 
 class TestResolveConfigFileForReading:

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -89,7 +89,7 @@ class TestResolveConfigNameForWriting:
         builtin_name = _config.BUILT_IN_CONFIG_NAME
 
         with pytest.raises(ValueError) as exc_info:
-            _config._resolve_config_name_for_writing(builtin_name, None)
+            _config._resolve_config_name_for_writing(builtin_name)
         assert f"Can't write {builtin_name}, it's a reserved name" in str(exc_info)
 
 
@@ -104,17 +104,6 @@ class TestResolveConfigFileForReading:
     ):
         monkeypatch.setenv("ORQ_CONFIG_PATH", str(tmp_path / "test.file"))
         assert _config._resolve_config_file_for_reading() is None
-
-
-class TestResolveConfigName:
-    @staticmethod
-    def test_raises_exception_if_cannot_resolve_name():
-        with pytest.raises(ValueError) as exc_info:
-            _config._resolve_config_name(None, None)
-        assert (
-            "Couldn't resolve an appropriate config name to read the "
-            "configuration from. Please pass it explicitly."
-        ) in str(exc_info)
 
 
 class TestResolveConfigEntryForReading:
@@ -142,55 +131,6 @@ class TestGenerateConfigName:
         assert "QE and CE runtime configurations must have a 'URI' value set." in str(
             exc_info
         )
-
-
-class TestReadDefaultConfigName:
-    @staticmethod
-    def test_happy_path(patch_config_location):
-        test_config_name = "test_name"
-        with open(patch_config_location / "config.json", "w") as f:
-            json.dump(
-                {
-                    "version": "0.0.0",
-                    "configs": {},
-                    "default_config_name": test_config_name,
-                },
-                f,
-            )
-
-        assert _config.read_default_config_name() == test_config_name
-
-    @staticmethod
-    def test_returns_builtins_if_no_file_found(patch_config_location):
-        assert _config.read_default_config_name() == _config.BUILT_IN_CONFIG_NAME
-
-
-class TestUpdateDefaultConfigName:
-    @staticmethod
-    def test_no_previous_config_file(patch_config_location):
-        _config.update_default_config_name("hello there")
-
-        with open(patch_config_location / "config.json", "r") as f:
-            data = json.load(f)
-        assert data["default_config_name"] == "hello there"
-
-    @staticmethod
-    def test_with_previous_config_file(patch_config_location):
-        with open(patch_config_location / "config.json", "w") as f:
-            json.dump(
-                {
-                    "version": "0.0.0",
-                    "configs": {},
-                    "default_config_name": "hello there",
-                },
-                f,
-            )
-
-        _config.update_default_config_name("general kenobi")
-
-        with open(patch_config_location / "config.json", "r") as f:
-            data = json.load(f)
-        assert data["default_config_name"] == "general kenobi"
 
 
 class TestValidateRuntimeOptions:


### PR DESCRIPTION
# The problem

We simplified config management a while ago. Users could no longer set default config but they could still read it and sometimes it would be used on random occasions.

# This PR's solution

Remove all references to default config

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
