### PR TITLE
chore: Use NamedTuple when returning IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+* `sdk.current_run_ids()` now returns a `NamedTuple` called `CurrentRunIDs` to help with typing.
 
 🥷 *Internal*
 
@@ -46,7 +47,6 @@
 * When a new config is saved, the message shown in the CLI now includes the runtime name.
 * API: rather then returning empty lists, ray local logs now return messages for `system` and `other` log categories that direct the user to the logs directory.
 * User-emitted logs are no longer wrapped in an JSON dictionary with metadata. `print("foo")` will now result in a log line `"foo"` instead of `'{"message": "foo", "timestamp": ..., "wf_run_id": ..., ...}'`
-* `sdk.current_run_ids()` now returns a `NamedTuple` called `CurrentRunIDs` to help with typing.
 
 🥷 *Internal*
 * Refactored `datetime` and timezone handling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 * When a new config is saved, the message shown in the CLI now includes the runtime name.
 * API: rather then returning empty lists, ray local logs now return messages for `system` and `other` log categories that direct the user to the logs directory.
 * User-emitted logs are no longer wrapped in an JSON dictionary with metadata. `print("foo")` will now result in a log line `"foo"` instead of `'{"message": "foo", "timestamp": ..., "wf_run_id": ..., ...}'`
+* `sdk.current_run_ids()` now returns a `NamedTuple` called `CurrentRunIDs` to help with typing.
 
 🥷 *Internal*
 * Refactored `datetime` and timezone handling.

--- a/src/orquestra/sdk/__init__.py
+++ b/src/orquestra/sdk/__init__.py
@@ -5,6 +5,7 @@
 
 from . import mlflow, secrets
 from ._base._api import (
+    CurrentRunIDs,
     RuntimeConfig,
     TaskRun,
     WorkflowRun,
@@ -70,4 +71,5 @@ __all__ = [
     "ProjectRef",
     "State",
     "Workspace",
+    "CurrentRunIDs",
 ]

--- a/src/orquestra/sdk/_base/_api/__init__.py
+++ b/src/orquestra/sdk/_base/_api/__init__.py
@@ -9,7 +9,7 @@ We re-export symbols here for grouping concepts under the "api" umbrella, e.g.
 """
 
 from ._config import RuntimeConfig, migrate_config_file
-from ._task_run import TaskRun, current_run_ids
+from ._task_run import CurrentRunIDs, TaskRun, current_run_ids
 from ._wf_run import WorkflowRun, list_workflow_runs
 
 __all__ = [
@@ -19,4 +19,5 @@ __all__ = [
     "WorkflowRun",
     "list_workflow_runs",
     "migrate_config_file",
+    "CurrentRunIDs",
 ]

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -593,6 +593,13 @@ def mock_in_process_context(monkeypatch):
 
 
 class TestGetBackendIDs:
+    @staticmethod
+    def test_access_by_attr(mock_in_process_context):
+        ids = sdk.current_run_ids()
+        assert ids.workflow_run_id == ids[0]
+        assert ids.task_invocation_id == ids[1]
+        assert ids.task_run_id == ids[2]
+
     class TestRuntimeSpecificGetIDs:
         @staticmethod
         def test_get_argo_backend_ids(mock_argo_context):

--- a/tests/sdk/v2/api/test_task_run.py
+++ b/tests/sdk/v2/api/test_task_run.py
@@ -596,9 +596,9 @@ class TestGetBackendIDs:
     @staticmethod
     def test_access_by_attr(mock_in_process_context):
         ids = sdk.current_run_ids()
-        assert ids.workflow_run_id == ids[0]
-        assert ids.task_invocation_id == ids[1]
-        assert ids.task_run_id == ids[2]
+        assert ids.workflow_run_id == ids[0] == "wf_run_id"
+        assert ids.task_invocation_id == ids[1] == "task_inv_id"
+        assert ids.task_run_id == ids[2] == "task_run_id"
 
     class TestRuntimeSpecificGetIDs:
         @staticmethod


### PR DESCRIPTION
# The problem

We returned a tuple of `(WorkflowRunId, Optional[TaskInvocationId]`, Optional[TaskRunId])` which can be a source of bugs. Accessing a tuple by index means it is easier to make copy/paste errors.

# This PR's solution

Changes this Tuple to a `NamedTuple` so one can access the different run IDs by attribute. For example:

Old:
```python
my_task_inv_id = sdk.current_run_ids()[1]
```

New:
```python
my_task_inv_id = sdk.current_run_ids().task_invocation_id
```

As this is a `NamedTuple`, this doesn't change any old behaviour and only adds a nicer way to get these IDs.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
