### PR TITLE
fix: Use non-root user to install Python packages and use a venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
+* Install Python modules in a venv using a non-root user to fix errors in custom Docker images.
 
 💅 *Improvements*
 * `sdk.current_run_ids()` now returns a `NamedTuple` called `CurrentRunIDs` to help with typing.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,13 +21,20 @@ fi
 
 rm -rf /var/lib/apt/lists/*
 
+useradd -ms /bin/bash -d /home/orquestra orquestra --uid 1000 --gid 100
+EOF
+
+USER 1000
+WORKDIR /home/orquestra
+
+ENV VIRTUAL_ENV=/home/orquestra/venv
+RUN python -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN <<EOF
 python -m pip install --no-cache-dir -U pip wheel
 python -m pip install --no-cache-dir "${SDK_REQUIREMENT}"
 EOF
-
-RUN useradd -ms /bin/bash -d /home/orquestra orquestra --uid 1000 --gid 100
-USER 1000
-WORKDIR /home/orquestra
 
 ENV RAY_STORAGE=/tmp
 # This environment variable configures the Ray runtime to download Git imports.

--- a/docs/guides/custom-images.rst
+++ b/docs/guides/custom-images.rst
@@ -28,6 +28,10 @@ can install any package that you need from Ubuntu repositories (by doing ``RUN a
 However, before doing so, you need to temporarily switch to the root user (via ``USER root`` directive) and
 restore back to user ``orquestra`` once you're done (``USER orquestra``).
 
+A virtual environment for the Python code is created at `/home/orquestra/venv`. Orquestra SDK and Ray modules are installed
+in this virtual environment. The `bin` directory of this virtual environment is added to the `PATH` environment variable
+as well so that you use the same Python executable in any subprocesses you might create in your code.
+
 .. note::
 
     You can use `standard OCI annotations <https://github.com/opencontainers/image-spec/blob/main/annotations.md>`_ to add metadata to your images.


### PR DESCRIPTION
# The problem

Installing Python modules as root user cause custom images to fail.

# This PR's solution

Installing Python modules as a non-root user and in a virtualenv to avoid edge cases.

# Jira Ticket

https://zapatacomputing.atlassian.net/browse/OP-166

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
