### PR TITLE
refactor: single place for handling dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 💅 *Improvements*
 
 🥷 *Internal*
+* Refactored `datetime` and timezone handling.
 
 📃 *Docs*
 

--- a/src/orquestra/sdk/_base/_dates.py
+++ b/src/orquestra/sdk/_base/_dates.py
@@ -1,0 +1,54 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Single place to handle datetimes and timezones without shooting yourself in the
+foot.
+"""
+
+from datetime import datetime, timezone
+
+
+def now() -> datetime:
+    """
+    Generates a timezone-aware current instant. The timezone is set to UTC.
+    """
+    return datetime.now(timezone.utc)
+
+
+def local_isoformat(instant: datetime) -> str:
+    """
+    Formats the instant using ISO8601 format with explicit time zone. The instant is
+    shifted to a local timezone for human-friendliness.
+    """
+    if instant.tzinfo is None:
+        raise ValueError("We only work with timezone-aware datetimes")
+
+    local_instant = instant.astimezone()
+    return local_instant.isoformat()
+
+
+def from_isoformat(formatted: str) -> datetime:
+    instant = datetime.fromisoformat(formatted.replace("Z", "+00:00"))
+    if instant.tzinfo is None:
+        raise ValueError("We only work with timezone-aware datetimes")
+
+    return instant
+
+
+def unix_time(instant: datetime) -> float:
+    """
+    Generates a timezone-aware datetime object from a UNIX epoch timestamp (UTC seconds
+    since 1970).
+    """
+    if instant.tzinfo is None:
+        raise ValueError("We only work with timezone-aware datetimes")
+    return instant.timestamp()
+
+
+def from_unix_time(epoch_seconds: float) -> datetime:
+    """
+    Parses a unix epoch timestamp (UTC seconds since 1970) into a
+    timezone-aware datetime object.
+    """
+    return datetime.fromtimestamp(epoch_seconds, timezone.utc)

--- a/src/orquestra/sdk/_base/_dates.py
+++ b/src/orquestra/sdk/_base/_dates.py
@@ -6,14 +6,18 @@ Single place to handle datetimes and timezones without shooting yourself in the
 foot.
 """
 
+import typing as t
 from datetime import datetime, timezone
 
+# Timezone-aware datetime. Represents an unambiguous time instant.
+Instant = t.NewType("Instant", datetime)
 
-def now() -> datetime:
+
+def now() -> Instant:
     """
     Generates a timezone-aware current instant. The timezone is set to UTC.
     """
-    return datetime.now(timezone.utc)
+    return Instant(datetime.now(timezone.utc))
 
 
 def local_isoformat(instant: datetime) -> str:
@@ -28,15 +32,15 @@ def local_isoformat(instant: datetime) -> str:
     return local_instant.isoformat()
 
 
-def from_isoformat(formatted: str) -> datetime:
+def from_isoformat(formatted: str) -> Instant:
     instant = datetime.fromisoformat(formatted.replace("Z", "+00:00"))
     if instant.tzinfo is None:
         raise ValueError("We only work with timezone-aware datetimes")
 
-    return instant
+    return Instant(instant)
 
 
-def unix_time(instant: datetime) -> float:
+def unix_time(instant: Instant) -> float:
     """
     Generates a timezone-aware datetime object from a UNIX epoch timestamp (UTC seconds
     since 1970).
@@ -46,9 +50,9 @@ def unix_time(instant: datetime) -> float:
     return instant.timestamp()
 
 
-def from_unix_time(epoch_seconds: float) -> datetime:
+def from_unix_time(epoch_seconds: float) -> Instant:
     """
     Parses a unix epoch timestamp (UTC seconds since 1970) into a
     timezone-aware datetime object.
     """
-    return datetime.fromtimestamp(epoch_seconds, timezone.utc)
+    return Instant(datetime.fromtimestamp(epoch_seconds, timezone.utc))

--- a/src/orquestra/sdk/_base/_dates.py
+++ b/src/orquestra/sdk/_base/_dates.py
@@ -20,16 +20,28 @@ def now() -> Instant:
     return Instant(datetime.now(timezone.utc))
 
 
-def local_isoformat(instant: datetime) -> str:
+def isoformat(instant: Instant) -> str:
     """
-    Formats the instant using ISO8601 format with explicit time zone. The instant is
-    shifted to a local timezone for human-friendliness.
+    Formats the instant using ISO8601 format with explicit time zone.
     """
     if instant.tzinfo is None:
         raise ValueError("We only work with timezone-aware datetimes")
 
+    return instant.isoformat()
+
+
+def local_isoformat(instant: Instant) -> str:
+    """
+    Formats the instant using ISO8601 format with explicit time zone. The instant is
+    shifted to a local timezone for human-friendliness.
+    """
+    # We need to check it as soon as possible. `.astimezone()` overrides empty tzinfo
+    # with local time zone.
+    if instant.tzinfo is None:
+        raise ValueError("We only work with timezone-aware datetimes")
+
     local_instant = instant.astimezone()
-    return local_instant.isoformat()
+    return isoformat(local_instant)
 
 
 def from_isoformat(formatted: str) -> Instant:

--- a/src/orquestra/sdk/_base/_dates.py
+++ b/src/orquestra/sdk/_base/_dates.py
@@ -7,7 +7,7 @@ foot.
 """
 
 import typing as t
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 # Timezone-aware datetime. Represents an unambiguous time instant.
 Instant = t.NewType("Instant", datetime)
@@ -56,3 +56,41 @@ def from_unix_time(epoch_seconds: float) -> Instant:
     timezone-aware datetime object.
     """
     return Instant(datetime.fromtimestamp(epoch_seconds, timezone.utc))
+
+
+def from_comps(
+    year,
+    month,
+    day,
+    hour,
+    minute,
+    second,
+    microsecond,
+    utc_hour_offset: int,
+) -> Instant:
+    """
+    Builds an instant from from timezone-local date components.
+    """
+    # I wanted to use `*args` instead of enumerating all the components one-by-one but I
+    # couldn't appease mypy errors.
+    return Instant(
+        datetime(
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            microsecond,
+            tzinfo=timezone(timedelta(hours=utc_hour_offset)),
+        )
+    )
+
+
+def utc_from_comps(*args, **kwargs) -> Instant:
+    """
+    Builds an timezone-aware instant from specific date components. The components
+    should be in UTC.
+    """
+    new_kwargs = {**kwargs, "utc_hour_offset": 0}
+    return from_comps(*args, **new_kwargs)

--- a/src/orquestra/sdk/_base/_dates.py
+++ b/src/orquestra/sdk/_base/_dates.py
@@ -59,32 +59,21 @@ def from_unix_time(epoch_seconds: float) -> Instant:
 
 
 def from_comps(
-    year,
-    month,
-    day,
-    hour,
-    minute,
-    second,
-    microsecond,
-    utc_hour_offset: int,
+    *args,
+    utc_hour_offset,
+    **kwargs,
 ) -> Instant:
     """
-    Builds an instant from from timezone-local date components.
+    Builds an instant from from timezone-local date components. Uses the same components
+    as ``datetime.datetime(...)``, apart from ``tzinfo``.
     """
-    # I wanted to use `*args` instead of enumerating all the components one-by-one but I
-    # couldn't appease mypy errors.
-    return Instant(
-        datetime(
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-            microsecond,
-            tzinfo=timezone(timedelta(hours=utc_hour_offset)),
-        )
-    )
+
+    new_kwargs: t.Dict[str, t.Any] = {
+        **kwargs,
+        "tzinfo": timezone(timedelta(hours=utc_hour_offset)),
+    }
+
+    return Instant(datetime(*args, **new_kwargs))
 
 
 def utc_from_comps(*args, **kwargs) -> Instant:

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -4,7 +4,6 @@
 """
 Internal models for the workflow driver API
 """
-from datetime import datetime
 from enum import Enum
 from typing import (
     Generic,
@@ -22,6 +21,7 @@ import pydantic
 from pydantic.generics import GenericModel
 from typing_extensions import Annotated
 
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.workflow_run import (
     ProjectId,
@@ -99,7 +99,7 @@ class GetWorkflowDefResponse(pydantic.BaseModel):
     """
 
     id: WorkflowDefID
-    created: datetime
+    created: Instant
     owner: str
     workflow: WorkflowDef
     workspaceId: WorkspaceId
@@ -158,8 +158,8 @@ class RunStatusResponse(pydantic.BaseModel):
     """
 
     state: StateResponse
-    startTime: Optional[datetime]
-    endTime: Optional[datetime]
+    startTime: Optional[Instant]
+    endTime: Optional[Instant]
 
     def to_ir(self) -> RunStatus:
         return RunStatus(

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import abc
+from orquestra.sdk._base import _dates, abc
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.responses import WorkflowResult
@@ -143,7 +143,7 @@ class InProcessRuntime(abc.RuntimeInterface):
 
         run_id = self._gen_next_run_id(workflow_def)
 
-        self._start_time_store[run_id] = datetime.now(timezone.utc)
+        self._start_time_store[run_id] = _dates.now()
 
         # We deserialize the constants in one go, instead of as needed
         consts: t.Dict[ir.ConstantNodeId, t.Any] = {
@@ -194,7 +194,7 @@ class InProcessRuntime(abc.RuntimeInterface):
         )
         self._output_store[run_id] = outputs
 
-        self._end_time_store[run_id] = datetime.now(timezone.utc)
+        self._end_time_store[run_id] = _dates.now()
         self._workflow_def_store[run_id] = workflow_def
         return run_id
 
@@ -303,7 +303,7 @@ class InProcessRuntime(abc.RuntimeInterface):
             raise exceptions.WorkspacesNotSupportedError(
                 "Filtering by workspace is not supported on In Process runtimes."
             )
-        now = datetime.now(timezone.utc)
+        now = _dates.now()
 
         if state is not None:
             if not isinstance(state, list):

--- a/src/orquestra/sdk/_base/_log_adapter.py
+++ b/src/orquestra/sdk/_base/_log_adapter.py
@@ -8,8 +8,8 @@ Log adapter adds a workflow context to logs, Workflow ID and Task ID.
 import json
 import logging
 import typing as t
-from datetime import datetime, timezone
 
+from orquestra.sdk._base import _dates
 from orquestra.sdk._base._api._task_run import current_run_ids
 from orquestra.sdk.schema.ir import TaskInvocationId
 from orquestra.sdk.schema.workflow_run import TaskRunId, WorkflowRunId
@@ -64,8 +64,8 @@ class ISOFormatter(logging.Formatter):
         Example output: ``2023-02-02T11:45:21.504754+00:00``
         """
         utc_timestamp = record.created
-        instant = datetime.fromtimestamp(utc_timestamp, timezone.utc)
-        return instant.isoformat()
+        instant = _dates.from_unix_time(utc_timestamp)
+        return _dates.local_isoformat(instant)
 
 
 def _make_logger(

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -22,7 +22,7 @@ import pydantic
 import requests
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import serde
+from orquestra.sdk._base import _dates, serde
 from orquestra.sdk._base._conversions._yaml_exporter import (
     pydantic_to_yaml,
     workflow_to_yaml,
@@ -885,7 +885,7 @@ class QERuntime(RuntimeInterface):
                 "Filtering by workspace or project is not supported on QE runtimes."
             )
 
-        now = datetime.now(timezone.utc)
+        now = _dates.now()
 
         # Grab the workflows we know about from the DB
         with WorkflowDB.open_project_db(self._project_dir) as db:

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -19,7 +19,7 @@ from typing_extensions import assert_never
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import _config, _db, loader
+from orquestra.sdk._base import _config, _dates, _db, loader
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._jwt import check_jwt_without_signature_verification
 from orquestra.sdk._base._qe import _client
@@ -495,9 +495,7 @@ class SummaryRepo:
         wf_runs.sort(
             key=lambda wf_run: wf_run.status.start_time
             if wf_run.status.start_time
-            else datetime.datetime.fromtimestamp(0).replace(
-                tzinfo=datetime.timezone.utc
-            )
+            else _dates.from_unix_time(0)
         )
 
         return ui_models.WFList(wf_rows=[_ui_model_from_wf(wf) for wf in wf_runs])

--- a/src/orquestra/sdk/_base/cli/_dorq/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_repos.py
@@ -6,7 +6,6 @@ Repositories that encapsulate data access used by dorq commands.
 
 The "data" layer. Shouldn't directly depend on the "view" layer.
 """
-import datetime
 import importlib
 import os
 import sys

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_corq_format/per_command.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_corq_format/per_command.py
@@ -193,7 +193,7 @@ def _format_datetime(dt: t.Optional[_dates.Instant]) -> str:
         # Print empty table cell
         return ""
 
-    return _dates.local_isoformat(dt)
+    return _dates.isoformat(dt)
 
 
 def _print_single_run(run: responses.WorkflowRun, project_dir: t.Optional[str]):

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_corq_format/per_command.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_corq_format/per_command.py
@@ -4,12 +4,12 @@
 import json
 import pathlib
 import typing as t
-from datetime import datetime
 from functools import singledispatch
 
 import pydantic
 import tabulate
 
+from orquestra.sdk._base import _dates
 from orquestra.sdk.schema import ir, responses, workflow_run
 
 
@@ -188,12 +188,12 @@ Workflow result {res_i}, returned from {fn_name}(), presented as
         print()
 
 
-def _format_datetime(dt: t.Optional[datetime]) -> str:
+def _format_datetime(dt: t.Optional[_dates.Instant]) -> str:
     if dt is None:
         # Print empty table cell
         return ""
 
-    return dt.isoformat()
+    return _dates.local_isoformat(dt)
 
 
 def _print_single_run(run: responses.WorkflowRun, project_dir: t.Optional[str]):

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_models.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_models.py
@@ -6,13 +6,13 @@ UI models. Common data structures between the "data" and "view" layers.
 
 Classes here are containers for information we show to the users in the CLI UI.
 Ideally, most data transformations would be already done (like counting the number of
-inished tasks) but should be easy to assert on in tests (e.g. we prefer ``datetime``
+inished tasks) but should be easy to assert on in tests (e.g. we prefer ``Instant``
 objects instead of date strings).
 """
-import datetime
 import typing as t
 from dataclasses import dataclass
 
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.workflow_run import RunStatus, WorkflowRunId
 
@@ -52,6 +52,6 @@ class WFList:
         workflow_run_id: str
         status: str
         tasks_succeeded: str
-        start_time: t.Optional[datetime.datetime]
+        start_time: t.Optional[Instant]
 
     wf_rows: t.Sequence[WFRow]

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -11,14 +11,14 @@ import sys
 import typing as t
 import webbrowser
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Iterator, List, Sequence
 
 import click
 from tabulate import tabulate
 
-from orquestra.sdk._base import _config, _env, _services, serde
+from orquestra.sdk._base import _config, _dates, _env, _services, serde
 from orquestra.sdk.schema import responses
 from orquestra.sdk.schema.ir import ArtifactFormat
 from orquestra.sdk.schema.workflow_run import (
@@ -294,7 +294,7 @@ class PromptPresenter:
             wfs,
             key=lambda wf: wf.status.start_time
             if wf.status.start_time
-            else datetime.fromtimestamp(0).replace(tzinfo=timezone.utc),
+            else _dates.from_unix_time(0),
             reverse=True,
         )
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_presenters.py
@@ -11,7 +11,6 @@ import sys
 import typing as t
 import webbrowser
 from contextlib import contextmanager
-from datetime import datetime
 from pathlib import Path
 from typing import Iterable, Iterator, List, Sequence
 
@@ -19,6 +18,7 @@ import click
 from tabulate import tabulate
 
 from orquestra.sdk._base import _config, _dates, _env, _services, serde
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk.schema import responses
 from orquestra.sdk.schema.ir import ArtifactFormat
 from orquestra.sdk.schema.workflow_run import (
@@ -222,7 +222,7 @@ class LoginPresenter:
         return webbrowser.open(url)
 
 
-def _format_datetime(dt: t.Optional[datetime]) -> str:
+def _format_datetime(dt: t.Optional[Instant]) -> str:
     return dt.astimezone().replace(tzinfo=None).ctime() if dt else ""
 
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -13,7 +13,7 @@ import os
 import re
 import typing as t
 import warnings
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 
 import pydantic
@@ -47,7 +47,9 @@ from ._client import RayClient
 from ._wf_metadata import InvUserMetadata, WfUserMetadata, pydatic_to_json_dict
 
 
-def _instant_from_timestamp(unix_timestamp: t.Optional[float]) -> t.Optional[datetime]:
+def _instant_from_timestamp(
+    unix_timestamp: t.Optional[float],
+) -> t.Optional[_dates.Instant]:
     if unix_timestamp is None:
         return None
     return _dates.from_unix_time(unix_timestamp)

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -21,7 +21,7 @@ import pydantic
 from orquestra.sdk.schema.responses import WorkflowResult
 
 from .. import exceptions
-from .._base import _services, serde
+from .._base import _dates, _services, serde
 from .._base._db import WorkflowDB
 from .._base._env import RAY_GLOBAL_WF_RUN_ID_ENV
 from .._base._logs._interfaces import LogReader
@@ -48,13 +48,9 @@ from ._wf_metadata import InvUserMetadata, WfUserMetadata, pydatic_to_json_dict
 
 
 def _instant_from_timestamp(unix_timestamp: t.Optional[float]) -> t.Optional[datetime]:
-    """
-    Parses a unix epoch timestamp (UTC seconds since 1970) into a
-    timezone-aware datetime object.
-    """
     if unix_timestamp is None:
         return None
-    return datetime.fromtimestamp(unix_timestamp, timezone.utc)
+    return _dates.from_unix_time(unix_timestamp)
 
 
 def _generate_wf_run_id(wf_def: ir.WorkflowDef):
@@ -514,7 +510,7 @@ class RayRuntime(RuntimeInterface):
             raise exceptions.WorkspacesNotSupportedError(
                 "Filtering by workspace or project is not supported on Ray runtimes."
             )
-        now = datetime.now(timezone.utc)
+        now = _dates.now()
 
         if state is not None:
             if not isinstance(state, list):

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -6,13 +6,11 @@ Class to get logs from Ray for particular Workflow, both historical and live.
 """
 import json
 import typing as t
-
-# from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 
 import pydantic
 
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk._base._logs import _regrouping
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk.schema.ir import TaskInvocationId
@@ -28,7 +26,7 @@ class WFLog(pydantic.BaseModel):
     """
 
     # Timezone-aware date+time.
-    timestamp: datetime
+    timestamp: Instant
     # Log level name, consistent with Python logging.
     level: str
     filename: str

--- a/src/orquestra/sdk/schema/workflow_run.py
+++ b/src/orquestra/sdk/schema/workflow_run.py
@@ -9,10 +9,10 @@ structure here is JSON-serializable.
 
 import enum
 import typing as t
-from datetime import datetime
 
 from pydantic import BaseModel
 
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
 
 WorkflowRunId = str
@@ -38,8 +38,8 @@ class State(enum.Enum):
 
 class RunStatus(BaseModel):
     state: State
-    start_time: t.Optional[datetime]
-    end_time: t.Optional[datetime]
+    start_time: t.Optional[Instant]
+    end_time: t.Optional[Instant]
 
 
 class TaskRun(BaseModel):

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -2,7 +2,7 @@
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
 import typing as t
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import Mock, create_autospec
 
 import pytest

--- a/tests/cli/dorq/test_arg_resolvers.py
+++ b/tests/cli/dorq/test_arg_resolvers.py
@@ -8,7 +8,8 @@ from unittest.mock import Mock, create_autospec
 import pytest
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._base._spaces._structs import Project, ProjectRef, Workspace
+from orquestra.sdk._base import _dates
+from orquestra.sdk._base._spaces._structs import Project, Workspace
 from orquestra.sdk._base.cli._dorq import _arg_resolvers, _repos
 from orquestra.sdk._base.cli._dorq._ui import _presenters, _prompts
 from orquestra.sdk.schema.configs import RuntimeConfiguration
@@ -478,7 +479,7 @@ class TestWFRunResolver:
             User didn't pass ``wf_run_id``.
             """
             # Given
-            current_time = datetime.now().astimezone()
+            current_time = _dates.now().astimezone()
 
             def return_wf(id, time_delay_in_sec: int):
                 run = Mock()
@@ -581,7 +582,7 @@ class TestWFRunResolver:
             User didn't pass ``wf_run_id``.
             """
             # Given
-            current_time = datetime.now()
+            current_time = _dates.now().astimezone()
 
             def return_wf(id, time_delay_in_sec: int):
                 run = Mock()

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -18,8 +18,7 @@ import requests
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import _db
-from orquestra.sdk._base import _dates
+from orquestra.sdk._base import _dates, _db
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._qe._client import QEClient
@@ -36,7 +35,6 @@ from orquestra.sdk.schema.workflow_run import WorkflowRun as WorkflowRunModel
 
 from ... import reloaders
 from ...sdk.v2.data.configs import TEST_CONFIG_JSON
-
 
 INSTANT_1 = _dates.from_comps(2023, 2, 24, 7, 26, 7, 704015, utc_hour_offset=1)
 INSTANT_2 = _dates.from_comps(2023, 2, 24, 7, 28, 37, 123, utc_hour_offset=1)

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -5,11 +5,11 @@
 Tests for repos. Isolated unit tests unless explicitly named as integration.
 """
 
+import datetime
 import json
 import sys
 import typing as t
 import warnings
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import Mock, create_autospec
 
@@ -19,6 +19,7 @@ import requests
 from orquestra import sdk
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _db
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._qe._client import QEClient
@@ -36,26 +37,18 @@ from orquestra.sdk.schema.workflow_run import WorkflowRun as WorkflowRunModel
 from ... import reloaders
 from ...sdk.v2.data.configs import TEST_CONFIG_JSON
 
-INSTANT_1 = datetime(
-    2023,
-    2,
-    24,
-    7,
-    26,
-    7,
-    704015,
-    tzinfo=timezone(timedelta(hours=1)),
-)
-INSTANT_2 = datetime(
-    2023,
-    2,
-    24,
-    7,
-    28,
-    37,
-    123,
-    tzinfo=timezone(timedelta(hours=1)),
-)
+
+def _instant(*args, utc_offset: int) -> Instant:
+    return Instant(
+        datetime.datetime(
+            *args,
+            tzinfo=datetime.timezone(datetime.timedelta(hours=utc_offset)),
+        )
+    )
+
+
+INSTANT_1 = _instant(2023, 2, 24, 7, 26, 7, 704015, utc_offset=1)
+INSTANT_2 = _instant(2023, 2, 24, 7, 28, 37, 123, utc_offset=1)
 
 
 class TestWorkflowRunRepo:
@@ -1098,7 +1091,7 @@ class TestSummaryRepo:
                         ],
                         status=RunStatus(
                             state=State.RUNNING,
-                            start_time=INSTANT_1 + timedelta(seconds=30),
+                            start_time=INSTANT_1 + datetime.timedelta(seconds=30),
                         ),
                     ),
                     WorkflowRunModel(
@@ -1120,7 +1113,7 @@ class TestSummaryRepo:
                             workflow_run_id="wf.2",
                             status="RUNNING",
                             tasks_succeeded="1/2",
-                            start_time=INSTANT_1 + timedelta(seconds=30),
+                            start_time=INSTANT_1 + datetime.timedelta(seconds=30),
                         ),
                     ],
                 ),
@@ -1133,7 +1126,7 @@ class TestSummaryRepo:
                         task_runs=[],
                         status=RunStatus(
                             state=State.RUNNING,
-                            start_time=INSTANT_1 + timedelta(seconds=30),
+                            start_time=INSTANT_1 + datetime.timedelta(seconds=30),
                         ),
                     ),
                     WorkflowRunModel(
@@ -1155,7 +1148,7 @@ class TestSummaryRepo:
                             workflow_run_id="wf.2",
                             status="RUNNING",
                             tasks_succeeded="0/0",
-                            start_time=INSTANT_1 + timedelta(seconds=30),
+                            start_time=INSTANT_1 + datetime.timedelta(seconds=30),
                         ),
                     ],
                 ),

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -19,7 +19,7 @@ import requests
 from orquestra import sdk
 from orquestra.sdk import exceptions
 from orquestra.sdk._base import _db
-from orquestra.sdk._base._dates import Instant
+from orquestra.sdk._base import _dates
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._qe._client import QEClient
@@ -38,17 +38,8 @@ from ... import reloaders
 from ...sdk.v2.data.configs import TEST_CONFIG_JSON
 
 
-def _instant(*args, utc_offset: int) -> Instant:
-    return Instant(
-        datetime.datetime(
-            *args,
-            tzinfo=datetime.timezone(datetime.timedelta(hours=utc_offset)),
-        )
-    )
-
-
-INSTANT_1 = _instant(2023, 2, 24, 7, 26, 7, 704015, utc_offset=1)
-INSTANT_2 = _instant(2023, 2, 24, 7, 28, 37, 123, utc_offset=1)
+INSTANT_1 = _dates.from_comps(2023, 2, 24, 7, 26, 7, 704015, utc_hour_offset=1)
+INSTANT_2 = _dates.from_comps(2023, 2, 24, 7, 28, 37, 123, utc_hour_offset=1)
 
 
 class TestWorkflowRunRepo:

--- a/tests/cli/dorq/ui/test_presenters.py
+++ b/tests/cli/dorq/ui/test_presenters.py
@@ -11,6 +11,7 @@ import pytest
 
 from orquestra import sdk
 from orquestra.sdk._base import serde
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk._base._spaces._structs import Project, Workspace
 from orquestra.sdk._base.cli._dorq._ui import _errors
 from orquestra.sdk._base.cli._dorq._ui import _models as ui_models
@@ -367,26 +368,30 @@ class TestLoginPresenter:
 DATA_DIR = Path(__file__).parent / "data"
 
 
-UTC_INSTANT = datetime(2023, 2, 24, 12, 26, 7, 704015, tzinfo=timezone.utc)
-ET_INSTANT_1 = datetime(
-    2023,
-    2,
-    24,
-    7,
-    26,
-    7,
-    704015,
-    tzinfo=timezone.utc,
+UTC_INSTANT = Instant(datetime(2023, 2, 24, 12, 26, 7, 704015, tzinfo=timezone.utc))
+ET_INSTANT_1 = Instant(
+    datetime(
+        2023,
+        2,
+        24,
+        7,
+        26,
+        7,
+        704015,
+        tzinfo=timezone.utc,
+    )
 )
-ET_INSTANT_2 = datetime(
-    2023,
-    2,
-    24,
-    7,
-    28,
-    37,
-    123,
-    tzinfo=timezone.utc,
+ET_INSTANT_2 = Instant(
+    datetime(
+        2023,
+        2,
+        24,
+        7,
+        28,
+        37,
+        123,
+        tzinfo=timezone.utc,
+    )
 )
 
 

--- a/tests/cli/dorq/workflow/test_list.py
+++ b/tests/cli/dorq/workflow/test_list.py
@@ -4,13 +4,13 @@
 """
 Unit tests for 'orq wf list' glue code.
 """
-import datetime
 import typing as t
 from unittest.mock import Mock
 
 import pytest
 
 from orquestra.sdk import exceptions as exceptions
+from orquestra.sdk._base import _dates
 from orquestra.sdk._base.cli._dorq._workflow import _list
 from orquestra.sdk.schema.workflow_run import RunStatus, State
 
@@ -37,8 +37,8 @@ class TestAction:
             run.id = "fake id"
             run.status = RunStatus(
                 state=State.RUNNING,
-                start_time=datetime.datetime.fromtimestamp(0),
-                end_time=datetime.datetime.fromtimestamp(0),
+                start_time=_dates.from_unix_time(0),
+                end_time=_dates.from_unix_time(0),
             )
             run.task_runs = []
             return run

--- a/tests/runtime/corq/test_format.py
+++ b/tests/runtime/corq/test_format.py
@@ -2,14 +2,13 @@
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
 import json
-from datetime import datetime
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 
 import orquestra.sdk as sdk
-from orquestra.sdk._base import _db
+from orquestra.sdk._base import _dates, _db
 from orquestra.sdk._base.cli._dorq._ui._corq_format import per_command
 from orquestra.sdk.schema import local_database, responses, workflow_run
 
@@ -22,8 +21,8 @@ OK_META = responses.ResponseMetadata(
 
 OK_STATUS = workflow_run.RunStatus(
     state=workflow_run.State.SUCCEEDED,
-    start_time=datetime.fromisoformat("2022-07-19T09:59:03.144368+00:00"),
-    end_time=datetime.fromisoformat("2022-07-19T09:59:03.159318+00:00"),
+    start_time=_dates.from_isoformat("2022-07-19T09:59:03.144368+00:00"),
+    end_time=_dates.from_isoformat("2022-07-19T09:59:03.159318+00:00"),
 )
 
 

--- a/tests/runtime/qe/test_qe_date_conversion.py
+++ b/tests/runtime/qe/test_qe_date_conversion.py
@@ -1,11 +1,9 @@
 ################################################################################
 # © Copyright 2022 Zapata Computing Inc.
 ################################################################################
-import datetime
-
 import pytest
 
-from orquestra.sdk._base._dates import Instant
+from orquestra.sdk._base._dates import Instant, utc_from_comps
 from orquestra.sdk._base._qe._qe_runtime import parse_date_or_none
 
 
@@ -51,7 +49,7 @@ def test_with_invalid_date_str(date_str: str):
 
 
 def _utc_instant(*args) -> Instant:
-    return Instant(datetime.datetime(*args, tzinfo=datetime.timezone.utc))
+    return utc_from_comps(*args)
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/qe/test_qe_date_conversion.py
+++ b/tests/runtime/qe/test_qe_date_conversion.py
@@ -5,6 +5,7 @@ import datetime
 
 import pytest
 
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk._base._qe._qe_runtime import parse_date_or_none
 
 
@@ -49,35 +50,39 @@ def test_with_invalid_date_str(date_str: str):
         parse_date_or_none(date_str)
 
 
+def _utc_instant(*args) -> Instant:
+    return Instant(datetime.datetime(*args, tzinfo=datetime.timezone.utc))
+
+
 @pytest.mark.parametrize(
-    "date_str, expected_datetime",
+    "date_str, expected",
     [
         # RFC3339
         (
             "2006-01-02T15:04:05Z",
-            datetime.datetime(2006, 1, 2, 15, 4, 5, 0, datetime.timezone.utc),
+            _utc_instant(2006, 1, 2, 15, 4, 5, 0),
         ),
         (
             "1989-12-13T00:00:00Z",
-            datetime.datetime(1989, 12, 13, 0, 0, 0, 0, datetime.timezone.utc),
+            _utc_instant(1989, 12, 13, 0, 0, 0, 0),
         ),
         # RFC3339Nano
         (
             "2006-01-02T15:04:05.999999999Z",
-            datetime.datetime(2006, 1, 2, 15, 4, 5, 999999, datetime.timezone.utc),
+            _utc_instant(2006, 1, 2, 15, 4, 5, 999999),
         ),
         (
             "2006-01-02T15:04:05.999999Z",
-            datetime.datetime(2006, 1, 2, 15, 4, 5, 999999, datetime.timezone.utc),
+            _utc_instant(2006, 1, 2, 15, 4, 5, 999999),
         ),
         (
             "1989-12-13T00:00:00.198922Z",
-            datetime.datetime(1989, 12, 13, 0, 0, 0, 198922, datetime.timezone.utc),
+            _utc_instant(1989, 12, 13, 0, 0, 0, 198922),
         ),
     ],
 )
-def test_with_zulu(date_str: str, expected_datetime: datetime.datetime):
-    assert parse_date_or_none(date_str) == expected_datetime
+def test_with_zulu(date_str: str, expected: Instant):
+    assert parse_date_or_none(date_str) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -673,7 +673,7 @@ class TestGetAvailableOutputs:
 
 
 def _utc_instant(*args) -> _dates.Instant:
-    return _dates.Instant(datetime.datetime(*args, tzinfo=datetime.timezone.utc))
+    return _dates.utc_from_comps(*args)
 
 
 class TestGetWorkflowRunStatus:

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -672,6 +672,10 @@ class TestGetAvailableOutputs:
         assert result["invocation-0-task-make-greeting-message"] == expected_inv_0
 
 
+def _utc_instant(*args) -> _dates.Instant:
+    return _dates.Instant(datetime.datetime(*args, tzinfo=datetime.timezone.utc))
+
+
 class TestGetWorkflowRunStatus:
     def test_happy_path(self, monkeypatch, runtime, mocked_responses):
         _get_workflow_run = Mock(
@@ -700,12 +704,8 @@ class TestGetWorkflowRunStatus:
                     invocation_id="invocation-1-task-multi-output-test",
                     status=RunStatus(
                         state=State.SUCCEEDED,
-                        start_time=datetime.datetime(
-                            1989, 12, 13, 9, 3, 49, tzinfo=datetime.timezone.utc
-                        ),
-                        end_time=datetime.datetime(
-                            1989, 12, 13, 9, 4, 28, tzinfo=datetime.timezone.utc
-                        ),
+                        start_time=_utc_instant(1989, 12, 13, 9, 3, 49),
+                        end_time=_utc_instant(1989, 12, 13, 9, 4, 28),
                     ),
                 ),
                 TaskRun(
@@ -713,23 +713,15 @@ class TestGetWorkflowRunStatus:
                     invocation_id="invocation-0-task-make-greeting-message",
                     status=RunStatus(
                         state=State.SUCCEEDED,
-                        start_time=datetime.datetime(
-                            1989, 12, 13, 9, 4, 29, tzinfo=datetime.timezone.utc
-                        ),
-                        end_time=datetime.datetime(
-                            1989, 12, 13, 9, 5, 8, tzinfo=datetime.timezone.utc
-                        ),
+                        start_time=_utc_instant(1989, 12, 13, 9, 4, 29),
+                        end_time=_utc_instant(1989, 12, 13, 9, 5, 8),
                     ),
                 ),
             ],
             status=RunStatus(
                 state=State.SUCCEEDED,
-                start_time=datetime.datetime(
-                    1989, 12, 13, 9, 3, 49, tzinfo=datetime.timezone.utc
-                ),
-                end_time=datetime.datetime(
-                    1989, 12, 13, 9, 5, 14, tzinfo=datetime.timezone.utc
-                ),
+                start_time=_utc_instant(1989, 12, 13, 9, 3, 49),
+                end_time=_utc_instant(1989, 12, 13, 9, 5, 14),
             ),
         )
 
@@ -878,12 +870,8 @@ class TestGetWorkflowRunStatus:
                     invocation_id="invocation-1-task-multi-output-test",
                     status=RunStatus(
                         state=State.SUCCEEDED,
-                        start_time=datetime.datetime(
-                            1989, 12, 13, 9, 3, 49, tzinfo=datetime.timezone.utc
-                        ),
-                        end_time=datetime.datetime(
-                            1989, 12, 13, 9, 4, 28, tzinfo=datetime.timezone.utc
-                        ),
+                        start_time=_utc_instant(1989, 12, 13, 9, 3, 49),
+                        end_time=_utc_instant(1989, 12, 13, 9, 4, 28),
                     ),
                 ),
                 TaskRun(
@@ -891,23 +879,15 @@ class TestGetWorkflowRunStatus:
                     invocation_id="invocation-0-task-make-greeting-message",
                     status=RunStatus(
                         state=State.SUCCEEDED,
-                        start_time=datetime.datetime(
-                            1989, 12, 13, 9, 4, 29, tzinfo=datetime.timezone.utc
-                        ),
-                        end_time=datetime.datetime(
-                            1989, 12, 13, 9, 5, 8, tzinfo=datetime.timezone.utc
-                        ),
+                        start_time=_utc_instant(1989, 12, 13, 9, 4, 29),
+                        end_time=_utc_instant(1989, 12, 13, 9, 5, 8),
                     ),
                 ),
             ],
             status=RunStatus(
                 state=State.SUCCEEDED,
-                start_time=datetime.datetime(
-                    1989, 12, 13, 9, 3, 49, tzinfo=datetime.timezone.utc
-                ),
-                end_time=datetime.datetime(
-                    1989, 12, 13, 9, 5, 14, tzinfo=datetime.timezone.utc
-                ),
+                start_time=_utc_instant(1989, 12, 13, 9, 3, 49),
+                end_time=_utc_instant(1989, 12, 13, 9, 5, 14),
             ),
         )
 

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -17,7 +17,7 @@ import responses
 
 import orquestra.sdk as sdk
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import _db, serde
+from orquestra.sdk._base import _dates, _db, serde
 from orquestra.sdk._base._conversions._yaml_exporter import (
     pydantic_to_yaml,
     workflow_to_yaml,
@@ -1404,12 +1404,9 @@ class TestListWorkflowRuns:
         type(mock_status.status).start_time = PropertyMock(
             side_effect=[
                 None,
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(seconds=5),
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(seconds=5),
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(days=4),
+                _dates.now() - datetime.timedelta(seconds=5),
+                _dates.now() - datetime.timedelta(seconds=5),
+                _dates.now() - datetime.timedelta(days=4),
             ]
         )
         monkeypatch.setattr(
@@ -1428,12 +1425,9 @@ class TestListWorkflowRuns:
         type(mock_status.status).start_time = PropertyMock(
             side_effect=[
                 None,
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(seconds=5),
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(seconds=5),
-                datetime.datetime.now(datetime.timezone.utc)
-                - datetime.timedelta(days=4),
+                _dates.now() - datetime.timedelta(seconds=5),
+                _dates.now() - datetime.timedelta(seconds=5),
+                _dates.now() - datetime.timedelta(days=4),
             ]
         )
         monkeypatch.setattr(

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -10,13 +10,14 @@ from pathlib import Path
 
 import pytest
 
+from orquestra.sdk._base._dates import Instant
 from orquestra.sdk._ray import _ray_logs
 
 DATA_DIR = Path(__file__).parent / "data"
 TEST_RAY_TEMP = DATA_DIR / "ray_temp"
 
 
-SAMPLE_TIMESTAMP = datetime(2023, 2, 9, 11, 26, 7, 99382, tzinfo=timezone.utc)
+SAMPLE_TIMESTAMP = Instant(datetime(2023, 2, 9, 11, 26, 7, 99382, tzinfo=timezone.utc))
 
 
 class TestIterUserLogPaths:

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -5,13 +5,14 @@
 Unit tests for orquestra.sdk._ray._dag. If you need a test against a live
 Ray connection, see tests/ray/test_integration.py instead.
 """
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 from unittest.mock import Mock, PropertyMock, create_autospec
 
 import pytest
 
 from orquestra.sdk import exceptions
+from orquestra.sdk._base import _dates
 from orquestra.sdk._base._config import RuntimeConfiguration, RuntimeName
 from orquestra.sdk._base._db import WorkflowDB
 from orquestra.sdk._base._spaces._structs import ProjectRef
@@ -19,7 +20,7 @@ from orquestra.sdk._ray import _client, _dag, _ray_logs
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
 from orquestra.sdk.schema.workflow_run import State
 
-TEST_TIME = datetime.now(timezone.utc)
+TEST_TIME = _dates.now()
 
 
 @pytest.fixture
@@ -326,9 +327,9 @@ class TestRayRuntime:
             type(mock_status.status).start_time = PropertyMock(
                 side_effect=[
                     None,
-                    datetime.now(timezone.utc) - timedelta(seconds=5),
-                    datetime.now(timezone.utc) - timedelta(seconds=5),
-                    datetime.now(timezone.utc) - timedelta(days=4),
+                    _dates.now() - timedelta(seconds=5),
+                    _dates.now() - timedelta(seconds=5),
+                    _dates.now() - timedelta(days=4),
                 ]
             )
             monkeypatch.setattr(
@@ -351,9 +352,9 @@ class TestRayRuntime:
             type(mock_status.status).start_time = PropertyMock(
                 side_effect=[
                     None,
-                    datetime.now(timezone.utc) - timedelta(seconds=5),
-                    datetime.now(timezone.utc) - timedelta(seconds=5),
-                    datetime.now(timezone.utc) - timedelta(days=4),
+                    _dates.now() - timedelta(seconds=5),
+                    _dates.now() - timedelta(seconds=5),
+                    _dates.now() - timedelta(days=4),
                 ]
             )
             monkeypatch.setattr(

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -398,23 +398,6 @@ class TestReadConfigNames:
         assert _config.read_config_names() == []
 
 
-FAKE_TIME = datetime.datetime(1605, 11, 5, 0, 0, 0)
-
-
-@pytest.fixture
-def patch_datetime_now(monkeypatch):
-    class mydatetime:
-        @classmethod
-        def now(cls):
-            return FAKE_TIME
-
-        @classmethod
-        def today(cls):
-            return FAKE_TIME
-
-    monkeypatch.setattr(datetime, "datetime", mydatetime)
-
-
 class TestNameGeneration:
     class TestRuntimeDatetimeNaming:
         @staticmethod

--- a/tests/sdk/v2/test_config.py
+++ b/tests/sdk/v2/test_config.py
@@ -16,11 +16,8 @@ where:
 The current solution for this is to focus on testing the layer that's close to
 the user. It's a lot easier to figure out appropriate behavior this way.
 """
-import datetime
-import json
 import typing as t
 from pathlib import Path
-from unittest.mock import Mock
 
 import filelock
 import pytest

--- a/tests/sdk/v2/test_dates.py
+++ b/tests/sdk/v2/test_dates.py
@@ -1,0 +1,120 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Unit tests for ``orquestra.sdk._base._dates``.
+"""
+
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from orquestra.sdk._base import _dates
+
+
+class TestNow:
+    @staticmethod
+    def test_is_tz_aware():
+        # When
+        instant = _dates.now()
+
+        # Then
+        assert instant.tzinfo is not None
+
+
+class TestFromISOFormat:
+    @staticmethod
+    @pytest.mark.parametrize("formatted", ["2011-11-04T00:05:23"])
+    def test_invalid(formatted: str):
+        # Then
+        with pytest.raises(ValueError):
+            # When
+            _ = _dates.from_isoformat(formatted)
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "formatted",
+        [
+            "2011-11-04T00:05:23+04:00",
+            "2011-11-04T00:05:23Z",
+        ],
+    )
+    def test_has_timezone(formatted: str):
+        # When
+        instant = _dates.from_isoformat(formatted)
+
+        # Then
+        assert instant.tzinfo is not None
+
+
+class TestLocalISOFormat:
+    @staticmethod
+    def test_tz_naive():
+        # Given
+        instant = datetime.fromtimestamp(1687528083)
+
+        # Then
+        with pytest.raises(ValueError):
+            # When
+            _ = _dates.local_isoformat(instant)
+
+    @staticmethod
+    def test_utc_input():
+        # Given
+        instant = datetime.fromtimestamp(1687528083, timezone.utc)
+
+        # When
+        formatted = _dates.local_isoformat(instant)
+
+        # Then
+        # The output depends on the local time zone where the tests are run. We can work
+        # around this by regexes.
+        assert re.match(r"2023-06-23T\d\d:\d8:03[\+-]\d\d:\d0", formatted)
+
+    @staticmethod
+    def test_non_utc_input():
+        # Given
+        instant = datetime.fromtimestamp(1687528083, timezone(timedelta(hours=-4)))
+
+        # When
+        formatted = _dates.local_isoformat(instant)
+
+        # Then
+        # The output depends on the local time zone where the tests are run. We can work
+        # around this by regexes.
+        assert re.match(r"2023-06-23T\d\d:\d8:03[+-]\d\d:\d0", formatted)
+
+
+class TestUnixTime:
+    @staticmethod
+    def test_tz_naive():
+        # Given
+        instant = datetime.fromtimestamp(1687528083)
+
+        # Then
+        with pytest.raises(ValueError):
+            # When
+            _ = _dates.unix_time(instant)
+
+
+class TestFromUnixTime:
+    @staticmethod
+    def test_has_timezone():
+        # When
+        instant = _dates.from_unix_time(1687528083)
+
+        # Then
+        assert instant.tzinfo is not None
+
+    @staticmethod
+    def test_roundtrip():
+        # Given
+        ts1 = 1687528083
+        instant = _dates.from_unix_time(ts1)
+
+        # When
+        ts2 = _dates.unix_time(instant)
+
+        # Then
+        assert ts2 == ts1

--- a/tests/sdk/v2/test_dates.py
+++ b/tests/sdk/v2/test_dates.py
@@ -90,7 +90,11 @@ class TestUnixTime:
     @staticmethod
     def test_tz_naive():
         # Given
-        instant = datetime.fromtimestamp(1687528083)
+        dt = datetime.fromtimestamp(1687528083)
+        # Instant is supposed to represent only timezone-aware datetimes. This test case
+        # deliberately uses timezone-naive object. Casting it to Instant anyway prevents
+        # typechecker errors.
+        instant = _dates.Instant(dt)
 
         # Then
         with pytest.raises(ValueError):

--- a/tests/sdk/v2/test_dates.py
+++ b/tests/sdk/v2/test_dates.py
@@ -48,11 +48,55 @@ class TestFromISOFormat:
         assert instant.tzinfo is not None
 
 
+class TestISOFormat:
+    @staticmethod
+    def test_tz_naive():
+        # Given
+        dt = datetime.fromtimestamp(1687528083)
+        # Instant is supposed to represent only timezone-aware datetimes. This test case
+        # deliberately uses timezone-naive object. Casting it to Instant anyway prevents
+        # typechecker errors.
+        instant = _dates.Instant(dt)
+
+        # Then
+        with pytest.raises(ValueError):
+            # When
+            _ = _dates.isoformat(instant)
+
+    @staticmethod
+    def test_utc_input():
+        # Given
+        instant = _dates.Instant(datetime.fromtimestamp(1687528083, timezone.utc))
+
+        # When
+        formatted = _dates.isoformat(instant)
+
+        # Then
+        assert formatted == "2023-06-23T13:48:03+00:00"
+
+    @staticmethod
+    def test_non_utc_input():
+        # Given
+        instant = _dates.Instant(
+            datetime.fromtimestamp(1687528083, timezone(timedelta(hours=-4)))
+        )
+
+        # When
+        formatted = _dates.isoformat(instant)
+
+        # Then
+        assert formatted == "2023-06-23T09:48:03-04:00"
+
+
 class TestLocalISOFormat:
     @staticmethod
     def test_tz_naive():
         # Given
-        instant = datetime.fromtimestamp(1687528083)
+        dt = datetime.fromtimestamp(1687528083)
+        # Instant is supposed to represent only timezone-aware datetimes. This test case
+        # deliberately uses timezone-naive object. Casting it to Instant anyway prevents
+        # typechecker errors.
+        instant = _dates.Instant(dt)
 
         # Then
         with pytest.raises(ValueError):
@@ -62,7 +106,7 @@ class TestLocalISOFormat:
     @staticmethod
     def test_utc_input():
         # Given
-        instant = datetime.fromtimestamp(1687528083, timezone.utc)
+        instant = _dates.Instant(datetime.fromtimestamp(1687528083, timezone.utc))
 
         # When
         formatted = _dates.local_isoformat(instant)
@@ -75,7 +119,9 @@ class TestLocalISOFormat:
     @staticmethod
     def test_non_utc_input():
         # Given
-        instant = datetime.fromtimestamp(1687528083, timezone(timedelta(hours=-4)))
+        instant = _dates.Instant(
+            datetime.fromtimestamp(1687528083, timezone(timedelta(hours=-4)))
+        )
 
         # When
         formatted = _dates.local_isoformat(instant)
@@ -122,3 +168,70 @@ class TestFromUnixTime:
 
         # Then
         assert ts2 == ts1
+
+
+class TestFromComps:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            pytest.param(
+                {"year": 1964, "month": 9, "day": 2, "utc_hour_offset": 3},
+                "1964-09-02T00:00:00+03:00",
+                id="minimal-args",
+            ),
+            pytest.param(
+                {
+                    "year": 2005,
+                    "month": 4,
+                    "day": 2,
+                    "hour": 21,
+                    "minute": 36,
+                    "second": 59,
+                    "utc_hour_offset": 1,
+                },
+                "2005-04-02T21:36:59+01:00",
+                id="full-printable",
+            ),
+        ],
+    )
+    def test_against_isoformat(kwargs, expected):
+        # When
+        instant = _dates.from_comps(**kwargs)
+        formatted = _dates.isoformat(instant)
+
+        # Then
+        assert formatted == expected
+
+
+class TestUTCFromComps:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "kwargs,expected",
+        [
+            pytest.param(
+                {"year": 1964, "month": 9, "day": 2},
+                "1964-09-02T00:00:00+00:00",
+                id="minimal-args",
+            ),
+            pytest.param(
+                {
+                    "year": 2005,
+                    "month": 4,
+                    "day": 2,
+                    "hour": 20,
+                    "minute": 36,
+                    "second": 59,
+                },
+                "2005-04-02T20:36:59+00:00",
+                id="full-printable",
+            ),
+        ],
+    )
+    def test_against_isoformat(kwargs, expected):
+        # When
+        instant = _dates.utc_from_comps(**kwargs)
+        formatted = _dates.isoformat(instant)
+
+        # Then
+        assert formatted == expected

--- a/tests/sdk/v2/test_in_process_runtime.py
+++ b/tests/sdk/v2/test_in_process_runtime.py
@@ -8,14 +8,14 @@ functionality is covered inside tests/v2/test_api.py.
 We need this file because test_api.py might be too coarse for some scenarios.
 When adding new tests, please consider that suite first.
 """
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from unittest.mock import create_autospec
 
 import pytest
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import serde
+from orquestra.sdk._base import _dates, serde
 from orquestra.sdk._base._in_process_runtime import InProcessRuntime
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base._testing._example_wfs import (
@@ -234,9 +234,7 @@ class TestListWorkflowRuns:
         # Given
         run_id = runtime.create_workflow_run(wf_def, None)
         _ = runtime.create_workflow_run(wf_def, None)
-        runtime._start_time_store[run_id] = datetime.now(timezone.utc) - timedelta(
-            days=1
-        )
+        runtime._start_time_store[run_id] = _dates.now() - timedelta(days=1)
 
         # When
         wf_runs = runtime.list_workflow_runs(max_age=timedelta(minutes=1))


### PR DESCRIPTION
# The problem

* Python's `datetime` is full of footguns.
* I got tired of looking into my snippet library anytime I needed to do something with dates.

# This PR's solution

* Defines a single place where we create and manipulate `datetime` instants. At least the most common + problematic scenarios.
* Replaces any usage of the vanilla `datetime` module I could find with `_dates`. 

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
