### PR TITLE
 feat: api get system logs from local ray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+* API: rather then returning empty lists, ray local logs now return messages for `system` and `other` log categories that direct the user to the logs directory.
 
 🥷 *Internal*
 * Refactored `datetime` and timezone handling.

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -138,7 +138,7 @@ class DirectRayReader:
         system_warning = (
             "WARNING: we don't parse system logs for the local runtime. "
             "The log files can be found in the directory "
-            "'~/.orquestra/ray/session_latest/logs."
+            f"'{self._ray_temp}'"
         )
         return [system_warning]
 
@@ -146,7 +146,7 @@ class DirectRayReader:
         other_warning = (
             "WARNING: we don't parse uncategorized logs for the local runtime. "
             "The log files can be found in the directory "
-            "'~/.orquestra/ray/session_latest/logs."
+            f"'{self._ray_temp}'"
         )
         return [other_warning]
 

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -130,6 +130,18 @@ class DirectRayReader:
 
         return [line.decode() for line in log_line_bytes]
 
+    def _get_system_log_lines(self) -> t.Sequence[str]:
+        # There is currently no concrete rule for which log files fall into the
+        # category of 'system'. Since the log files exist locally for the user, we
+        # simply point them to the appropriate directory rather than trying to
+        # construct the category for them.
+        system_warning = (
+            "WARNING: we don't parse system logs for the local runtime. "
+            "The log files can be found in the directory "
+            "'~/.orquestra/ray/session_latest/logs."
+        )
+        return [system_warning]
+
     def get_task_logs(
         self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId
     ) -> t.List[str]:
@@ -157,9 +169,11 @@ class DirectRayReader:
 
         env_setup = self._get_env_setup_lines()
 
+        system = self._get_system_log_lines()
+
         return WorkflowLogs(
             per_task=logs_dict,
             env_setup=env_setup,
-            system=[],
+            system=system,
             other=[],
         )

--- a/src/orquestra/sdk/_ray/_ray_logs.py
+++ b/src/orquestra/sdk/_ray/_ray_logs.py
@@ -142,6 +142,14 @@ class DirectRayReader:
         )
         return [system_warning]
 
+    def _get_other_log_lines(self) -> t.Sequence[str]:
+        other_warning = (
+            "WARNING: we don't parse uncategorized logs for the local runtime. "
+            "The log files can be found in the directory "
+            "'~/.orquestra/ray/session_latest/logs."
+        )
+        return [other_warning]
+
     def get_task_logs(
         self, wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId
     ) -> t.List[str]:
@@ -168,12 +176,12 @@ class DirectRayReader:
             logs_dict.setdefault(log.task_inv_id, []).append(log.json())
 
         env_setup = self._get_env_setup_lines()
-
         system = self._get_system_log_lines()
+        other = self._get_other_log_lines()
 
         return WorkflowLogs(
             per_task=logs_dict,
             env_setup=env_setup,
             system=system,
-            other=[],
+            other=other,
         )

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -267,7 +267,6 @@ class TestDirectRayReader:
                 # Then
                 assert logs.per_task == {}
 
-        @staticmethod
         @pytest.mark.parametrize(
             "wf_run_id",
             [
@@ -275,40 +274,50 @@ class TestDirectRayReader:
                 pytest.param("doesnt-exist", id="invalid_id"),
             ],
         )
-        def test_env_setup(wf_run_id: str):
-            # Given
-            reader = _ray_logs.DirectRayReader(ray_temp=TEST_RAY_TEMP)
+        class TestNonTaskLogTypes:
+            @staticmethod
+            def test_env_setup(wf_run_id: str):
+                # Given
+                reader = _ray_logs.DirectRayReader(ray_temp=TEST_RAY_TEMP)
 
-            # When
-            logs = reader.get_workflow_logs(wf_run_id)
+                # When
+                logs = reader.get_workflow_logs(wf_run_id)
 
-            # Then
-            for tell_tale in [
-                "Cloning virtualenv",
-                "'pip', 'install'",
-                "Installing python requirements",
-            ]:
-                assert len([line for line in logs.env_setup if tell_tale in line]) > 0
+                # Then
+                for tell_tale in [
+                    "Cloning virtualenv",
+                    "'pip', 'install'",
+                    "Installing python requirements",
+                ]:
+                    assert (
+                        len([line for line in logs.env_setup if tell_tale in line]) > 0
+                    )
 
-        @staticmethod
-        @pytest.mark.parametrize(
-            "wf_run_id",
-            [
-                pytest.param(_existing_wf_run_id(), id="valid_id"),
-                pytest.param("doesnt-exist", id="invalid_id"),
-            ],
-        )
-        def test_system(wf_run_id: str):
-            # Given
-            reader = _ray_logs.DirectRayReader(ray_temp=TEST_RAY_TEMP)
+            @staticmethod
+            def test_system(wf_run_id: str):
+                # Given
+                reader = _ray_logs.DirectRayReader(ray_temp=TEST_RAY_TEMP)
 
-            # When
-            logs = reader.get_workflow_logs(wf_run_id)
+                # When
+                logs = reader.get_workflow_logs(wf_run_id)
 
-            # Then
-            assert logs.system == [
-                "WARNING: we don't parse system logs for the local runtime. The log files can be found in the directory '~/.orquestra/ray/session_latest/logs."  # noqa: E501
-            ]
+                # Then
+                assert logs.system == [
+                    "WARNING: we don't parse system logs for the local runtime. The log files can be found in the directory '~/.orquestra/ray/session_latest/logs."  # noqa: E501
+                ]
+
+            @staticmethod
+            def test_other(wf_run_id: str):
+                # Given
+                reader = _ray_logs.DirectRayReader(ray_temp=TEST_RAY_TEMP)
+
+                # When
+                logs = reader.get_workflow_logs(wf_run_id)
+
+                # Then
+                assert logs.other == [
+                    "WARNING: we don't parse uncategorized logs for the local runtime. The log files can be found in the directory '~/.orquestra/ray/session_latest/logs."  # noqa: E501
+                ]
 
     class TestGetTaskLogs:
         @staticmethod

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -290,6 +290,26 @@ class TestDirectRayReader:
             ]:
                 assert len([line for line in logs.env_setup if tell_tale in line]) > 0
 
+        @staticmethod
+        @pytest.mark.parametrize(
+            "wf_run_id",
+            [
+                pytest.param(_existing_wf_run_id(), id="valid_id"),
+                pytest.param("doesnt-exist", id="invalid_id"),
+            ],
+        )
+        def test_system(wf_run_id: str):
+            # Given
+            reader = _ray_logs.DirectRayReader(ray_temp=TEST_RAY_TEMP)
+
+            # When
+            logs = reader.get_workflow_logs(wf_run_id)
+
+            # Then
+            assert logs.system == [
+                "WARNING: we don't parse system logs for the local runtime. The log files can be found in the directory '~/.orquestra/ray/session_latest/logs."  # noqa: E501
+            ]
+
     class TestGetTaskLogs:
         @staticmethod
         def test_happy_path():

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -303,7 +303,7 @@ class TestDirectRayReader:
 
                 # Then
                 assert logs.system == [
-                    "WARNING: we don't parse system logs for the local runtime. The log files can be found in the directory '~/.orquestra/ray/session_latest/logs."  # noqa: E501
+                    f"WARNING: we don't parse system logs for the local runtime. The log files can be found in the directory '{TEST_RAY_TEMP}'"  # noqa: E501
                 ]
 
             @staticmethod
@@ -316,7 +316,7 @@ class TestDirectRayReader:
 
                 # Then
                 assert logs.other == [
-                    "WARNING: we don't parse uncategorized logs for the local runtime. The log files can be found in the directory '~/.orquestra/ray/session_latest/logs."  # noqa: E501
+                    f"WARNING: we don't parse uncategorized logs for the local runtime. The log files can be found in the directory '{TEST_RAY_TEMP}'"  # noqa: E501
                 ]
 
     class TestGetTaskLogs:


### PR DESCRIPTION
ORQSDK-865

# The problem

At present, `wf.get_logs().system` will always be an empty list for local ray workflow runs.

# This PR's solution

There isn't a hard-and-fast rule for what constitutes a 'system' log in this context. There also isn't a mandate for providing system logs via the API since the log files exist locally on the user's machine. Therefore we instead insert an artificial log line directing the user to the appropriate directory.

```
>>> wf.get_logs().system
["WARNING: we don't parse system logs for the local runtime. The log files can be found in the directory '~/.orquestra/ray/session_latest/logs."]
```

(We also insert an almost identical message for the 'other' logs)

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
