### PR TITLE
Feat: `get_current_user` function to mlflow namespace for powering MLflow UI label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Removed unsupported `WorkflowDef.local_run()` function
 
 🔥 *Features*
+* Add `sdk.mlflow.get_current_user()` function to improve MLflow UI labeling
 
 🧟 *Deprecations*
 

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -27,22 +27,22 @@ Consumed by the Workflow SDK to set auth in remote contexts
 
 CURRENT_CLUSTER_ENV = "ORQ_CURRENT_CLUSTER"
 """
-Set by Studio to share cluster's URL
+Set by Studio and CE to share cluster's URL
 """
 
 CURRENT_WORKSPACE_ENV = "ORQ_CURRENT_WORKSPACE"
 """
-Set by Studio to share current workspace ID
+Set by Studio and CE to share current workspace ID
 """
 
 CURRENT_PROJECT_ENV = "ORQ_CURRENT_PROJECT"
 """
-Set by Studio to share current project ID
+Set by Studio and CE to share current project ID
 """
 
 CURRENT_USER_ENV = "ORQ_CURRENT_USER"
 """
-Set by Studio to share current project ID
+Set by Studio and CE to share current user
 """
 
 ORQ_VERBOSE = "ORQ_VERBOSE"

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -40,6 +40,11 @@ CURRENT_PROJECT_ENV = "ORQ_CURRENT_PROJECT"
 Set by Studio to share current project ID
 """
 
+CURRENT_USER_ENV = "ORQ_CURRENT_USER"
+"""
+Set by Studio to share current project ID
+"""
+
 ORQ_VERBOSE = "ORQ_VERBOSE"
 """
 If set to a truthy value, enables printing debug information when running the ``orq``

--- a/src/orquestra/sdk/_base/_jwt.py
+++ b/src/orquestra/sdk/_base/_jwt.py
@@ -26,3 +26,12 @@ def check_jwt_without_signature_verification(token: str):
         )
     except jwt.DecodeError:
         raise InvalidTokenError("Auth token is not a JWT. Try logging in again.")
+
+
+def get_email_from_jwt_token(token: str):
+    try:
+        token_info = jwt.decode(token, options={"verify_signature": False})
+    except jwt.DecodeError:
+        raise InvalidTokenError("Auth token is not a JWT. Try logging in again.")
+
+    return token_info["email"]

--- a/src/orquestra/sdk/mlflow/__init__.py
+++ b/src/orquestra/sdk/mlflow/__init__.py
@@ -4,6 +4,6 @@
 
 """A set of Orquestra utilities relating to interacting with MLFlow."""
 
-from ._connection_utils import get_temp_artifacts_dir
+from ._connection_utils import get_current_user, get_temp_artifacts_dir
 
-__all__ = ["get_temp_artifacts_dir"]
+__all__ = ["get_temp_artifacts_dir", "get_current_user"]

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -42,6 +42,25 @@ def get_temp_artifacts_dir() -> Path:
 
 
 def get_current_user(config_name: t.Optional[str]) -> str:
+    """
+    Return current user that can be used to power MLFlow UI label
+
+    When used inside a studio or CE task, returns actively logged-in user.
+    When used locally, uses token stored inside config to figure out what username
+    was used during login.
+
+    Args:
+        config_name: config entry to use to deduce username. Ignored when used
+            in studio or inside task executed on CE runtime.
+
+    Raises:
+        orquestra.sdk.exceptions.ConfigNameNotFoundError: when no matching config was
+            found or when called locally without config parameter
+        orquestra.sdk.exceptions.RuntimeConfigError: when chosen config does not
+            contain token runtime option
+        orquestra.sdk.exceptions.InvalidTokenError: When token saved inside config
+            is not a valid JWT token
+    """
     if CURRENT_USER_ENV in os.environ:
         return os.environ[CURRENT_USER_ENV]
 
@@ -52,8 +71,8 @@ def get_current_user(config_name: t.Optional[str]) -> str:
         token = read_config(config_name).runtime_options["token"]
     except KeyError:
         raise RuntimeConfigError(
-            "Selected config does not have remote token configured"
-            ". Did you log in it?"
+            "Selected config does not have remote token configured. "
+            "Did you log in with it?"
         )
 
     return get_email_from_jwt_token(token)

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -5,9 +5,14 @@
 """Utilities for communicating with mlflow."""
 
 import os
+import typing as t
 from pathlib import Path
 
+from orquestra.sdk._base._config import read_config
+from orquestra.sdk._base._env import CURRENT_USER_ENV
+from orquestra.sdk._base._jwt import get_email_from_jwt_token
 from orquestra.sdk._base._services import ORQUESTRA_BASE_PATH
+from orquestra.sdk.exceptions import ConfigNameNotFoundError, RuntimeConfigError
 
 DEFAULT_TEMP_ARTIFACTS_DIR: Path = ORQUESTRA_BASE_PATH / "mlflow" / "artifacts"
 
@@ -34,3 +39,21 @@ def get_temp_artifacts_dir() -> Path:
     path.mkdir(parents=True, exist_ok=True)
 
     return path
+
+
+def get_current_user(config_name: t.Optional[str]) -> str:
+    if CURRENT_USER_ENV in os.environ:
+        return os.environ[CURRENT_USER_ENV]
+
+    if config_name is None:
+        raise ConfigNameNotFoundError("Unable to get current user without config.")
+
+    try:
+        token = read_config(config_name).runtime_options["token"]
+    except KeyError:
+        raise RuntimeConfigError(
+            "Selected config does not have remote token configured"
+            ". Did you log in it?"
+        )
+
+    return get_email_from_jwt_token(token)

--- a/tests/cli/dorq/test_repos.py
+++ b/tests/cli/dorq/test_repos.py
@@ -1299,6 +1299,8 @@ class TestConfigRepo:
                 "test_config_no_runtime_options",
                 "test_config_qe",
                 "actual_name",
+                "proper_token",
+                "improper_token",
             }
 
         @staticmethod

--- a/tests/sdk/v2/data/configs.py
+++ b/tests/sdk/v2/data/configs.py
@@ -40,7 +40,7 @@ TEST_CONFIGS_DICT: t.Mapping[str, t.Mapping[str, t.Any]] = {
         "runtime_name": "CE_REMOTE",
         "runtime_options": {
             "uri": "http://some_cool_uri.io",
-            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6Im15X2hpZGRlbl9lbWFpbEBsb3ZlbHktZW1haWwuY29tIn0.HNQ4xovOEWQh7HbxmwiViVR-Xw792yXrbUDknzChncA",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6Im15X2hpZGRlbl9lbWFpbEBsb3ZlbHktZW1haWwuY29tIn0.HNQ4xovOEWQh7HbxmwiViVR-Xw792yXrbUDknzChncA",  # noqa
         },
     },
     "improper_token": {
@@ -48,7 +48,7 @@ TEST_CONFIGS_DICT: t.Mapping[str, t.Mapping[str, t.Any]] = {
         "runtime_name": "CE_REMOTE",
         "runtime_options": {
             "uri": "http://some_cool_uri.io",
-            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6Im15X2hpZGRl9lbWFpbEBsb3ZlbHktZW1haWwuY29tIn0.HNQ4xovOEWQh7HbxmwiViVR-Xw792yXrbUDknzChncA",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6Im15X2hpZGRl9lbWFpbEBsb3ZlbHktZW1haWwuY29tIn0.HNQ4xovOEWQh7HbxmwiViVR-Xw792yXrbUDknzChncA",  # noqa
         },
     },
 }

--- a/tests/sdk/v2/data/configs.py
+++ b/tests/sdk/v2/data/configs.py
@@ -35,6 +35,22 @@ TEST_CONFIGS_DICT: t.Mapping[str, t.Mapping[str, t.Any]] = {
             "token": "this_token_best_token",
         },
     },
+    "proper_token": {
+        "config_name": "proper_token",
+        "runtime_name": "CE_REMOTE",
+        "runtime_options": {
+            "uri": "http://some_cool_uri.io",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6Im15X2hpZGRlbl9lbWFpbEBsb3ZlbHktZW1haWwuY29tIn0.HNQ4xovOEWQh7HbxmwiViVR-Xw792yXrbUDknzChncA",
+        },
+    },
+    "improper_token": {
+        "config_name": "improper_token",
+        "runtime_name": "CE_REMOTE",
+        "runtime_options": {
+            "uri": "http://some_cool_uri.io",
+            "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJlbWFpbCI6Im15X2hpZGRl9lbWFpbEBsb3ZlbHktZW1haWwuY29tIn0.HNQ4xovOEWQh7HbxmwiViVR-Xw792yXrbUDknzChncA",
+        },
+    },
 }
 TEST_CONFIG_JSON: t.Mapping[str, t.Any] = {
     "version": CONFIG_FILE_CURRENT_VERSION,


### PR DESCRIPTION
# The problem

Users had to hardcode their mlflow ui label
https://zapatacomputing.atlassian.net/browse/ORQSDK-888

# This PR's solution

Create new function that return whoever started the workflow

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
