### PR TITLE
docs: correct references to 'in-process' that should be 'in_process'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 🥷 *Internal*
 
 📃 *Docs*
+* The help string for configs in the CLI now specifies the correct `in_process` rather than `in-process`.
 
 ## v0.52.0
 

--- a/docs/guides/workflow-runs.rst
+++ b/docs/guides/workflow-runs.rst
@@ -64,7 +64,7 @@ Configurations for interaction with remote runtime are created by using the :ref
 
 Configs for remote clusters will get auto-named based on URI.
 Local ray runtime has hardcoded config name, either "local" or "ray".
-In-process runtime has also hardcoded config name, "in-process"
+In-process runtime has also hardcoded config name, "in_process"
 
 Saved configs can be listed with ``list_configs()`` and retrieved with ``load()``:
 

--- a/src/orquestra/sdk/_base/cli/_dorq/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_entry.py
@@ -34,7 +34,7 @@ CONFIG_OPTION = cloup.option(
     "--config",
     required=False,
     help="""
-Name of the config used to submit workflow. Use 'in-process' for running workflow
+Name of the config used to submit workflow. Use 'in_process' for running workflow
 as local python process, 'ray' to run workflow in local ray cluster.
 To get config name for remote runtime, use orq login -s <uri> first
 """,


### PR DESCRIPTION
# The problem

The help text for the config option in our CLI directs the user to use `in-process` for the in-process runtime. The actual argument they should use is `in_process`.

# This PR's solution

Corrects this help string, and the only other reference I could find to this name.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
