### PR TITLE
Imp: Throw an early error at submittion time when invalid number of resources was requested

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 💅 *Improvements*
 * `sdk.current_run_ids()` now returns a `NamedTuple` called `CurrentRunIDs` to help with typing.
-* Task that requests ray-incompatible number of resources throws an error at submission time
+* Tasks that request resources that are incompatible with Ray will throw an error at submission time.
 
 🥷 *Internal*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 💅 *Improvements*
 * `sdk.current_run_ids()` now returns a `NamedTuple` called `CurrentRunIDs` to help with typing.
+* Task that requests ray-incompatible number of resources throws an error at submission time
 
 🥷 *Internal*
 

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -534,11 +534,17 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
                     raise InvalidTaskDefinitionError(err)
             if self._resources.gpu is not None:
                 try:
-                    int(self._resources.gpu)
+                    int_gpu = int(float(self._resources.gpu))
+                    float_gpu = float(self._resources.gpu)
+                    if int_gpu != float_gpu:
+                        raise ValueError
+                # Value error can be either if gpus are float, or passed as some form
+                # of kubernetes-resource string, like "1000m"
                 except ValueError:
                     err = (
-                        f"function {self._fn_name} has GPU resource quantity which is "
-                        "not a whole number. Make sure GPU is defined only as integer."
+                        f"function {self._fn_name} has GPU resource quantity which "
+                        f"is not a whole number. Make sure GPU is defined only "
+                        f"as integer."
                     )
                     raise InvalidTaskDefinitionError(err)
 

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -115,6 +115,8 @@ class WorkflowDef(Generic[_R]):
                 has uncommitted changes.
             orquestra.sdk.exceptions.WorkflowSyntaxError: when there are no tasks
                 defined for this workflow.
+            orquestra.sdk.exceptions.InvalidTaskDefinitionError: when there is invalid
+                task used inside this workflow
         """
         from orquestra.sdk._base import _traversal
 

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -411,7 +411,7 @@ def make_ray_dag(
                 )
             if invocation.resources.gpu is not None:
                 # Fractional GPUs not supported currently
-                gpu = int(invocation.resources.gpu)
+                gpu = int(float(invocation.resources.gpu))
                 ray_options["num_gpus"] = gpu
 
         ray_result = _make_ray_dag_node(

--- a/tests/sdk/v2/test_dsl.py
+++ b/tests/sdk/v2/test_dsl.py
@@ -724,7 +724,7 @@ def test_dependency_imports(dependency_imports, expected_imports):
     assert my_task._dependency_imports == expected_imports
 
 
-class TestInvalidResources:
+class TestResources:
     @pytest.mark.parametrize(
         "cpu", ["1001m", "1500m", "1.5", "2001m", "1.0001k", "1500000u"]
     )
@@ -740,10 +740,21 @@ class TestInvalidResources:
         with pytest.raises(InvalidTaskDefinitionError):
             wf().model
 
-    @pytest.mark.parametrize(
-        "gpu", ["1001m", "1500m", "1.5", "2001m", "1.0001k", "1500000u", "0.15", "0.5"]
-    )
-    def test_invalud_gpu_resources(self, gpu):
+    @pytest.mark.parametrize("cpu", ["1000m", "500m", "1.0", "3.0", "1", "1k"])
+    def test_valid_cpu_resources(self, cpu):
+        @sdk.task(resources=sdk.Resources(cpu=cpu))
+        def t():
+            ...
+
+        @sdk.workflow
+        def wf():
+            return t()
+
+        # should not raise
+        wf().model
+
+    @pytest.mark.parametrize("gpu", ["1", "1.0", "10.0"])
+    def test_valid_gpu_resources(self, gpu):
         @sdk.task(resources=sdk.Resources(gpu=gpu))
         def t():
             ...
@@ -752,5 +763,5 @@ class TestInvalidResources:
         def wf():
             return t()
 
-        with pytest.raises(InvalidTaskDefinitionError):
-            wf().model
+        # should not raise
+        wf().model


### PR DESCRIPTION
# The problem

Ray doesn't accept >1 quantities of resources if they are not a whole number.
This causes remote workflows to fail very late in the process.
https://zapatacomputing.atlassian.net/browse/ORQSDK-906

# This PR's solution

Throw an error way earlier, at submission time.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
