### PR TITLE
fix: Add State.KILLED as a valid 'completed' state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 🐛 *Bug Fixes*
 * Fix an error when calling `get_artifacts()` on unfinished or failed workflow
+* `KILLED` workflows will no longer show an error when waiting for the workflow to complete.
 
 💅 *Improvements*
 * Consolidate all `NotATaskWarning` warnings into a single warning for each workflow.

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -41,7 +41,7 @@ from ..abc import RuntimeInterface
 from ._config import RuntimeConfig, _resolve_config
 from ._task_run import TaskRun
 
-COMPLETED_STATES = [State.FAILED, State.TERMINATED, State.SUCCEEDED]
+COMPLETED_STATES = [State.FAILED, State.TERMINATED, State.SUCCEEDED, State.KILLED]
 
 
 class WorkflowRun:
@@ -304,7 +304,7 @@ class WorkflowRun:
             time.sleep(sleep_time)
             status = self.get_status()
 
-        if status not in [State.SUCCEEDED, State.TERMINATED, State.FAILED]:
+        if status not in COMPLETED_STATES:
             raise NotImplementedError(
                 f'Workflow run with id "{self.run_id}" '
                 f'finished with unrecognised state "{status}"'


### PR DESCRIPTION
# The problem

KILLED workflows were causing an exception when people waited for completion

# This PR's solution

- Adds State.KILLED as a valid completed state
- Adds a unit test to check the completed states work with `wait_until_finished`
- Mocks `time.sleep` in some other unit tests because it was annoying me

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
