### PR TITLE
docs: Use orquestra-sdk[all] as the update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 📃 *Docs*
 * Added "Beginner's Guide to the CLI"
+* Update migration docs to use `orquestra-sdk[all]` to ensure extras are updated.
 
 
 ##  v0.53.0

--- a/docs/guides/migrating-from-quantum-engine.rst
+++ b/docs/guides/migrating-from-quantum-engine.rst
@@ -28,7 +28,7 @@ Checklist
 Short list:
 
 #. Use Python 3.9. You can check it with ``python -V``.
-#. Run ``pip install -U orquestra-sdk`` frequently.
+#. Run ``pip install -U "orquestra-sdk[all]"`` frequently.
 #. Update your task and workflow "imports". More info below.
 #. Update your task and workflow "resources". More info below.
 #. When logging in, use ``orq login``.


### PR DESCRIPTION
# The problem

The "update" command can result in a weird state, because if someone ever does `pip install "orquestra-sdk[all]"` (or with any extra) updated extra requirements are not considered with `pip install -U orquestra-sdk`, for example when the `ray` extra is updated.

# This PR's solution

Changes the update command.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
