### PR TITLE
fix: module not found errors on CE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,11 @@ python -m pip install --no-cache-dir -U pip wheel
 python -m pip install --no-cache-dir "${SDK_REQUIREMENT}"
 EOF
 
+# We installed some executables (like 'ray') in a virtual environment. We need to expose them when 
+# running interactive shell.
+# https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
+RUN echo "source ${VIRTUAL_ENV}/bin/activate" >> /home/orquestra/.bashrc
+
 # This is needed to ensure that the virtual env is used when running
 # non-interactive shells (e.g. when running a startup script)
 # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,12 +43,6 @@ EOF
 # Prefer to use pip, python, and other binaries from the virtual env.
 ENV PATH="/opt/orquestra/venv/bin:$PATH"
 
-# This is needed to ensure that the virtual env is used when running
-# non-interactive shells (e.g. when running a startup script)
-# https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
-RUN echo "source ${VIRTUAL_ENV}/bin/activate" >> /opt/orquestra/source-venv
-ENV BASH_ENV=/opt/orquestra/source-venv
-
 ENV RAY_STORAGE=/tmp
 # This environment variable configures the Ray runtime to download Git imports.
 # Without this set, Git imports are ignored

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,10 +40,8 @@ python -m pip install --no-cache-dir -U pip wheel
 python -m pip install --no-cache-dir "${SDK_REQUIREMENT}"
 EOF
 
-# We installed some executables (like 'ray') in a virtual environment. We need to expose them when 
-# running interactive shell.
-# https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
-RUN echo "source ${VIRTUAL_ENV}/bin/activate" >> /home/orquestra/.bashrc
+# Prefer to use pip, python, and other binaries from the virtual env.
+ENV PATH="/opt/orquestra/venv/bin:$PATH"
 
 # This is needed to ensure that the virtual env is used when running
 # non-interactive shells (e.g. when running a startup script)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,6 +43,12 @@ EOF
 # Prefer to use pip, python, and other binaries from the virtual env.
 ENV PATH="/opt/orquestra/venv/bin:$PATH"
 
+# This is needed to ensure that the virtual env is used when running
+# non-interactive shells (e.g. when running a startup script)
+# https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
+RUN echo "source ${VIRTUAL_ENV}/bin/activate" >> /opt/orquestra/source-venv
+ENV BASH_ENV=/opt/orquestra/source-venv
+
 ENV RAY_STORAGE=/tmp
 # This environment variable configures the Ray runtime to download Git imports.
 # Without this set, Git imports are ignored

--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -69,6 +69,9 @@ python -m pip install --no-cache-dir .
 python -m pip install --no-cache-dir "${SDK_REQUIREMENT}"
 EOF
 
+# Prefer to use pip, python, and other binaries from the virtual env.
+ENV PATH="/opt/orquestra/venv/bin:$PATH"
+
 # This is needed to ensure that the virtual env is used when running
 # non-interactive shells (e.g. when running a startup script)
 # https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files

--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -72,12 +72,6 @@ EOF
 # Prefer to use pip, python, and other binaries from the virtual env.
 ENV PATH="/opt/orquestra/venv/bin:$PATH"
 
-# This is needed to ensure that the virtual env is used when running
-# non-interactive shells (e.g. when running a startup script)
-# https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
-RUN echo "source ${VIRTUAL_ENV}/bin/activate" >> /opt/orquestra/source-venv
-ENV BASH_ENV=/opt/orquestra/source-venv
-
 ENV RAY_STORAGE=/tmp
 # This environment variable configures the Ray runtime to download Git imports.
 # Without this set, Git imports are ignored

--- a/docker/cuda.Dockerfile
+++ b/docker/cuda.Dockerfile
@@ -72,6 +72,12 @@ EOF
 # Prefer to use pip, python, and other binaries from the virtual env.
 ENV PATH="/opt/orquestra/venv/bin:$PATH"
 
+# This is needed to ensure that the virtual env is used when running
+# non-interactive shells (e.g. when running a startup script)
+# https://www.gnu.org/software/bash/manual/html_node/Bash-Startup-Files.html#Bash-Startup-Files
+RUN echo "source ${VIRTUAL_ENV}/bin/activate" >> /opt/orquestra/source-venv
+ENV BASH_ENV=/opt/orquestra/source-venv
+
 ENV RAY_STORAGE=/tmp
 # This environment variable configures the Ray runtime to download Git imports.
 # Without this set, Git imports are ignored


### PR DESCRIPTION
# The problem

My pre-release e2e tests showed that workflows are failing with the recent changes to our dockerfiles. @emre-aydin helped me find that there's a problem with missing "ray" executable. We had a venv auto-activation but I think some component (Workflow Driver?) runs a different kind of shell.

# This PR's solution

Prefer to use `python`, `pip`, `ray`, etc from the venv owned by `orquestra`.

I've confirmed the CPU dockerfiles to work by running our testing workflows on `evil`. My procedure was:
1. `git tag v0.53.0.dev1`
2. `pip install .` (to have the client SDK set to the tagged version)
3. Trigger a build of SDK base image with version from (1)
4. Trigger a build of WDR dev image from WDR@main & SDK image from (2). Publish it to `evil`
5. Run testing workflow
6. Check out `v0.52.0`
7. Repeat steps 2-5

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
