### PR TITLE
Feat: get mlflow tracking uri and token in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed unsupported `WorkflowDef.local_run()` function
 
 🔥 *Features*
+* `sdk.mlflow.get_tracking_uri()` and `sdk.mlflow.get_tracking_token()` are now provided to give access to the MLFlow tracking information.
 
 🧟 *Deprecations*
 

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -19,6 +19,7 @@ import requests
 from requests import codes
 
 from orquestra.sdk import ProjectRef
+from orquestra.sdk._base._spaces._api import make_workspace_zri
 from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.responses import ComputeEngineWorkflowResult, WorkflowResult
 from orquestra.sdk.schema.workflow_run import (
@@ -795,16 +796,8 @@ class DriverClient:
         """
         Gets the list of all projects in given workspace
         """
-        default_tenant_id = 0
-        special_workspace = "system"
-        zri_type = "resource_group"
 
-        # we have to build project ZRI from some hardcoded values + workspaceId
-        # based on https://zapatacomputing.atlassian.net/wiki/spaces/Platform/pages/512787664/2022-09-26+Zapata+Resource+Identifiers+ZRIs  # noqa
-        workspace_zri = (
-            f"zri:v1::{default_tenant_id}:"
-            f"{special_workspace}:{zri_type}:{workspace_id}"
-        )
+        workspace_zri = make_workspace_zri(workspace_id)
 
         resp = self._get(
             self._uri_provider.uri_for("list_projects", parameters=(workspace_zri,)),

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -96,14 +96,20 @@ Example:
 
 # --------------------------------- MLFlow -----------------------------------
 
-ORQ_MLFLOW_CR_NAME = "ORQ_MLFLOW_CR_NAME"
+MLFLOW_CR_NAME = "ORQ_MLFLOW_CR_NAME"
 """
 Used to set the MLFlow CR name.
 """
 
-ORQ_MLFLOW_PORT = "ORQ_MLFLOW_PORT"
+MLFLOW_PORT = "ORQ_MLFLOW_PORT"
 """
 Used to set the port for communicating with MLFlow.
+"""
+
+MLFLOW_ARTIFACTS_DIR = "ORQ_MLFLOW_ARTIFACTS_DIR"
+"""
+Used to set the temporary directory to which mlflow artifacts can be written before
+uploading.
 """
 
 # ------------------------------- utilities ----------------------------------

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -89,6 +89,18 @@ Example:
 """
 
 
+# --------------------------------- MLFlow -----------------------------------
+
+ORQ_MLFLOW_CR_NAME = "ORQ_MLFLOW_CR_NAME"
+"""
+Used to set the MLFlow CR name.
+"""
+
+ORQ_MLFLOW_PORT = "ORQ_MLFLOW_PORT"
+"""
+Used to set the port for communicating with MLFlow.
+"""
+
 # ------------------------------- utilities ----------------------------------
 
 

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -1,6 +1,11 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
+
+"""
+Global constants used to access environment variables.
+"""
+
 import os
 import typing as t
 

--- a/src/orquestra/sdk/_base/_spaces/_api.py
+++ b/src/orquestra/sdk/_base/_spaces/_api.py
@@ -55,3 +55,24 @@ def list_projects(
     runtime = resolved_config._get_runtime()
 
     return runtime.list_projects(resolved_workspace_id)
+
+
+def make_workspace_zri(workspace_id: str) -> str:
+    """
+    Make the workspace ZRI for the specified workspace ID.
+
+    Builds project ZRI from some hardcoded values and the workspaceId based on
+    https://zapatacomputing.atlassian.net/wiki/spaces/Platform/pages/512787664/2022-09-26+Zapata+Resource+Identifiers+ZRIs
+    """  # noqa: E501
+    default_tenant_id = 0
+    special_workspace = "system"
+    zri_type = "resource_group"
+
+    return f"zri:v1::{default_tenant_id}:{special_workspace}:{zri_type}:{workspace_id}"
+
+
+def make_workspace_url(resource_catalog_url: str, workspace_zri: str) -> str:
+    """
+    Construct the URL for a workspace based on the resource catalog and workspace ZRI.
+    """
+    return f"{resource_catalog_url}/api/workspaces/{workspace_zri}"

--- a/src/orquestra/sdk/mlflow/__init__.py
+++ b/src/orquestra/sdk/mlflow/__init__.py
@@ -4,6 +4,6 @@
 
 """A set of Orquestra utilities relating to interacting with MLFlow."""
 
-from ._connection_utils import get_temp_artifacts_dir
+from ._connection_utils import get_temp_artifacts_dir, get_tracking_token
 
-__all__ = ["get_temp_artifacts_dir"]
+__all__ = ["get_temp_artifacts_dir", "get_temp_artifacts_dir", "get_tracking_token"]

--- a/src/orquestra/sdk/mlflow/__init__.py
+++ b/src/orquestra/sdk/mlflow/__init__.py
@@ -11,4 +11,9 @@ from ._connection_utils import (
     get_tracking_uri,
 )
 
-__all__ = ["get_current_user", "get_temp_artifacts_dir", "get_tracking_uri", "get_tracking_token"]
+__all__ = [
+    "get_current_user",
+    "get_temp_artifacts_dir",
+    "get_tracking_uri",
+    "get_tracking_token",
+]

--- a/src/orquestra/sdk/mlflow/__init__.py
+++ b/src/orquestra/sdk/mlflow/__init__.py
@@ -4,6 +4,10 @@
 
 """A set of Orquestra utilities relating to interacting with MLFlow."""
 
-from ._connection_utils import get_temp_artifacts_dir, get_tracking_token
+from ._connection_utils import (
+    get_temp_artifacts_dir,
+    get_tracking_token,
+    get_tracking_uri,
+)
 
-__all__ = ["get_temp_artifacts_dir", "get_temp_artifacts_dir", "get_tracking_token"]
+__all__ = ["get_temp_artifacts_dir", "get_tracking_uri", "get_tracking_token"]

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -43,7 +43,7 @@ def _is_executing_remoteley() -> bool:
             _env.MLFLOW_PORT,
             _env.MLFLOW_ARTIFACTS_DIR,
         ]
-        if None not in [os.getenv(envvar) for envvar in envvars]:
+        if all(os.getenv(envvar) for envvar in envvars):
             return True
     return False
 

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -5,8 +5,8 @@
 """Utilities for communicating with mlflow."""
 
 import os
-import warnings
 import typing as t
+import warnings
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -14,14 +14,13 @@ from requests import Response, Session
 
 from orquestra import sdk
 from orquestra.sdk._base import _env
-from orquestra.sdk._base._services import ORQUESTRA_BASE_PATH
-from orquestra.sdk._base._spaces._api import make_workspace_url, make_workspace_zri
-from orquestra.sdk.schema.configs import ConfigName
 from orquestra.sdk._base._config import read_config
 from orquestra.sdk._base._env import CURRENT_USER_ENV
 from orquestra.sdk._base._jwt import get_email_from_jwt_token
 from orquestra.sdk._base._services import ORQUESTRA_BASE_PATH
+from orquestra.sdk._base._spaces._api import make_workspace_url, make_workspace_zri
 from orquestra.sdk.exceptions import ConfigNameNotFoundError, RuntimeConfigError
+from orquestra.sdk.schema.configs import ConfigName
 
 DEFAULT_TEMP_ARTIFACTS_DIR: Path = ORQUESTRA_BASE_PATH / "mlflow" / "artifacts"
 RESOURCE_CATALOG_URI: str = "http://orquestra-resource-catalog.resource-catalog"
@@ -199,7 +198,8 @@ def get_tracking_uri(workspace_id: str, config_name: Optional[str] = None) -> st
 
 def get_tracking_token(config_name: Optional[str] = None) -> str:
     """
-    Get a token suitable for authorizing the MLflow client for accessing Orquestra's MLflow tracking server.
+    Get a token suitable for authorizing the MLflow client for accessing Orquestra's
+    MLflow tracking server.
 
     Args:
         config_name: The name of a stored configuration specifying the execution
@@ -262,5 +262,6 @@ def get_current_user(config_name: t.Optional[str]) -> str:
         )
 
     return get_email_from_jwt_token(token)
-  
+
+
 # endregion

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -36,7 +36,6 @@ def _is_executing_remoteley() -> bool:
         _env.PASSPORT_FILE_ENV,
         _env.MLFLOW_CR_NAME,
         _env.MLFLOW_PORT,
-        _env.PASSPORT_FILE_ENV,
         _env.MLFLOW_ARTIFACTS_DIR,
     ]
     if None in [os.getenv(envvar) for envvar in envvars]:
@@ -189,7 +188,6 @@ def get_tracking_uri(workspace_id: str, config_name: Optional[str] = None) -> st
         if not config_name:
             raise ValueError("The config_name parameter is required for local runs.")
 
-        # TODO: try-except block to raise a more informative error message.
         config = sdk.RuntimeConfig.load(config_name)
         try:
             return f"{config.uri}/mlflow/{workspace_id}"

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -193,7 +193,7 @@ def get_tracking_uri(workspace_id: str, config_name: Optional[str] = None) -> st
 
 def get_tracking_token(config_name: Optional[str] = None) -> str:
     """
-    Get the MLFlow tracking token.
+    Get a token suitable for authorizing the MLflow client for accessing Orquestra's MLflow tracking server.
 
     Args:
         config_name: The name of a stored configuration specifying the execution

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -108,18 +108,16 @@ def get_temp_artifacts_dir() -> Path:
     do not need adjusting between runtimes.
     """
 
-    path: Path
-    if "ORQ_MLFLOW_ARTIFACTS_DIR" in os.environ:
-        # In Studio and CE there is an environment variable that points to the artifact
-        # directory.
-        path = Path(os.environ["ORQ_MLFLOW_ARTIFACTS_DIR"])
-    else:
-        # If the artifact dir envvar doesn't exist, we're probably executing locally.
-        path = DEFAULT_TEMP_ARTIFACTS_DIR
+    temp_dir_path: Path = Path(
+        os.getenv(_env.MLFLOW_ARTIFACTS_DIR) or DEFAULT_TEMP_ARTIFACTS_DIR
+    )
+    # In Studio and CE there is an environment variable that points to the artifact
+    # directory. If the artifact dir envvar doesn't exist, assume we're executing
+    # locally and use the default artifacts dir.
 
-    path.mkdir(parents=True, exist_ok=True)
+    temp_dir_path.mkdir(parents=True, exist_ok=True)
 
-    return path
+    return temp_dir_path
 
 
 def get_tracking_uri(workspace_id: str, config_name: Optional[str] = None) -> str:

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -141,7 +141,7 @@ def get_tracking_uri(workspace_id: str, config_name: Optional[str] = None) -> st
     passing ``config_name``.
 
     Args:
-        workspace_id: ID of the workspace.
+        workspace_id: ID of the workspace. You can get it from Orquestra Portal UI.
         config_name: The name of a stored configuration specifying the execution
             environment. If this function is being executed remotely, this parameter
             can be omitted.

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -6,10 +6,96 @@
 
 import os
 from pathlib import Path
+from typing import Optional, Tuple
 
+from requests import Response, Session
+
+from orquestra import sdk
+from orquestra.sdk._base import _env
 from orquestra.sdk._base._services import ORQUESTRA_BASE_PATH
+from orquestra.sdk.schema.configs import ConfigName
 
 DEFAULT_TEMP_ARTIFACTS_DIR: Path = ORQUESTRA_BASE_PATH / "mlflow" / "artifacts"
+RESOURCE_CATALOG_URI: str = "http://orquestra-resource-catalog.resource-catalog"
+DEFAULT_ORQ_MLFLOW_CR_NAME: str = "mlflow"
+DEFAULT_ORQ_MLFLOW_PORT: int = 8080
+
+
+# region: private
+def _get_mlflow_domain_name_and_port() -> Tuple[str, int]:
+    """
+    Reads in the CR name and port from environment variables.
+
+    The environment variables are:
+    - ORQ_MLFLOW_CR_NAME
+    - ORQ_MLFLOW_PORT
+
+    If a variable is not set, i.e. when executing locally and the user has not
+    chosen to set them manually, returns the default value instead.
+
+    Example usage:
+
+    ```python
+    mlflow_cr_name, mlflow_port = _get_mlflow_domain_name_and_port()
+    ```
+    """
+    # TODO: check with studio/platform to ensure that the env var names are correct.
+    # TODO: at present this function is called _only_ from a path that assumes we're
+    # executing on a cluster. If that assumption also means we can assume that these
+    # env vars are set, we can remove the defaults entirely.
+    mlflow_cr_name: str
+    mlflow_port: int
+    if not (mlflow_cr_name := os.getenv(_env.ORQ_MLFLOW_CR_NAME)):
+        mlflow_cr_name = DEFAULT_ORQ_MLFLOW_CR_NAME
+    if not (mlflow_port := os.getenv(_env.ORQ_MLFLOW_PORT)):
+        mlflow_port = DEFAULT_ORQ_MLFLOW_PORT
+    return mlflow_cr_name, mlflow_port
+
+
+def _read_passport_token() -> Optional[str]:
+    """
+    Read in the passport token environment variable, if it exists
+    """
+    if not (passport_path := os.getenv(_env.PASSPORT_FILE_ENV)):
+        return None
+
+    return Path(passport_path).read_text()
+
+
+def _make_workspace_zri(workspace_id: str) -> str:
+    """
+    Make the workspace ZRI for the specified workspace ID.
+
+    we have to build project ZRI from some hardcoded values + workspaceId based on
+    https://zapatacomputing.atlassian.net/wiki/spaces/Platform/pages/512787664/2022-09-26+Zapata+Resource+Identifiers+ZRIs
+    """  # noqa: E501
+    default_tenant_id = 0
+    special_workspace = "system"
+    zri_type = "resource_group"
+
+    return f"zri:v1::{default_tenant_id}:{special_workspace}:{zri_type}:{workspace_id}"
+
+
+def _make_workspace_url(resource_catalog_url: str, workspace_zri: str) -> str:
+    """
+    Construct the URL for a workspace based on the resource catalog and workspace ZRI.
+    """
+    return f"{resource_catalog_url}/api/workspaces/{workspace_zri}"
+
+
+def _make_session(token) -> Session:
+    """
+    Create a HTTP session with the specified token.
+    """
+    session = Session()
+    session.headers["Content-Type"] = "application/json"
+    session.headers["Authorization"] = f"Bearer {token}"
+    return session
+
+
+# endregion
+
+# region: public
 
 
 def get_temp_artifacts_dir() -> Path:
@@ -34,3 +120,71 @@ def get_temp_artifacts_dir() -> Path:
     path.mkdir(parents=True, exist_ok=True)
 
     return path
+
+
+def get_tracking_uri(workspace_id: str, config_name: Optional[str] = None) -> str:
+    """
+    Get the MLFlow tracking URI for the specified workspace.
+
+    Args:
+        workspace_id: ID of the workspace.
+        config_name: The name of a stored configuration specifying the execution
+            environment. If this function is being executed remotely, this parameter
+            can be omitted.
+
+    Raises:
+        ValueError: When this function is called without a config name in a local
+            execution context.
+    """
+
+    # TODO: do we need to handle the case where a user has set the token environment
+    # variable locally?
+    # TODO: how do we handle cases where we're executing remotely, but the user
+    # provides a config name that doesn't match?
+    # TODO: do we need to worry about configs without a uri?
+    if token := _read_passport_token():
+        # Assume we're on a cluster
+        session: Session = _make_session(token)
+        workspace_zri: str = _make_workspace_zri(workspace_id)
+        workspace_url: str = _make_workspace_url(RESOURCE_CATALOG_URI, workspace_zri)
+
+        resp: Response = session.get(workspace_url)
+        resp.raise_for_status()
+        namespace: str = resp.json()["namespace"]
+        mlflow_cr_name, mlflow_port = _get_mlflow_domain_name_and_port()
+
+        return f"http://{mlflow_cr_name}.{namespace}:{mlflow_port}"
+    else:
+        # Assume we're executing locally, use external URIs
+        if not config_name:
+            raise ValueError("The config_name parameter is required for local runs.")
+        cluster_uri: str = sdk.RuntimeConfig.load(config_name).uri
+
+        return f"{cluster_uri}/mlflow/{workspace_id}"
+
+
+def get_tracking_token(config_name: Optional[str] = None) -> str:
+    """
+    Get the MLFlow tracking token.
+
+    Args:
+        config_name: The name of a stored configuration specifying the execution
+            environment. If this function is being executed remotely, this parameter
+            can be omitted.
+
+    Raises:
+        ValueError: When this function is called without a config name in a local
+            execution context.
+    """
+    if token := _read_passport_token():
+        # Assume we're on a cluster
+        return token
+    else:
+        # Assume we're executing locally, use the token from the config.
+        if not config_name:
+            raise ValueError("The config_name parameter is required for local runs.")
+        config: sdk.RuntimeConfig = sdk.RuntimeConfig.load(config_name)
+        return config.token
+
+
+# endregion

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -17,8 +17,8 @@ from orquestra.sdk.schema.configs import ConfigName
 
 DEFAULT_TEMP_ARTIFACTS_DIR: Path = ORQUESTRA_BASE_PATH / "mlflow" / "artifacts"
 RESOURCE_CATALOG_URI: str = "http://orquestra-resource-catalog.resource-catalog"
-DEFAULT_ORQ_MLFLOW_CR_NAME: str = "mlflow"
-DEFAULT_ORQ_MLFLOW_PORT: int = 8080
+DEFAULT_MLFLOW_CR_NAME: str = "mlflow"
+DEFAULT_MLFLOW_PORT: int = 8080
 
 
 # region: private
@@ -45,10 +45,10 @@ def _get_mlflow_domain_name_and_port() -> Tuple[str, int]:
     # env vars are set, we can remove the defaults entirely.
     mlflow_cr_name: str
     mlflow_port: int
-    if not (mlflow_cr_name := os.getenv(_env.ORQ_MLFLOW_CR_NAME)):
-        mlflow_cr_name = DEFAULT_ORQ_MLFLOW_CR_NAME
-    if not (mlflow_port := os.getenv(_env.ORQ_MLFLOW_PORT)):
-        mlflow_port = DEFAULT_ORQ_MLFLOW_PORT
+    if not (mlflow_cr_name := os.getenv(_env.MLFLOW_CR_NAME)):
+        mlflow_cr_name = DEFAULT_MLFLOW_CR_NAME
+    if not (mlflow_port := os.getenv(_env.MLFLOW_PORT)):
+        mlflow_port = DEFAULT_MLFLOW_PORT
     return mlflow_cr_name, mlflow_port
 
 
@@ -66,7 +66,7 @@ def _make_workspace_zri(workspace_id: str) -> str:
     """
     Make the workspace ZRI for the specified workspace ID.
 
-    we have to build project ZRI from some hardcoded values + workspaceId based on
+    Builds project ZRI from some hardcoded values and the workspaceId based on
     https://zapatacomputing.atlassian.net/wiki/spaces/Platform/pages/512787664/2022-09-26+Zapata+Resource+Identifiers+ZRIs
     """  # noqa: E501
     default_tenant_id = 0

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -153,7 +153,11 @@ def get_temp_artifacts_dir() -> Path:
 
 def get_tracking_uri(workspace_id: str, config_name: Optional[str] = None) -> str:
     """
-    Get the MLFlow tracking URI for the specified workspace.
+    Infer a URI for accessing an MLflow tracking server deployed within this workspace.
+    
+    When run within an Orquestra cluster, this function returns an "internal URI" that helps save cluster bandwidth. This works even without specifying ``config_name``.
+    
+    When run outside a cluster, this function returns an "external URI". Requires passing ``config_name``.
 
     Args:
         workspace_id: ID of the workspace.

--- a/tests/sdk/v2/mlflow/test_connection_utils.py
+++ b/tests/sdk/v2/mlflow/test_connection_utils.py
@@ -3,26 +3,24 @@
 ################################################################################
 
 import pathlib
+from contextlib import suppress as do_not_raise
 from typing import List
 from unittest.mock import Mock, create_autospec
 
 import pytest
 from pytest import MonkeyPatch
 from requests import Response, Session
-from contextlib import suppress as do_not_raise
-
-import pytest
 
 import orquestra.sdk.exceptions as exceptions
 from orquestra import sdk
 from orquestra.sdk._base._env import (
     CURRENT_CLUSTER_ENV,
+    CURRENT_USER_ENV,
     MLFLOW_ARTIFACTS_DIR,
     MLFLOW_CR_NAME,
     MLFLOW_PORT,
     PASSPORT_FILE_ENV,
 )
-from orquestra.sdk._base._env import CURRENT_USER_ENV
 
 
 class TestGetTempArtifactsDir:
@@ -83,7 +81,6 @@ class TestGetTempArtifactsDir:
 
             # Then
             assert dir.exists()
-
 
 
 @pytest.fixture
@@ -344,6 +341,7 @@ class TestGetTrackingToken:
                 "The config_name parameter is required for local runs." in e.exconly()
             )
 
+
 class TestGetCurrentUser:
     @pytest.mark.parametrize(
         "env_var, config_name, raises, expected_user",
@@ -377,4 +375,3 @@ class TestGetCurrentUser:
 
         with raises:
             assert expected_user == sdk.mlflow.get_current_user(config_name)
-

--- a/tests/sdk/v2/mlflow/test_connection_utils.py
+++ b/tests/sdk/v2/mlflow/test_connection_utils.py
@@ -3,8 +3,19 @@
 ################################################################################
 
 import pathlib
+from unittest.mock import Mock, create_autospec
+
+import pytest
+from pytest import MonkeyPatch
+from requests import Response, Session
 
 from orquestra import sdk
+from orquestra.sdk._base._env import (
+    MLFLOW_ARTIFACTS_DIR,
+    MLFLOW_CR_NAME,
+    MLFLOW_PORT,
+    PASSPORT_FILE_ENV,
+)
 
 
 class TestGetTempArtifactsDir:
@@ -16,7 +27,7 @@ class TestGetTempArtifactsDir:
         @staticmethod
         def test_happy_path(tmp_path: pathlib.Path, monkeypatch):
             # Given
-            monkeypatch.setenv("ORQ_MLFLOW_ARTIFACTS_DIR", str(tmp_path))
+            monkeypatch.setenv(MLFLOW_ARTIFACTS_DIR, str(tmp_path))
 
             # When
             path = sdk.mlflow.get_temp_artifacts_dir()
@@ -29,7 +40,7 @@ class TestGetTempArtifactsDir:
             # Given
             dir = tmp_path / "dir_that_does_not_exist"
             assert not dir.exists()
-            monkeypatch.setenv("ORQ_MLFLOW_ARTIFACTS_DIR", str(dir))
+            monkeypatch.setenv(MLFLOW_ARTIFACTS_DIR, str(dir))
 
             # When
             _ = sdk.mlflow.get_temp_artifacts_dir()
@@ -65,3 +76,381 @@ class TestGetTempArtifactsDir:
 
             # Then
             assert dir.exists()
+
+
+@pytest.fixture
+def mock_is_executing_remotely(monkeypatch):
+    monkeypatch.setattr(
+        sdk.mlflow._connection_utils, "_is_executing_remoteley", Mock(return_value=True)
+    )
+
+
+@pytest.fixture
+def mock_is_executing_locally(monkeypatch):
+    monkeypatch.setattr(
+        sdk.mlflow._connection_utils,
+        "_is_executing_remoteley",
+        Mock(return_value=False),
+    )
+
+
+class TestGetMLFlowCRNameAndPort:
+    @staticmethod
+    def test_happy_path(monkeypatch: MonkeyPatch, mock_is_executing_remotely):
+        # Given
+        monkeypatch.setenv(MLFLOW_CR_NAME, "<mlflow cr name sentinel>")
+        monkeypatch.setenv(MLFLOW_PORT, "2266")
+
+        # When
+        name, port = sdk.mlflow._connection_utils._get_mlflow_cr_name_and_port()
+
+        # Then
+        assert name == "<mlflow cr name sentinel>"
+        assert port == 2266
+
+    @staticmethod
+    def test_defensive_assert_for_remote_only(
+        monkeypatch: MonkeyPatch, mock_is_executing_locally
+    ):
+        # Given
+        monkeypatch.setattr(
+            sdk.mlflow._connection_utils,
+            "_is_executing_remoteley",
+            Mock(return_value=False),
+        )
+
+        # Then
+        with pytest.raises(AssertionError):
+            _ = sdk.mlflow._connection_utils._get_mlflow_cr_name_and_port()
+
+
+class TestReadPassportToken:
+    @staticmethod
+    def test_happy_path(monkeypatch: MonkeyPatch, tmp_path: pathlib.Path):
+        # Given
+        token_file = tmp_path / "tmp_token_file.txt"
+        token_file.write_text("<token sentinel>")
+        monkeypatch.setenv(PASSPORT_FILE_ENV, str(token_file))
+
+        # When
+        token = sdk.mlflow._connection_utils._read_passport_token()
+
+        # Then
+        assert token == "<token sentinel>"
+
+
+class TestMakeWorkspaceZRI:
+    @staticmethod
+    def test_string_construction():
+        # When
+        zri = sdk.mlflow._connection_utils._make_workspace_zri(
+            "<workspace id sentinel>"
+        )
+
+        # Then
+        assert zri == "zri:v1::0:system:resource_group:<workspace id sentinel>"
+
+
+class TestMakeWorkspaceURL:
+    @staticmethod
+    def test_string_construction():
+        # When
+        url = sdk.mlflow._connection_utils._make_workspace_url(
+            "<resource catalog url sentinel>", "<workspace zri sentinel>"
+        )
+
+        # Then
+        assert (
+            url
+            == "<resource catalog url sentinel>/api/workspaces/<workspace zri sentinel>"
+        )
+
+
+class TestMakeSession:
+    @staticmethod
+    def test_happy_path(monkeypatch: MonkeyPatch):
+        # Given
+        mock_requests_session = create_autospec(Session)
+        mock_requests_session.headers = {}
+        monkeypatch.setattr(
+            sdk.mlflow._connection_utils,
+            "Session",
+            Mock(return_value=mock_requests_session),
+        )
+
+        # When
+        session = sdk.mlflow._connection_utils._make_session("<token sentinel>")
+
+        # Then
+        assert session.headers["Content-Type"] == "application/json"
+        assert session.headers["Authorization"] == "Bearer <token sentinel>"
+
+
+class TestGetTrackingURI:
+    @pytest.mark.usefixtures("mock_is_executing_remotely")
+    class TestRemote:
+        @staticmethod
+        def test_unit_happy_path(monkeypatch: MonkeyPatch):
+            # Given
+            mock_session = create_autospec(Session)
+            mock_response = create_autospec(Response)
+            mock_response.json.return_value = {"namespace": "<namespace sentinel>"}
+            mock_session.get.return_value = mock_response
+            mock_read_passport_token = Mock(return_value="<passport token sentinel>")
+            mock_make_session = Mock(return_value=mock_session)
+            mock_make_workspace_zri = Mock(return_value="<workspace ZRI sentinel>")
+            mock_make_workspace_url = Mock(return_value="<workspace URL sentinel>")
+            mock_get_mlflow_cr_name_and_port = Mock(
+                return_value=("<CR Name Sentinel>", "<port sentinel>")
+            )
+
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_read_passport_token",
+                mock_read_passport_token,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils, "_make_session", mock_make_session
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_make_workspace_zri",
+                mock_make_workspace_zri,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_make_workspace_url",
+                mock_make_workspace_url,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_get_mlflow_cr_name_and_port",
+                mock_get_mlflow_cr_name_and_port,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "RESOURCE_CATALOG_URI",
+                "<resource catalog uri sentinel>",
+            )
+
+            # When
+            tracking_url = sdk.mlflow.get_tracking_uri("<workspace id sentinel>")
+
+            # Then
+            assert (
+                tracking_url
+                == "http://<CR Name Sentinel>.<namespace sentinel>:<port sentinel>"
+            )
+            mock_read_passport_token.assert_called_once_with()
+            mock_make_session.assert_called_once_with("<passport token sentinel>")
+            mock_make_workspace_zri.assert_called_once_with("<workspace id sentinel>")
+            mock_make_workspace_url.assert_called_once_with(
+                "<resource catalog uri sentinel>", "<workspace ZRI sentinel>"
+            )
+            mock_get_mlflow_cr_name_and_port.assert_called_once_with()
+
+        @staticmethod
+        def test_warns_user_that_config_parameter_will_be_ignored(monkeypatch):
+            # Given
+            mock_session = create_autospec(Session)
+            mock_response = create_autospec(Response)
+            mock_response.json.return_value = {"namespace": "<namespace sentinel>"}
+            mock_session.get.return_value = mock_response
+            mock_read_passport_token = Mock(return_value="<passport token sentinel>")
+            mock_make_session = Mock(return_value=mock_session)
+            mock_make_workspace_zri = Mock(return_value="<workspace ZRI sentinel>")
+            mock_make_workspace_url = Mock(return_value="<workspace URL sentinel>")
+            mock_get_mlflow_cr_name_and_port = Mock(
+                return_value=("<CR Name Sentinel>", "<port sentinel>")
+            )
+
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_read_passport_token",
+                mock_read_passport_token,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils, "_make_session", mock_make_session
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_make_workspace_zri",
+                mock_make_workspace_zri,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_make_workspace_url",
+                mock_make_workspace_url,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_get_mlflow_cr_name_and_port",
+                mock_get_mlflow_cr_name_and_port,
+            )
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "RESOURCE_CATALOG_URI",
+                "<resource catalog uri sentinel>",
+            )
+
+            # When
+            with pytest.warns(UserWarning) as e:
+                _ = sdk.mlflow.get_tracking_uri(
+                    "<workspace id sentinel>", config_name="<config sentinel>"
+                )
+
+            # Then
+            assert len(e.list) == 1
+            assert (
+                "The 'config_name' parameter is used only when executing locally, and will be ignored."  # noqa: E501
+                in str(e.list[0].message)
+            )
+
+        @staticmethod
+        def test_integration_happy_path(
+            tmp_path: pathlib.Path, monkeypatch: MonkeyPatch
+        ):
+            # Given
+            # Mock the passport token envvar and its file location
+            token_file = tmp_path / "tmp_token_file.txt"
+            token_file.write_text("<token sentinel>")
+            monkeypatch.setenv(PASSPORT_FILE_ENV, str(token_file))
+            # Mock the http session and response
+            mock_requests_session = create_autospec(Session)
+            mock_response = create_autospec(Response)
+            mock_response.json.return_value = {"namespace": "<namespace sentinel>"}
+            mock_requests_session.headers = {}
+            mock_requests_session.get.return_value = mock_response
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "Session",
+                Mock(return_value=mock_requests_session),
+            )
+            # Mock the custom resource name and port envvars
+            monkeypatch.setenv(MLFLOW_CR_NAME, "<mlflow cr name sentinel>")
+            monkeypatch.setenv(MLFLOW_PORT, "2266")
+
+            # When
+            tracking_url = sdk.mlflow.get_tracking_uri("<workspace id sentinel>")
+
+            # Then
+            assert (
+                tracking_url
+                == "http://<mlflow cr name sentinel>.<namespace sentinel>:2266"
+            )
+
+    @pytest.mark.usefixtures("mock_is_executing_locally")
+    class TestLocal:
+        @staticmethod
+        def test_happy_path(monkeypatch: MonkeyPatch):
+            # Given
+            mock_config = create_autospec(sdk.RuntimeConfig)
+            mock_config.uri = "<uri sentinel>"
+            monkeypatch.setattr(
+                sdk.RuntimeConfig, "load", Mock(return_value=mock_config)
+            )
+
+            # When
+            tracking_url = sdk.mlflow.get_tracking_uri(
+                "<workspace id sentinel>", config_name="<config_name_sentinel>"
+            )
+
+            # Then
+            assert tracking_url == "<uri sentinel>/mlflow/<workspace id sentinel>"
+
+        @staticmethod
+        def test_raises_ValueError_if_no_config_name():
+            # When
+            with pytest.raises(ValueError) as e:
+                _ = sdk.mlflow.get_tracking_uri("<workspace id sentinel>")
+
+            # Then
+            assert (
+                "The config_name parameter is required for local runs." in e.exconly()
+            )
+
+        @staticmethod
+        def test_raises_ValueError_if_config_has_no_uri(monkeypatch: MonkeyPatch):
+            # Given
+            mock_config = create_autospec(sdk.RuntimeConfig)
+            monkeypatch.setattr(
+                sdk.RuntimeConfig, "load", Mock(return_value=mock_config)
+            )
+
+            # When
+            with pytest.raises(ValueError) as e:
+                _ = sdk.mlflow.get_tracking_uri("<workspace id sentinel>")
+
+            # Then
+            assert "FOO" in e.exconly()
+
+
+class TestGetTrackingToken:
+    @pytest.mark.usefixtures("mock_is_executing_remotely")
+    class TestWithRemote:
+        @staticmethod
+        def test_uses_passport_token(monkeypatch: MonkeyPatch):
+            # Given
+            mock_read_passport_token = Mock(return_value="<passport token sentinel>")
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_read_passport_token",
+                mock_read_passport_token,
+            )
+
+            # When
+            tracking_token = sdk.mlflow.get_tracking_token()
+
+            # Then
+            assert tracking_token == "<passport token sentinel>"
+
+        @staticmethod
+        def test_warns_user_that_config_parameter_will_be_ignored(monkeypatch):
+            # Given
+            mock_read_passport_token = Mock(return_value="<passport token sentinel>")
+            monkeypatch.setattr(
+                sdk.mlflow._connection_utils,
+                "_read_passport_token",
+                mock_read_passport_token,
+            )
+
+            # When
+            with pytest.warns(UserWarning) as e:
+                _ = sdk.mlflow.get_tracking_token(config_name="<config name sentinel>")
+
+            # Then
+            assert len(e.list) == 1
+            assert (
+                "The 'config_name' parameter is used only when executing locally, and will be ignored."  # noqa: E501
+                in str(e.list[0].message)
+            )
+
+    @pytest.mark.usefixtures("mock_is_executing_locally")
+    class TestWithLocal:
+        @staticmethod
+        def test_uses_config_token(monkeypatch):
+            # Given
+            mock_config = create_autospec(sdk.RuntimeConfig)
+            mock_config.token = "<token sentinel>"
+            monkeypatch.setattr(
+                sdk.RuntimeConfig, "load", Mock(return_value=mock_config)
+            )
+
+            # When
+            tracking_token = sdk.mlflow.get_tracking_token(
+                config_name="<config sentinel>"
+            )
+
+            # Then
+            assert tracking_token == "<token sentinel>"
+
+        @staticmethod
+        def test_raises_ValueError_if_no_config_name():
+            # When
+            with pytest.raises(ValueError) as e:
+                _ = sdk.mlflow.get_tracking_token()
+
+            # Then
+            assert (
+                "The config_name parameter is required for local runs." in e.exconly()
+            )

--- a/tests/sdk/v2/mlflow/test_connection_utils.py
+++ b/tests/sdk/v2/mlflow/test_connection_utils.py
@@ -139,33 +139,6 @@ class TestReadPassportToken:
         assert token == "<token sentinel>"
 
 
-class TestMakeWorkspaceZRI:
-    @staticmethod
-    def test_string_construction():
-        # When
-        zri = sdk.mlflow._connection_utils._make_workspace_zri(
-            "<workspace id sentinel>"
-        )
-
-        # Then
-        assert zri == "zri:v1::0:system:resource_group:<workspace id sentinel>"
-
-
-class TestMakeWorkspaceURL:
-    @staticmethod
-    def test_string_construction():
-        # When
-        url = sdk.mlflow._connection_utils._make_workspace_url(
-            "<resource catalog url sentinel>", "<workspace zri sentinel>"
-        )
-
-        # Then
-        assert (
-            url
-            == "<resource catalog url sentinel>/api/workspaces/<workspace zri sentinel>"
-        )
-
-
 class TestMakeSession:
     @staticmethod
     def test_happy_path(monkeypatch: MonkeyPatch):

--- a/tests/sdk/v2/mlflow/test_connection_utils.py
+++ b/tests/sdk/v2/mlflow/test_connection_utils.py
@@ -99,14 +99,14 @@ class TestGetMLFlowCRNameAndPort:
     def test_happy_path(monkeypatch: MonkeyPatch, mock_is_executing_remotely):
         # Given
         monkeypatch.setenv(MLFLOW_CR_NAME, "<mlflow cr name sentinel>")
-        monkeypatch.setenv(MLFLOW_PORT, "2266")
+        monkeypatch.setenv(MLFLOW_PORT, "<mlflow port sentinel>")
 
         # When
         name, port = sdk.mlflow._connection_utils._get_mlflow_cr_name_and_port()
 
         # Then
         assert name == "<mlflow cr name sentinel>"
-        assert port == 2266
+        assert port == "<mlflow port sentinel>"
 
     @staticmethod
     def test_defensive_assert_for_remote_only(
@@ -328,7 +328,7 @@ class TestGetTrackingURI:
             )
             # Mock the custom resource name and port envvars
             monkeypatch.setenv(MLFLOW_CR_NAME, "<mlflow cr name sentinel>")
-            monkeypatch.setenv(MLFLOW_PORT, "2266")
+            monkeypatch.setenv(MLFLOW_PORT, "<mlflow port sentinel>")
 
             # When
             tracking_url = sdk.mlflow.get_tracking_uri("<workspace id sentinel>")
@@ -336,7 +336,7 @@ class TestGetTrackingURI:
             # Then
             assert (
                 tracking_url
-                == "http://<mlflow cr name sentinel>.<namespace sentinel>:2266"
+                == "http://<mlflow cr name sentinel>.<namespace sentinel>:<mlflow port sentinel>"  # noqa: E501
             )
 
     @pytest.mark.usefixtures("mock_is_executing_locally")
@@ -379,10 +379,15 @@ class TestGetTrackingURI:
 
             # When
             with pytest.raises(ValueError) as e:
-                _ = sdk.mlflow.get_tracking_uri("<workspace id sentinel>")
+                _ = sdk.mlflow.get_tracking_uri(
+                    "<workspace id sentinel>", config_name="<config_name_sentinel>"
+                )
 
             # Then
-            assert "FOO" in e.exconly()
+            assert (
+                "The config '<config_name_sentinel>' has no URI associated with it."
+                in e.exconly()
+            )
 
 
 class TestGetTrackingToken:

--- a/tests/sdk/v2/test_spaces.py
+++ b/tests/sdk/v2/test_spaces.py
@@ -1,8 +1,13 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+
 import typing as t
 
 import pytest
 
 from orquestra.sdk._base._env import CURRENT_PROJECT_ENV, CURRENT_WORKSPACE_ENV
+from orquestra.sdk._base._spaces._api import make_workspace_url, make_workspace_zri
 from orquestra.sdk._base._spaces._resolver import resolve_studio_project_ref
 from orquestra.sdk._base._spaces._structs import ProjectRef
 
@@ -34,3 +39,28 @@ def test_studio_resolver(
         workspace_id=ws,
         project_id=proj,
     )
+
+
+class TestMakeWorkspaceZRI:
+    @staticmethod
+    def test_string_construction():
+        # When
+        zri = make_workspace_zri("<workspace id sentinel>")
+
+        # Then
+        assert zri == "zri:v1::0:system:resource_group:<workspace id sentinel>"
+
+
+class TestMakeWorkspaceURL:
+    @staticmethod
+    def test_string_construction():
+        # When
+        url = make_workspace_url(
+            "<resource catalog url sentinel>", "<workspace zri sentinel>"
+        )
+
+        # Then
+        assert (
+            url
+            == "<resource catalog url sentinel>/api/workspaces/<workspace zri sentinel>"
+        )


### PR DESCRIPTION
# The problem

We need a user-facing utility for constructing MLflow tracking URI and token, for all three execution environments, preferably with little-to-no defaults; should be a reliable basis for other QoL improvements. 

# This PR's solution

Implements 2 new functions: `sdk.mlflow.get_tracking_uri()` and `sdk.mlflow.get_tracking_token()`. Example usage:

```python
from orquestra import sdk
import os

os.environ["MLFLOW_TRACKING_URI"] = sdk.mlflow.get_tracking_uri(workspace_id="joka-123", config_name="prod-d", )
os.environ["MLFLOW_TRACKING_TOKEN"] = sdk.mlflow.get_tracking_token(config_name="prod-d")
```

## Behavior on Cluster/Studio

- The `config_name` parameter is ignored, with a warning to the user that this is the case.
- The token is read from the file specified by the `PASSPORT_FILE_ENV` environment variable
- The tracking URI is constructed by opening an HTTP session using the token in order to determine the namespace, combining this with the  `ORQ_MLFLOW_CR_NAME` and `ORQ_MLFLOW_PORT` environment variables in the form `http://[ORQ_MLFLOW_CR_NAME].[NAMESPACE]:[ORQ_MLFLOW_PORT]`

## Behaviour on Local

- The token is sourced from the stored config.
- The tracking URI is constructed from the stored config URI and workspace ID in the form `[URI]/mlflow/[WORKSPACE ID]`

## A Note on Determining the Execution Environment

At present we use two mechanisms to determine whether the execution environment is 'local' or 'remote'. 
If the `CURRENT_CLUSTER_ENV` environment variable is set, we take this as concrete proof that we're remote. As this variable was only added in [OP-137](https://zapatacomputing.atlassian.net/browse/OP-137), its absence cannot be assumed to be proof that we're running locally. Therefore we also check the `PASSPORT_FILE_ENV`, `MLFLOW_CR_NAME`, `MLFLOW_PORT`, and `MLFLOW_ARTIFACTS_DIR` environment variables. If one or more of these are not set, we take this as indicating that we're running on local. This is a temporary measure as we only support N-1 backwards compatibility, so this second layer of checking can be removed in the next release ([ORQSDK-914](https://zapatacomputing.atlassian.net/browse/ORQSDK-914))

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).

[ORQSDK-879]

[ORQSDK-879]: https://zapatacomputing.atlassian.net/browse/ORQSDK-879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[OP-137]: https://zapatacomputing.atlassian.net/browse/OP-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ