### PR TITLE
Feat: Add warning when accessing secrets without specifying workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `sdk.secret` functions will no longer use default configuration from local runtimes. Config has to be passed explicitly unless running on remote cluster
 
 🔥 *Features*
+* Adding `FutureWarning` when accessing CE Secrets without specifying Workspace.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -159,6 +159,13 @@ def GithubImport(
                 f"not {type(personal_access_token).__name__}."
             )
         raise TypeError(errmsg)
+    if personal_access_token is not None and isinstance(personal_access_token, Secret):
+        if Secret.workspace_id is None:
+            raise FutureWarning(
+                "Please specify workspace ID directly for accessing secrets."
+                " Support for default workspaces will be sunset in the future."
+            )
+
     return GitImportWithAuth(
         repo_url=f"https://github.com/{repo}.git",
         git_ref=git_ref,

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -160,7 +160,7 @@ def GithubImport(
             )
         raise TypeError(errmsg)
     if personal_access_token is not None and isinstance(personal_access_token, Secret):
-        if Secret.workspace_id is None:
+        if personal_access_token.workspace_id is None:
             warnings.warn(
                 "Please specify workspace ID directly for accessing secrets."
                 " Support for default workspaces will be sunset in the future.",

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -161,9 +161,10 @@ def GithubImport(
         raise TypeError(errmsg)
     if personal_access_token is not None and isinstance(personal_access_token, Secret):
         if Secret.workspace_id is None:
-            raise FutureWarning(
+            warnings.warn(
                 "Please specify workspace ID directly for accessing secrets."
-                " Support for default workspaces will be sunset in the future."
+                " Support for default workspaces will be sunset in the future.",
+                FutureWarning,
             )
 
     return GitImportWithAuth(

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -18,6 +18,14 @@ def _translate_to_zri(workspace_id: str, secret_name: str) -> str:
     return f"zri:v1::0:{workspace_id}:secret:{secret_name}"
 
 
+def _raise_warning_for_none_workspace(workspace: t.Optional[str]):
+    if workspace is None:
+        raise FutureWarning(
+            "Please specify workspace ID directly for accessing secrets."
+            " Support for default workspaces will be sunset in the future."
+        )
+
+
 def get(
     name: str,
     *,
@@ -50,6 +58,8 @@ def get(
             this function will return a "future" which will be used to retrieve the
             secret at execution time.
     """
+    _raise_warning_for_none_workspace(workspace_id)
+
     if _exec_ctx.global_context == _exec_ctx.ExecContext.WORKFLOW_BUILD:
         return t.cast(
             str,
@@ -96,6 +106,8 @@ def list(
         orquestra.sdk.exceptions.UnauthorizedError: when the authorization with the
             remote vault failed.
     """
+    _raise_warning_for_none_workspace(workspace_id)
+
     try:
         client = _auth.authorized_client(config_name)
     except sdk_exc.ConfigNameNotFoundError:
@@ -133,6 +145,8 @@ def set(
         orquestra.sdk.exceptions.UnauthorizedError: when the authorization with the
             remote vault failed.
     """
+    _raise_warning_for_none_workspace(workspace_id)
+
     try:
         client = _auth.authorized_client(config_name)
     except sdk_exc.ConfigNameNotFoundError:
@@ -179,6 +193,8 @@ def delete(
         orquestra.sdk.exceptions.UnauthorizedError: when the authorization with the
             remote vault failed.
     """
+    _raise_warning_for_none_workspace(workspace_id)
+
     try:
         client = _auth.authorized_client(config_name)
     except sdk_exc.ConfigNameNotFoundError:

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -5,24 +5,27 @@
 Code for user-facing utilities related to secrets.
 """
 import typing as t
+import warnings
 
 from .. import exceptions as sdk_exc
 from .._base import _dsl, _exec_ctx
+from ..schema.workflow_run import WorkspaceId
 from . import _auth, _exceptions, _models
 
 
-def _translate_to_zri(workspace_id: str, secret_name: str) -> str:
+def _translate_to_zri(workspace_id: WorkspaceId, secret_name: str) -> str:
     """
     Create ZRI from workspace_id and secret_name
     """
     return f"zri:v1::0:{workspace_id}:secret:{secret_name}"
 
 
-def _raise_warning_for_none_workspace(workspace: t.Optional[str]):
+def _raise_warning_for_none_workspace(workspace: t.Optional[WorkspaceId]):
     if workspace is None:
-        raise FutureWarning(
+        warnings.warn(
             "Please specify workspace ID directly for accessing secrets."
-            " Support for default workspaces will be sunset in the future."
+            " Support for default workspaces will be sunset in the future.",
+            FutureWarning,
         )
 
 

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -390,7 +390,7 @@ class TestTaskRun:
                             id="secret-0",
                             secret_name="test",
                             secret_config=None,
-                            workspace_id="",
+                            workspace_id="ws",
                         )
                     ],
                     {},

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -390,7 +390,7 @@ class TestTaskRun:
                             id="secret-0",
                             secret_name="test",
                             secret_config=None,
-                            workspace_id=None,
+                            workspace_id="",
                         )
                     ],
                     {},

--- a/tests/sdk/v2/data/task_run_workflow_defs.py
+++ b/tests/sdk/v2/data/task_run_workflow_defs.py
@@ -44,7 +44,7 @@ def wf_single_task_with_const_parent():
 
 @sdk.workflow
 def wf_single_task_with_secret_parent():
-    return [return_num(sdk.secrets.get("test"))]
+    return [return_num(sdk.secrets.get("test", workspace_id=""))]
 
 
 @sdk.workflow

--- a/tests/sdk/v2/data/task_run_workflow_defs.py
+++ b/tests/sdk/v2/data/task_run_workflow_defs.py
@@ -44,7 +44,7 @@ def wf_single_task_with_const_parent():
 
 @sdk.workflow
 def wf_single_task_with_secret_parent():
-    return [return_num(sdk.secrets.get("test", workspace_id=""))]
+    return [return_num(sdk.secrets.get("test", workspace_id="ws"))]
 
 
 @sdk.workflow

--- a/tests/sdk/v2/secrets/test_api.py
+++ b/tests/sdk/v2/secrets/test_api.py
@@ -63,6 +63,23 @@ class TestIntegrationWithClient:
                 with pytest.raises(type(exc)):
                     secrets_action()
 
+        @staticmethod
+        @pytest.mark.parametrize(
+            "secrets_action",
+            [
+                lambda: sdk.secrets.get(name="some-secret"),
+                lambda: sdk.secrets.delete(name="some-secret"),
+                lambda: sdk.secrets.list(),
+                lambda: sdk.secrets.set(
+                    name="some-secret",
+                    value="You're doing great! :)",
+                ),
+            ],
+        )
+        def test_raises_warning_no_workspace(secrets_client_mock, secrets_action):
+            with pytest.warns(FutureWarning):
+                secrets_action()
+
         class TestForwardsConfigErrors:
             @staticmethod
             @pytest.mark.parametrize(

--- a/tests/sdk/v2/secrets/test_api.py
+++ b/tests/sdk/v2/secrets/test_api.py
@@ -44,12 +44,13 @@ class TestIntegrationWithClient:
             @pytest.mark.parametrize(
                 "secrets_action",
                 [
-                    lambda: sdk.secrets.get(name="some-secret"),
-                    lambda: sdk.secrets.delete(name="some-secret"),
-                    lambda: sdk.secrets.list(),
+                    lambda: sdk.secrets.get(name="some-secret", workspace_id=""),
+                    lambda: sdk.secrets.delete(name="some-secret", workspace_id=""),
+                    lambda: sdk.secrets.list(workspace_id=""),
                     lambda: sdk.secrets.set(
                         name="some-secret",
                         value="You're doing great! :)",
+                        workspace_id="",
                     ),
                 ],
             )
@@ -73,12 +74,13 @@ class TestIntegrationWithClient:
             @pytest.mark.parametrize(
                 "secrets_action",
                 [
-                    lambda: sdk.secrets.get(name="some-secret"),
-                    lambda: sdk.secrets.delete(name="some-secret"),
-                    lambda: sdk.secrets.list(),
+                    lambda: sdk.secrets.get(name="some-secret", workspace_id=""),
+                    lambda: sdk.secrets.delete(name="some-secret", workspace_id=""),
+                    lambda: sdk.secrets.list(workspace_id=""),
                     lambda: sdk.secrets.set(
                         name="some-secret",
                         value="You're doing great! :)",
+                        workspace_id="",
                     ),
                 ],
             )
@@ -88,7 +90,7 @@ class TestIntegrationWithClient:
                 with pytest.raises(type(exc)):
                     secrets_action()
 
-    @pytest.mark.parametrize("workspace_id", ["coolest_workspace_ever", None])
+    @pytest.mark.parametrize("workspace_id", ["coolest_workspace_ever"])
     class TestPassingData:
         @staticmethod
         def test_creating(secrets_client_mock, workspace_id):

--- a/tests/sdk/v2/secrets/test_api.py
+++ b/tests/sdk/v2/secrets/test_api.py
@@ -44,13 +44,13 @@ class TestIntegrationWithClient:
             @pytest.mark.parametrize(
                 "secrets_action",
                 [
-                    lambda: sdk.secrets.get(name="some-secret", workspace_id=""),
-                    lambda: sdk.secrets.delete(name="some-secret", workspace_id=""),
-                    lambda: sdk.secrets.list(workspace_id=""),
+                    lambda: sdk.secrets.get(name="some-secret", workspace_id="ws"),
+                    lambda: sdk.secrets.delete(name="some-secret", workspace_id="ws"),
+                    lambda: sdk.secrets.list(workspace_id="ws"),
                     lambda: sdk.secrets.set(
                         name="some-secret",
                         value="You're doing great! :)",
-                        workspace_id="",
+                        workspace_id="ws",
                     ),
                 ],
             )
@@ -74,13 +74,13 @@ class TestIntegrationWithClient:
             @pytest.mark.parametrize(
                 "secrets_action",
                 [
-                    lambda: sdk.secrets.get(name="some-secret", workspace_id=""),
-                    lambda: sdk.secrets.delete(name="some-secret", workspace_id=""),
-                    lambda: sdk.secrets.list(workspace_id=""),
+                    lambda: sdk.secrets.get(name="some-secret", workspace_id="ws"),
+                    lambda: sdk.secrets.delete(name="some-secret", workspace_id="ws"),
+                    lambda: sdk.secrets.list(workspace_id="ws"),
                     lambda: sdk.secrets.set(
                         name="some-secret",
                         value="You're doing great! :)",
-                        workspace_id="",
+                        workspace_id="ws",
                     ),
                 ],
             )

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -418,7 +418,7 @@ def test_deferred_git_import_resolved(my_fake_repo_setup):
     "username,personal_access_token",
     [
         (None, None),
-        ("emiliano_zapata", _dsl.Secret("my_secret")),
+        ("emiliano_zapata", _dsl.Secret("my_secret", workspace_id="ws")),
     ],
 )
 def test_github_import_is_git_import_with_auth(username, personal_access_token):
@@ -434,6 +434,16 @@ def test_github_import_is_git_import_with_auth(username, personal_access_token):
         username=username,
         auth_secret=personal_access_token,
     )
+
+
+def test_github_import_is_git_import_with_auth():
+    with pytest.warns(FutureWarning):
+        _dsl.GithubImport(
+            "zapatacomputing/orquestra-workflow-sdk",
+            "main",
+            username="UN",
+            personal_access_token=sdk.Secret("MY PAT"),
+        )
 
 
 class TestGithubImportRaisesTypeErrorForNonSecretPAT:

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -436,7 +436,7 @@ def test_github_import_is_git_import_with_auth(username, personal_access_token):
     )
 
 
-def test_github_import_is_git_import_with_auth():
+def test_warns_when_no_workspace_provided():
     with pytest.warns(FutureWarning):
         _dsl.GithubImport(
             "zapatacomputing/orquestra-workflow-sdk",

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -369,7 +369,7 @@ def dupe_import_wf():
 
 @_workflow.workflow
 def workflow_with_secret():
-    secret = secrets.get("my_secret", workspace_id="")
+    secret = secrets.get("my_secret", workspace_id="ws")
     return simple_task(secret)
 
 

--- a/tests/sdk/v2/test_traversal.py
+++ b/tests/sdk/v2/test_traversal.py
@@ -369,7 +369,7 @@ def dupe_import_wf():
 
 @_workflow.workflow
 def workflow_with_secret():
-    secret = secrets.get("my_secret")
+    secret = secrets.get("my_secret", workspace_id="")
     return simple_task(secret)
 
 


### PR DESCRIPTION
# The problem

Default workspace on platform side will become deprecated in the future.

# This PR's solution

Raise warning for users to prepare for that breaking change

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
