### PR TITLE
Fix: Fix usage of get_artifacts on failed workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
+* Fix error when calling get_artifacts() on unfinished or failed workflow
 
 💅 *Improvements*
 * Consolidate all `NotATaskWarning` warnings into a single warning for each workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
-* Fix error when calling get_artifacts() on unfinished or failed workflow
+* Fix an error when calling `get_artifacts()` on unfinished or failed workflow
 
 💅 *Improvements*
 * Consolidate all `NotATaskWarning` warnings into a single warning for each workflow.

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -338,6 +338,9 @@ class CERuntime(RuntimeInterface):
         artifact_vals: Dict[TaskInvocationId, WorkflowResult] = {}
 
         for task_run_id, artifact_ids in artifact_map.items():
+            # No artifact available yet on the workflow driver
+            if len(artifact_ids) == 0:
+                continue
             inv_id = self._invocation_id_by_task_run_id(workflow_run_id, task_run_id)
             assert (
                 len(artifact_ids) == 1

--- a/tests/sdk/v2/driver/test_ce_runtime.py
+++ b/tests/sdk/v2/driver/test_ce_runtime.py
@@ -706,6 +706,7 @@ class TestGetAvailableOutputs:
             mocked_client.get_workflow_run_artifacts.return_value = {
                 f"{workflow_run_id}@task-inv-1": ["wf-art-1"],
                 f"{workflow_run_id}@task-inv-2": ["wf-art-3"],
+                f"{workflow_run_id}@task-inv-3": [],
             }
             return mocked_client
 


### PR DESCRIPTION
# The problem

get_artifacts failed when used on failed workflow
https://zapatacomputing.atlassian.net/browse/ORQSDK-932

# This PR's solution

Workflow Driver returns an empty list of artifacts when task did not produce any artifacts yet. We missed that scenario. 

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
