### PR TITLE
Imp: Aggregate all NotATaskWarnings to one warning 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+* Consolidate all warnings into one NotATaskWarning warning for the entire workflow
 
 🥷 *Internal*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
-* Consolidate all warnings into one NotATaskWarning warning for the entire workflow
+* Consolidate all `NotATaskWarning` warnings into a single warning for each workflow.
 
 🥷 *Internal*
 

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -320,7 +320,7 @@ class WorkflowTemplate(Generic[_P, _R]):
         if non_task_functions:
             warnings.warn(
                 f'Functions: "{", ".join(non_task_functions)}" called in the workflow '
-                f"are not a tasks. Did you mean to decorate it with @task?",
+                f"are not tasks. Did you mean to decorate them with @task?",
                 NotATaskWarning,
             )
 

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -304,6 +304,7 @@ class WorkflowTemplate(Generic[_P, _R]):
         # First we check the contents of the workflow function and warn the user if we
         # find any function calls to non-tasks.
         fn_calls = _get_function_calls(self._fn)
+        non_task_functions = []
         for called_fn in fn_calls:
             if isinstance(called_fn.function, loader.FakeImportedAttribute):
                 raise RuntimeError(
@@ -314,13 +315,15 @@ class WorkflowTemplate(Generic[_P, _R]):
                 isinstance(called_fn.function, TaskDef)
                 or called_fn.function in allowed_function_calls
             ):
-                warnings.warn_explicit(
-                    f'"{called_fn.name}" is not a task. Did you mean to decorate '
-                    "it with @task?",
-                    NotATaskWarning,
-                    called_fn.source_file or "<unknown>",
-                    called_fn.line_no or 0,
-                )
+                non_task_functions.append(called_fn.name)
+
+        if non_task_functions:
+            warnings.warn(
+                f'Functions: "{", ".join(non_task_functions)}" called in the workflow '
+                f"are not a tasks. Did you mean to decorate it with @task?",
+                NotATaskWarning,
+            )
+
         data_aggregation: Optional[DataAggregation]
         if self._data_aggregation is False:
             data_aggregation = DataAggregation(run=False)

--- a/tests/sdk/v2/test_workflow.py
+++ b/tests/sdk/v2/test_workflow.py
@@ -65,6 +65,8 @@ def faked_task_wf():
 def test_workflow_undecorated_task():
     with pytest.warns(_workflow.NotATaskWarning) as warnings:
         _ = undecorated_task_wf()
+
+    assert len(warnings) == 1
     warning = str(warnings[0])
     assert "undecorated" in warning
     assert "another_one" in warning
@@ -143,14 +145,14 @@ class TestModelsSerializeProperly:
         model = _simple_workflow.model
         assert called.model == model
 
-    @pytest.mark.filterwarnings('ignore:"Functions task" are not a task')
     def test_fail_if_task_def_returned(self):
         @sdk.workflow
         def _returned_task_def_workflow():
             return sdk.task()(undecorated)
 
         with pytest.raises(WorkflowSyntaxError):
-            _returned_task_def_workflow.model
+            with pytest.warns(_workflow.NotATaskWarning):
+                _returned_task_def_workflow.model
 
     @pytest.mark.filterwarnings('ignore:"Functions task" are not a task')
     def test_fail_if_task_def_passed_as_arg(self):
@@ -160,7 +162,8 @@ class TestModelsSerializeProperly:
             return _task_with_args(task)
 
         with pytest.raises(WorkflowSyntaxError):
-            _returned_task_def_workflow.model
+            with pytest.warns(_workflow.NotATaskWarning):
+                _returned_task_def_workflow.model
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/v2/test_workflow.py
+++ b/tests/sdk/v2/test_workflow.py
@@ -45,9 +45,13 @@ def undecorated():
     pass
 
 
+def another_one():
+    pass
+
+
 @sdk.workflow
 def undecorated_task_wf():
-    return [undecorated()]
+    return [undecorated(), another_one()]
 
 
 task = loader.FakeImportedAttribute()
@@ -59,8 +63,11 @@ def faked_task_wf():
 
 
 def test_workflow_undecorated_task():
-    with pytest.warns(_workflow.NotATaskWarning):
+    with pytest.warns(_workflow.NotATaskWarning) as warnings:
         _ = undecorated_task_wf()
+    warning = str(warnings[0])
+    assert "undecorated" in warning
+    assert "another_one" in warning
 
 
 def test_workflow_with_fake_imported_task():
@@ -136,7 +143,7 @@ class TestModelsSerializeProperly:
         model = _simple_workflow.model
         assert called.model == model
 
-    @pytest.mark.filterwarnings('ignore:"task" is not a task')
+    @pytest.mark.filterwarnings('ignore:"Functions task" are not a task')
     def test_fail_if_task_def_returned(self):
         @sdk.workflow
         def _returned_task_def_workflow():
@@ -145,7 +152,7 @@ class TestModelsSerializeProperly:
         with pytest.raises(WorkflowSyntaxError):
             _returned_task_def_workflow.model
 
-    @pytest.mark.filterwarnings('ignore:"task" is not a task')
+    @pytest.mark.filterwarnings('ignore:"Functions task" are not a task')
     def test_fail_if_task_def_passed_as_arg(self):
         @sdk.workflow
         def _returned_task_def_workflow():


### PR DESCRIPTION
# The problem

With a lot of functions not being a tasks, console used to spammed with warning
https://zapatacomputing.atlassian.net/browse/ORQSDK-314

# This PR's solution
Consolidate all warnings into one big NotATaskWarning warning

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
