### PR TITLE
fix: Use non-root user to install Python packages and use a venv in CUDA Docker image

### DIFF
--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -35,7 +35,6 @@ ENV CUQUANTUM_DIR=/opt/nvidia/cuquantum
 
 # get required tools to build qsim
 RUN <<EOF
-python -m pip install pybind11
 apt-get install --yes git
 export DEBIAN_FRONTEND=noninteractive
 apt-get install --yes cmake
@@ -58,6 +57,8 @@ RUN python -m venv "$VIRTUAL_ENV" --prompt system
 RUN <<EOF
 set -ex
 . "$VIRTUAL_ENV/bin/activate"
+
+python -m pip install pybind11
 
 git clone https://github.com/quantumlib/qsim.git
 cd qsim


### PR DESCRIPTION
# The problem

Root user is used for installing Python module and the system Python executable is used, which creates problems for custom image authors.

# This PR's solution

This is a follow-up PR to another and makes the same change for the CUDA images.

# Jira ticket

https://zapatacomputing.atlassian.net/browse/OP-166

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
