### PR TITLE
feat: Error message when submitting an unsupported workflow SDK version to CE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 🔥 *Features*
 * `orq --version` or `orq -V` will now show the current SDK version.
 * `orq wf list` properly prompts for a workspace after selecting config if option `-w` was not provided
+* Helpful error when Compute Engine rejects a workflow if the Workflow SDK version is too old.
 
 🧟 *Deprecations*
 

--- a/src/orquestra/sdk/_base/_conversions/_imports.py
+++ b/src/orquestra/sdk/_base/_conversions/_imports.py
@@ -1,5 +1,5 @@
 ################################################################################
-# © Copyright 2022 Zapata Computing Inc.
+# © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
 import logging
 import re
@@ -10,14 +10,11 @@ from orquestra.sdk.schema import ir, yaml_model
 
 from ...packaging import get_installed_version
 from .. import _git_url_utils, serde
+from .._regex import SEMVER_REGEX
 from . import _ids
 
 POSSIBLE_IMPORTS = (ir.PythonImports, ir.GitImport)
 ORQ_SDK_URL = "git@github.com:zapatacomputing/orquestra-workflow-sdk.git"
-
-# From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string  # noqa:E501
-# with addition of `\.` before prerelease to match setuptools_scm format
-SEMVER_REGEX = r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:[-\.](?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"  # noqa:E501
 
 
 class ImportTranslator:

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -156,6 +156,20 @@ class CERuntime(RuntimeInterface):
                 "Unable to start the workflow run "
                 "- there are errors in the workflow definition."
             ) from e
+        except _exceptions.UnsupportedSDKVersion as e:
+            raise exceptions.WorkflowRunNotStarted(
+                (
+                    "This is an unsupported version of orquestra-sdk.\n{}{}"
+                    'Try updating with `pip install -U "orquestra-sdk[all]"`'
+                ).format(
+                    ""
+                    if e.submitted_version is None
+                    else f" - Current version: {e.submitted_version}\n",
+                    ""
+                    if e.supported_versions is None
+                    else f" - Supported versions: {e.supported_versions}\n",
+                )
+            ) from e
         except _exceptions.InvalidWorkflowRunRequest as e:
             raise exceptions.WorkflowRunNotStarted(
                 "Unable to start the workflow run."

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -30,13 +30,19 @@ from orquestra.sdk.schema.workflow_run import (
     WorkspaceId,
 )
 
-from . import _exceptions, _models
 from .._regex import VERSION_REGEX
+from . import _exceptions, _models
+
 
 def _match_unsupported_version(error_detail: str):
-    # We try to match format of the error message to parse the supported and submitted versions.
+    # We try to match format of the error message to parse the supported and
+    # submitted versions.
     # If we fail, we return None and carry on.
-    matches = re.match(rf"Unsupported SDK version: (?P<requested>{VERSION_REGEX})?\. Supported SDK versions: \[(?P<available>({VERSION_REGEX}[,]?)+)?\]", error_detail)
+    matches = re.match(
+        rf"Unsupported SDK version: (?P<requested>{VERSION_REGEX})?\. "
+        rf"Supported SDK versions: \[(?P<available>({VERSION_REGEX}[,]?)+)?\]",
+        error_detail,
+    )
     if matches is None:
         return None, None
 
@@ -46,7 +52,6 @@ def _match_unsupported_version(error_detail: str):
     available = available_match.split(",") if available_match is not None else None
 
     return requested, available
-
 
 
 class ExternalUriProvider:

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -9,6 +9,7 @@ Implemented API spec:
 """
 
 import io
+import re
 import zlib
 from tarfile import TarFile
 from typing import Generic, List, Mapping, Optional, Tuple, TypeVar, Union
@@ -30,7 +31,22 @@ from orquestra.sdk.schema.workflow_run import (
 )
 
 from . import _exceptions, _models
-from ._models import K8sEventLog
+from .._regex import VERSION_REGEX
+
+def _match_unsupported_version(error_detail: str):
+    # We try to match format of the error message to parse the supported and submitted versions.
+    # If we fail, we return None and carry on.
+    matches = re.match(rf"Unsupported SDK version: (?P<requested>{VERSION_REGEX})?\. Supported SDK versions: \[(?P<available>({VERSION_REGEX}[,]?)+)?\]", error_detail)
+    if matches is None:
+        return None, None
+
+    group_matches = matches.groupdict()
+    requested = group_matches.get("requested")
+    available_match = group_matches.get("available")
+    available = available_match.split(",") if available_match is not None else None
+
+    return requested, available
+
 
 
 class ExternalUriProvider:
@@ -355,6 +371,7 @@ class DriverClient:
 
         Raises:
             InvalidWorkflowRunRequest: see the exception's docstring
+            UnsupportedSDKVersion: see the exception's docstring
             InvalidTokenError: see the exception's docstring
             ForbiddenError: see the exception's docstring
             UnknownHTTPError: see the exception's docstring
@@ -368,6 +385,9 @@ class DriverClient:
 
         if resp.status_code == codes.BAD_REQUEST:
             error = _models.Error.parse_obj(resp.json())
+            if error.code == _models.ErrorCode.SDK_VERSION_UNSUPPORTED:
+                requested, available = _match_unsupported_version(error.detail)
+                raise _exceptions.UnsupportedSDKVersion(requested, available)
             raise _exceptions.InvalidWorkflowRunRequest(
                 message=error.message, detail=error.detail
             )

--- a/src/orquestra/sdk/_base/_driver/_exceptions.py
+++ b/src/orquestra/sdk/_base/_driver/_exceptions.py
@@ -1,5 +1,5 @@
 ################################################################################
-# © Copyright 2022 Zapata Computing Inc.
+# © Copyright 2022 - 2023 Zapata Computing Inc.
 ################################################################################
 """
 Exception types related to the Workflow Driver API.

--- a/src/orquestra/sdk/_base/_driver/_exceptions.py
+++ b/src/orquestra/sdk/_base/_driver/_exceptions.py
@@ -4,6 +4,8 @@
 """
 Exception types related to the Workflow Driver API.
 """
+from typing import List, Optional
+
 import requests
 
 
@@ -34,6 +36,22 @@ class InvalidWorkflowRunRequest(Exception):
         self.message = message
         self.detail = detail
         super().__init__(message, detail)
+
+
+class UnsupportedSDKVersion(InvalidWorkflowRunRequest):
+    """
+    Raised when an unsupported Workflow SDK version is used to submit a workflow run
+    """
+
+    def __init__(
+        self, submitted_version: Optional[str], supported_versions: Optional[List[str]]
+    ):
+        self.submitted_version = submitted_version
+        self.supported_versions = supported_versions
+        super().__init__(
+            f"Unsupported Workflow SDK version: {submitted_version}",
+            f"Supported Workflow SDK versions: {supported_versions}",
+        )
 
 
 class InvalidWorkflowDefID(Exception):

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -4,7 +4,7 @@
 """
 Internal models for the workflow driver API
 """
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import (
     Generic,
     List,
@@ -67,6 +67,20 @@ class Response(GenericModel, Generic[DataT, MetaT]):
 
 class MetaEmpty(pydantic.BaseModel):
     pass
+
+
+class ErrorCode(IntEnum):
+    """
+    Implements:
+        https://github.com/zapatacomputing/workflow-driver/blob/59eb3985151a813c69fec5a4777e8ed5c9a1f718/openapi/src/resources/workflow-runs.yaml#L59
+    """
+
+    REQUEST_BODY_INVALID_JSON = 1
+    WORKFLOW_DEF_ID_MISSING = 2
+    RESOURCE_REQUEST_INVALID = 3
+    SDK_VERSION_UNSUPPORTED = 4
+    WORKFLOW_DEF_ID_NOT_UUID = 5
+    WORKFLOW_DEF_NOT_FOUND = 6
 
 
 class Error(pydantic.BaseModel):

--- a/src/orquestra/sdk/_base/_regex.py
+++ b/src/orquestra/sdk/_base/_regex.py
@@ -1,0 +1,14 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+
+# From https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string  # noqa:E501
+# with addition of `\.` before prerelease to match setuptools_scm format
+# The regex is split into parts to make reading the expressions easier
+VERSION_NUMBER = r"0|[1-9]\d*"
+PRERELEASE = r"(?:{VERSION_NUMBER}|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:{VERSION_NUMBER}|\d*[a-zA-Z-][0-9a-zA-Z-]*))*"
+BUILD_METADATA = r"[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*"
+
+# VERSION_REGEX and SEMVER_REGEX are the same: however, SEMVER_REGEX matches an entire line and includes group names.
+VERSION_REGEX = rf"({VERSION_NUMBER})\.({VERSION_NUMBER})\.({VERSION_NUMBER})(?:[-\.]({PRERELEASE}))?(?:\+({BUILD_METADATA}))?"
+SEMVER_REGEX = rf"^(?P<major>{VERSION_NUMBER})\.(?P<minor>{VERSION_NUMBER})\.(?P<patch>{VERSION_NUMBER})(?:[-\.](?P<prerelease>{PRERELEASE}))?(?:\+(?P<buildmetadata>{BUILD_METADATA}))?$"  # noqa:E501

--- a/src/orquestra/sdk/_base/_regex.py
+++ b/src/orquestra/sdk/_base/_regex.py
@@ -6,9 +6,10 @@
 # with addition of `\.` before prerelease to match setuptools_scm format
 # The regex is split into parts to make reading the expressions easier
 VERSION_NUMBER = r"0|[1-9]\d*"
-PRERELEASE = r"(?:{VERSION_NUMBER}|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:{VERSION_NUMBER}|\d*[a-zA-Z-][0-9a-zA-Z-]*))*"
+PRERELEASE = r"(?:{VERSION_NUMBER}|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:{VERSION_NUMBER}|\d*[a-zA-Z-][0-9a-zA-Z-]*))*"  # noqa: E501
 BUILD_METADATA = r"[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*"
 
-# VERSION_REGEX and SEMVER_REGEX are the same: however, SEMVER_REGEX matches an entire line and includes group names.
-VERSION_REGEX = rf"({VERSION_NUMBER})\.({VERSION_NUMBER})\.({VERSION_NUMBER})(?:[-\.]({PRERELEASE}))?(?:\+({BUILD_METADATA}))?"
-SEMVER_REGEX = rf"^(?P<major>{VERSION_NUMBER})\.(?P<minor>{VERSION_NUMBER})\.(?P<patch>{VERSION_NUMBER})(?:[-\.](?P<prerelease>{PRERELEASE}))?(?:\+(?P<buildmetadata>{BUILD_METADATA}))?$"  # noqa:E501
+# VERSION_REGEX and SEMVER_REGEX are the same:
+# however, SEMVER_REGEX matches an entire line and includes group names.
+VERSION_REGEX = rf"({VERSION_NUMBER})\.({VERSION_NUMBER})\.({VERSION_NUMBER})(?:[-\.]({PRERELEASE}))?(?:\+({BUILD_METADATA}))?"  # noqa: E501
+SEMVER_REGEX = rf"^(?P<major>{VERSION_NUMBER})\.(?P<minor>{VERSION_NUMBER})\.(?P<patch>{VERSION_NUMBER})(?:[-\.](?P<prerelease>{PRERELEASE}))?(?:\+(?P<buildmetadata>{BUILD_METADATA}))?$"  # noqa: E501

--- a/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_dorq/_ui/_errors.py
@@ -164,3 +164,9 @@ def _(e: exceptions.InvalidTokenError) -> ResponseStatusCode:
 def _(e: exceptions.ExpiredTokenError) -> ResponseStatusCode:
     click.echo("The auth token has expired.\n" "Please try logging in again.")
     return ResponseStatusCode.UNAUTHORIZED
+
+
+@pretty_print_exception.register
+def _(e: exceptions.WorkflowRunNotStarted) -> ResponseStatusCode:
+    click.echo(e)
+    return ResponseStatusCode.INVALID_WORKFLOW_RUN

--- a/tests/cli/dorq/ui/test_errors.py
+++ b/tests/cli/dorq/ui/test_errors.py
@@ -94,6 +94,10 @@ class TestPrettyPrintException:
                 exceptions.RayNotRunningError(),
                 "Could not find any running Ray instance. You can use 'orq status' to check the status of the ray service. If it is not running, it can be started with the `orq up` command.",  # noqa: E501
             ),
+            (
+                exceptions.WorkflowRunNotStarted("An issue submitting the workflow"),
+                "An issue submitting the workflow",
+            ),
         ],
     )
     def tests_prints_exception_without_traceback(capsys, exc, stdout_marker: str):

--- a/tests/sdk/v2/driver/resp_mocks.py
+++ b/tests/sdk/v2/driver/resp_mocks.py
@@ -8,7 +8,7 @@ takes a lot of lines. Kept as a Python file for some DRY-ness.
 
 
 from pathlib import Path
-from typing import Any, List
+from typing import Any, List, Optional
 
 from orquestra.sdk._base._driver._models import (
     TaskInvocationID,
@@ -126,16 +126,21 @@ def make_create_wf_def_response(id_: WorkflowDefID):
     return {"data": {"id": id_}}
 
 
-def make_error_response(message: str, detail: str):
+def make_error_response(message: str, detail: str, code: Optional[int] = None):
     """
     Based on:
     https://github.com/zapatacomputing/workflow-driver/blob/34eba4253b56266772795a8a59d6ec7edf88c65a/openapi/src/schemas/Error.yaml
     """
 
-    return {
+    resp = {
         "message": message,
         "detail": detail,
     }
+
+    if code is not None:
+        resp["code"] = code
+
+    return resp
 
 
 # --- Workflow Runs ---

--- a/tests/sdk/v2/driver/resp_mocks.py
+++ b/tests/sdk/v2/driver/resp_mocks.py
@@ -8,7 +8,7 @@ takes a lot of lines. Kept as a Python file for some DRY-ness.
 
 
 from pathlib import Path
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from orquestra.sdk._base._driver._models import (
     TaskInvocationID,
@@ -132,7 +132,7 @@ def make_error_response(message: str, detail: str, code: Optional[int] = None):
     https://github.com/zapatacomputing/workflow-driver/blob/34eba4253b56266772795a8a59d6ec7edf88c65a/openapi/src/schemas/Error.yaml
     """
 
-    resp = {
+    resp: Dict[str, Any] = {
         "message": message,
         "detail": detail,
     }

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -3,7 +3,7 @@
 from contextlib import nullcontext as do_not_raise
 from datetime import timedelta
 from pathlib import Path
-from typing import ContextManager
+from typing import ContextManager, List, Optional
 from unittest.mock import DEFAULT, MagicMock, Mock, call, create_autospec
 
 import pytest
@@ -281,6 +281,39 @@ class TestCreateWorkflowRun:
             # When
             with pytest.raises(exceptions.WorkflowRunNotStarted):
                 _ = runtime.create_workflow_run(my_workflow.model, None)
+
+        @pytest.mark.parametrize("submitted_version", (None, "0.1.0"))
+        @pytest.mark.parametrize("supported_versions", (None, ["0.1.0"], ["0.2.0", "0.3.0"]))
+        def test_unsupported_sdk_version(
+            self,
+            mocked_client: MagicMock,
+            runtime: _ce_runtime.CERuntime,
+            submitted_version: Optional[str],
+            supported_versions: Optional[List[str]],
+        ):
+            # Given
+            mocked_client.create_workflow_run.side_effect = (
+                _exceptions.UnsupportedSDKVersion(submitted_version, supported_versions)
+            )
+
+            # When
+            with pytest.raises(exceptions.WorkflowRunNotStarted) as exc_info:
+                _ = runtime.create_workflow_run(my_workflow.model, None)
+
+            error_message = str(exc_info.value)
+            assert "This is an unsupported version of orquestra-sdk.\n" in error_message
+            assert 'Try updating with `pip install -U "orquestra-sdk[all]"`' in error_message
+
+            if submitted_version is None:
+                assert " - Current version:" not in error_message
+            else:
+                assert f" - Current version: {submitted_version}" in error_message
+
+            if supported_versions is None:
+                assert " - Supported versions:" not in error_message
+            else:
+                assert f" - Supported versions: {supported_versions}" in error_message
+
 
         def test_unknown_http(
             self, mocked_client: MagicMock, runtime: _ce_runtime.CERuntime

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -283,7 +283,9 @@ class TestCreateWorkflowRun:
                 _ = runtime.create_workflow_run(my_workflow.model, None)
 
         @pytest.mark.parametrize("submitted_version", (None, "0.1.0"))
-        @pytest.mark.parametrize("supported_versions", (None, ["0.1.0"], ["0.2.0", "0.3.0"]))
+        @pytest.mark.parametrize(
+            "supported_versions", (None, ["0.1.0"], ["0.2.0", "0.3.0"])
+        )
         def test_unsupported_sdk_version(
             self,
             mocked_client: MagicMock,
@@ -302,7 +304,10 @@ class TestCreateWorkflowRun:
 
             error_message = str(exc_info.value)
             assert "This is an unsupported version of orquestra-sdk.\n" in error_message
-            assert 'Try updating with `pip install -U "orquestra-sdk[all]"`' in error_message
+            assert (
+                'Try updating with `pip install -U "orquestra-sdk[all]"`'
+                in error_message
+            )
 
             if submitted_version is None:
                 assert " - Current version:" not in error_message
@@ -313,7 +318,6 @@ class TestCreateWorkflowRun:
                 assert " - Supported versions:" not in error_message
             else:
                 assert f" - Supported versions: {supported_versions}" in error_message
-
 
         def test_unknown_http(
             self, mocked_client: MagicMock, runtime: _ce_runtime.CERuntime

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -2,7 +2,6 @@
 ################################################################################
 from contextlib import nullcontext as do_not_raise
 from datetime import timedelta
-from pathlib import Path
 from typing import ContextManager, List, Optional
 from unittest.mock import DEFAULT, MagicMock, Mock, call, create_autospec
 

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -4,7 +4,8 @@
 """
 Tests for orquestra.sdk._base._driver._client.
 """
-from typing import Any, Dict
+import re
+from typing import Any, Dict, List, Optional
 from unittest.mock import create_autospec
 
 import numpy as np
@@ -17,12 +18,10 @@ from orquestra.sdk._base._driver._client import (
     DriverClient,
     ExternalUriProvider,
     Paginated,
+    _match_unsupported_version,
 )
 from orquestra.sdk._base._driver._models import (
     GetWorkflowDefResponse,
-    K8sEventLog,
-    Message,
-    RayHeadNodeEventLog,
     Resources,
     SystemLogSourceType,
 )
@@ -63,6 +62,29 @@ def endpoint_mocker_base(mocked_responses):
         return _mocker
 
     return _inner
+
+
+@pytest.mark.parametrize(
+    "error_detail,expected_sdk_version,expected_supported_versions",
+    (
+        # Unexpected detail format
+        ("Bad request", None, None),
+        ("Unsupported version: 0.1.0", None, None),
+        # Expected detail format
+        ("Unsupported SDK version: 0.1.0. Supported SDK versions: [0.2.0,0.3.0]", "0.1.0", ["0.2.0", "0.3.0"]),
+        ("Unsupported SDK version: 0.1.0. Supported SDK versions: [0.2.0]", "0.1.0", ["0.2.0"]),
+        # Missing versions
+        ("Unsupported SDK version: 0.1.0. Supported SDK versions: []", "0.1.0", None),
+        ("Unsupported SDK version: . Supported SDK versions: [0.1.0]", None, ["0.1.0"]),
+        # Development version
+        ("Unsupported SDK version: 0.3.1.dev9+gabc1230. Supported SDK versions: [0.2.0,0.3.0]", "0.3.1.dev9+gabc1230", ["0.2.0", "0.3.0"]),
+    ),
+)
+def test_unsupported_version_regex(error_detail: str, expected_sdk_version: Optional[str], expected_supported_versions: Optional[List[str]]):
+    sdk_version, supported_versions = _match_unsupported_version(error_detail)
+
+    assert sdk_version == expected_sdk_version
+    assert supported_versions == expected_supported_versions
 
 
 class TestClient:
@@ -1000,6 +1022,56 @@ class TestClient:
 
                 with pytest.raises(_exceptions.InvalidWorkflowRunRequest):
                     _ = client.create_workflow_run(workflow_def_id, resources)
+
+            @staticmethod
+            def test_invalid_sdk_version(
+                endpoint_mocker,
+                client: DriverClient,
+                workflow_def_id: str,
+                resources: Resources,
+            ):
+                submitted_version = "0.1.0"
+                supported_versions = "[0.2.0,0.3.0]"
+                endpoint_mocker(
+                    json=resp_mocks.make_error_response(
+                        message="Bad Request",
+                        detail= f"Unsupported SDK version: {submitted_version}. Supported SDK versions: {supported_versions}",
+                        code=4,
+                    ),
+                    # Specified in:
+                    # https://github.com/zapatacomputing/workflow-driver/blob/6270a214fff40f53d7b25ec967f2e7875eb296e3/openapi/src/resources/workflow-runs.yaml#L45
+                    status=400,
+                )
+
+                with pytest.raises(_exceptions.UnsupportedSDKVersion) as exc_info:
+                    _ = client.create_workflow_run(workflow_def_id, resources)
+
+                assert exc_info.value.submitted_version == submitted_version
+                assert exc_info.value.supported_versions == ["0.2.0", "0.3.0"]
+
+            @staticmethod
+            def test_invalid_sdk_version_unparsed_fallback(
+                endpoint_mocker,
+                client: DriverClient,
+                workflow_def_id: str,
+                resources: Resources,
+            ):
+                endpoint_mocker(
+                    json=resp_mocks.make_error_response(
+                        message="Bad Request",
+                        detail= "This message is different!",
+                        code=4,
+                    ),
+                    # Specified in:
+                    # https://github.com/zapatacomputing/workflow-driver/blob/6270a214fff40f53d7b25ec967f2e7875eb296e3/openapi/src/resources/workflow-runs.yaml#L45
+                    status=400,
+                )
+
+                with pytest.raises(_exceptions.UnsupportedSDKVersion) as exc_info:
+                    _ = client.create_workflow_run(workflow_def_id, resources)
+
+                assert exc_info.value.submitted_version == None
+                assert exc_info.value.supported_versions == None
 
             @staticmethod
             def test_sets_auth(

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -71,16 +71,32 @@ def endpoint_mocker_base(mocked_responses):
         ("Bad request", None, None),
         ("Unsupported version: 0.1.0", None, None),
         # Expected detail format
-        ("Unsupported SDK version: 0.1.0. Supported SDK versions: [0.2.0,0.3.0]", "0.1.0", ["0.2.0", "0.3.0"]),
-        ("Unsupported SDK version: 0.1.0. Supported SDK versions: [0.2.0]", "0.1.0", ["0.2.0"]),
+        (
+            "Unsupported SDK version: 0.1.0. Supported SDK versions: [0.2.0,0.3.0]",
+            "0.1.0",
+            ["0.2.0", "0.3.0"],
+        ),
+        (
+            "Unsupported SDK version: 0.1.0. Supported SDK versions: [0.2.0]",
+            "0.1.0",
+            ["0.2.0"],
+        ),
         # Missing versions
         ("Unsupported SDK version: 0.1.0. Supported SDK versions: []", "0.1.0", None),
         ("Unsupported SDK version: . Supported SDK versions: [0.1.0]", None, ["0.1.0"]),
         # Development version
-        ("Unsupported SDK version: 0.3.1.dev9+gabc1230. Supported SDK versions: [0.2.0,0.3.0]", "0.3.1.dev9+gabc1230", ["0.2.0", "0.3.0"]),
+        (
+            "Unsupported SDK version: 0.3.1.dev9+gabc1230. Supported SDK versions: [0.2.0,0.3.0]",  # noqa: E501
+            "0.3.1.dev9+gabc1230",
+            ["0.2.0", "0.3.0"],
+        ),
     ),
 )
-def test_unsupported_version_regex(error_detail: str, expected_sdk_version: Optional[str], expected_supported_versions: Optional[List[str]]):
+def test_unsupported_version_regex(
+    error_detail: str,
+    expected_sdk_version: Optional[str],
+    expected_supported_versions: Optional[List[str]],
+):
     sdk_version, supported_versions = _match_unsupported_version(error_detail)
 
     assert sdk_version == expected_sdk_version
@@ -1035,7 +1051,7 @@ class TestClient:
                 endpoint_mocker(
                     json=resp_mocks.make_error_response(
                         message="Bad Request",
-                        detail= f"Unsupported SDK version: {submitted_version}. Supported SDK versions: {supported_versions}",
+                        detail=f"Unsupported SDK version: {submitted_version}. Supported SDK versions: {supported_versions}",  # noqa: E501
                         code=4,
                     ),
                     # Specified in:
@@ -1059,7 +1075,7 @@ class TestClient:
                 endpoint_mocker(
                     json=resp_mocks.make_error_response(
                         message="Bad Request",
-                        detail= "This message is different!",
+                        detail="This message is different!",
                         code=4,
                     ),
                     # Specified in:
@@ -1070,8 +1086,8 @@ class TestClient:
                 with pytest.raises(_exceptions.UnsupportedSDKVersion) as exc_info:
                     _ = client.create_workflow_run(workflow_def_id, resources)
 
-                assert exc_info.value.submitted_version == None
-                assert exc_info.value.supported_versions == None
+                assert exc_info.value.submitted_version is None
+                assert exc_info.value.supported_versions is None
 
             @staticmethod
             def test_sets_auth(

--- a/tests/sdk/v2/driver/test_client.py
+++ b/tests/sdk/v2/driver/test_client.py
@@ -4,7 +4,6 @@
 """
 Tests for orquestra.sdk._base._driver._client.
 """
-import re
 from typing import Any, Dict, List, Optional
 from unittest.mock import create_autospec
 

--- a/tests/sdk/v2/test_regex.py
+++ b/tests/sdk/v2/test_regex.py
@@ -1,0 +1,38 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+import re
+
+import pytest
+
+from orquestra.sdk._base._regex import SEMVER_REGEX, VERSION_REGEX
+
+
+@pytest.mark.parametrize(
+    "version",
+    (
+        "0.1.0",
+        "0.1.1.dev1+gabc1234",
+        "0.1.0+d19891213",
+        "0.1.1.dev1+gabc1234.d19891213",
+    ),
+)
+def test_version_and_semver_both_match(version: str):
+    semver = re.match(SEMVER_REGEX, version)
+    ver = re.match(VERSION_REGEX, version)
+    assert semver is not None
+    assert ver is not None
+    assert semver.string == ver.string == version
+
+
+def test_semver_has_named_groups():
+    version = "0.1.1.dev1+gabc1234.d19891213"
+    match = re.match(SEMVER_REGEX, version)
+    assert match is not None
+    assert match.groupdict() == {
+        "buildmetadata": "gabc1234.d19891213",
+        "major": "0",
+        "minor": "1",
+        "patch": "1",
+        "prerelease": "dev1",
+    }


### PR DESCRIPTION
# The problem

We don't support all older versions of orquestra-sdk when submitting to CE.
CE will reject unsupported versions with an error message.

# This PR's solution

- Update our CE models to support error code enums
- Parse the supported versions from the CE response
- Add some tests for our regexes

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
