### PR TITLE
docs: ensure that dependency installation issues are resolved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Update migration docs to use `orquestra-sdk[all]` to ensure extras are updated.
 * Corrected minor typos in the dependency installation guide.
 
+
 ##  v0.53.0
 
 🚨 *Breaking Changes*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 📃 *Docs*
 * Added "Beginner's Guide to the CLI"
 * Update migration docs to use `orquestra-sdk[all]` to ensure extras are updated.
-
+* Corrected minor typos in the dependency installation guide.
 
 ##  v0.53.0
 

--- a/docs/guides/dependency-installation.rst
+++ b/docs/guides/dependency-installation.rst
@@ -122,7 +122,7 @@ Source vs Dependency
 
 The ``@sdk.task`` decorator accepts two types of import arguments---source and dependency.
 Both accept any of the import types specified here.
-The importer passed to ``source_import=`` should provide the source code for locating the task definition, while external dependencies should be specified to ``dependency_imports=``.
+The importer passed to ``source_import=`` should provide the source code for locating the task definition, while external dependencies should be specified in ``dependency_imports=``.
 
 .. note::
    The ``source`` vs ``dependency`` import distinction used to be more relevant in the past.


### PR DESCRIPTION
[ORQSDK-903]

# The problem

## issues:

on this whole page, GitHubImport is spelled with a capital H, but the actual code is with a lowercase h like GithubImport (might be fixed)

“the SDK will set this appropriately for the context:” the following code example doesn’t get properly pulled in

“in which case am inline import” → “in which case an inline import” 

“depends on several python modules and a GitLab repo” the actual code doesn’t show a GitLab repo

“For additional control a git reference (branch name, tag, or commit) may be specified:” the following code example doesn’t render

“For this example we have named” I don’t see any examples in this section

“The examples below use PythonImports" no examples seen in the docs :disappointed:

suggestions:

“external dependencies should be specified to” → “external dependencies should be specified in”

“The required modules can be specified as arguments to the importer, or listed in a requirements.txt file specified by the file argument.” it would be nice to see an example of this! could be very useful

# This PR's solution

All but one of the issues have already been addressed in other PRs. The remaining suggestion, “external dependencies should be specified to” → “external dependencies should be specified in”, is implemented here.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


[ORQSDK-903]: https://zapatacomputing.atlassian.net/browse/ORQSDK-903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ