### PR TITLE
imp: expose `dates` in the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
-* `orq wf *` and `orq task *` commands (other than `orq wf submit`) wont prompt for project parameter anymore, as it was ignored anyway 
+* `orq wf *` and `orq task *` commands (other than `orq wf submit`) wont prompt for project parameter anymore, as it was ignored anyway.
+* New public module: `orquestra.sdk.dates`! `orquestra.sdk.schema.workflow_run` doesn't depend on private modules now. This caused type errors.
 
 🥷 *Internal*
 

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -21,7 +21,7 @@ import pydantic
 from pydantic.generics import GenericModel
 from typing_extensions import Annotated
 
-from orquestra.sdk._base._dates import Instant
+from orquestra.sdk.dates import Instant
 from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.workflow_run import (
     ProjectId,

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -8,15 +8,14 @@ In-process implementation of the runtime interface.
 import typing as t
 import warnings
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _dates, abc
+from orquestra.sdk import dates, exceptions
+from orquestra.sdk._base import abc
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.responses import WorkflowResult
 from orquestra.sdk.schema.workflow_run import (
-    ProjectId,
     RunStatus,
     State,
     TaskRun,
@@ -143,7 +142,7 @@ class InProcessRuntime(abc.RuntimeInterface):
 
         run_id = self._gen_next_run_id(workflow_def)
 
-        self._start_time_store[run_id] = _dates.now()
+        self._start_time_store[run_id] = dates.now()
 
         # We deserialize the constants in one go, instead of as needed
         consts: t.Dict[ir.ConstantNodeId, t.Any] = {
@@ -194,7 +193,7 @@ class InProcessRuntime(abc.RuntimeInterface):
         )
         self._output_store[run_id] = outputs
 
-        self._end_time_store[run_id] = _dates.now()
+        self._end_time_store[run_id] = dates.now()
         self._workflow_def_store[run_id] = workflow_def
         return run_id
 
@@ -297,7 +296,7 @@ class InProcessRuntime(abc.RuntimeInterface):
                 A list of the workflow runs
         """
 
-        now = _dates.now()
+        now = dates.now()
 
         if state is not None:
             if not isinstance(state, list):

--- a/src/orquestra/sdk/_base/_logs/_markers.py
+++ b/src/orquestra/sdk/_base/_logs/_markers.py
@@ -17,10 +17,9 @@ import typing as t
 from contextlib import contextmanager
 from dataclasses import dataclass
 
+from orquestra.sdk import dates
 from orquestra.sdk.schema.ir import TaskInvocationId
 from orquestra.sdk.schema.workflow_run import WorkflowRunId
-
-from .. import _dates
 
 ORQ_MARKER_PREFIX = "ORQ-MARKER:"
 ORQ_MARKER_PATTERN = re.compile(re.escape(ORQ_MARKER_PREFIX) + r"(.+)")
@@ -31,13 +30,13 @@ class TaskStartMarker:
     event = "task_start"
     wf_run_id: WorkflowRunId
     task_inv_id: TaskInvocationId
-    timestamp: _dates.Instant
+    timestamp: dates.Instant
 
     @property
     def line(self) -> str:
         event = {
             "event": self.event,
-            "timestamp": _dates.local_isoformat(self.timestamp),
+            "timestamp": dates.local_isoformat(self.timestamp),
             "wf_run_id": self.wf_run_id,
             "task_inv_id": self.task_inv_id,
         }
@@ -49,13 +48,13 @@ class TaskEndMarker:
     event = "task_end"
     wf_run_id: t.Optional[WorkflowRunId]
     task_inv_id: t.Optional[TaskInvocationId]
-    timestamp: _dates.Instant
+    timestamp: dates.Instant
 
     @property
     def line(self) -> str:
         event = {
             "event": self.event,
-            "timestamp": _dates.local_isoformat(self.timestamp),
+            "timestamp": dates.local_isoformat(self.timestamp),
             **({"wf_run_id": self.wf_run_id} if self.wf_run_id else {}),
             **({"task_inv_id": self.task_inv_id} if self.task_inv_id else {}),
         }
@@ -85,13 +84,13 @@ def parse_line(line: str) -> t.Optional[Marker]:
             return TaskStartMarker(
                 wf_run_id=event_dict["wf_run_id"],
                 task_inv_id=event_dict["task_inv_id"],
-                timestamp=_dates.from_isoformat(event_dict["timestamp"]),
+                timestamp=dates.from_isoformat(event_dict["timestamp"]),
             )
         elif event_dict["event"] == TaskEndMarker.event:
             return TaskEndMarker(
                 wf_run_id=event_dict.get("wf_run_id"),
                 task_inv_id=event_dict.get("task_inv_id"),
-                timestamp=_dates.from_isoformat(event_dict["timestamp"]),
+                timestamp=dates.from_isoformat(event_dict["timestamp"]),
             )
         else:
             return None
@@ -105,7 +104,7 @@ def print_start(wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId):
 
     Required for task-log correlation.
     """
-    now = _dates.now()
+    now = dates.now()
     marker = TaskStartMarker(
         wf_run_id=wf_run_id, task_inv_id=task_inv_id, timestamp=now
     )
@@ -119,7 +118,7 @@ def print_end(wf_run_id: WorkflowRunId, task_inv_id: TaskInvocationId):
 
     Required for task-log correlation.
     """
-    now = _dates.now()
+    now = dates.now()
     marker = TaskEndMarker(wf_run_id=wf_run_id, task_inv_id=task_inv_id, timestamp=now)
     print(marker.line)
     print(marker.line, file=sys.stderr)

--- a/src/orquestra/sdk/_base/_qe/_qe_runtime.py
+++ b/src/orquestra/sdk/_base/_qe/_qe_runtime.py
@@ -21,8 +21,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 import pydantic
 import requests
 
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _dates, serde
+from orquestra.sdk import dates, exceptions
+from orquestra.sdk._base import serde
 from orquestra.sdk._base._conversions._yaml_exporter import (
     pydantic_to_yaml,
     workflow_to_yaml,
@@ -861,7 +861,7 @@ class QERuntime(RuntimeInterface):
                 "Filtering by workspace or project is not supported on QE runtimes."
             )
 
-        now = _dates.now()
+        now = dates.now()
 
         # Grab the workflows we know about from the DB
         with WorkflowDB.open_project_db(self._project_dir) as db:

--- a/src/orquestra/sdk/_base/cli/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_repos.py
@@ -17,13 +17,12 @@ import requests
 from typing_extensions import assert_never
 
 from orquestra import sdk
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _config, _dates, _db, loader
+from orquestra.sdk import dates, exceptions
+from orquestra.sdk._base import _config, _db, loader
 from orquestra.sdk._base._driver._client import DriverClient, ExternalUriProvider
 from orquestra.sdk._base._jwt import check_jwt_without_signature_verification
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._qe import _client
-from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base.abc import ArtifactValue
 from orquestra.sdk.schema import _compat
 from orquestra.sdk.schema.configs import (
@@ -483,7 +482,7 @@ class SummaryRepo:
         wf_runs.sort(
             key=lambda wf_run: wf_run.status.start_time
             if wf_run.status.start_time
-            else _dates.from_unix_time(0)
+            else dates.from_unix_time(0)
         )
 
         return ui_models.WFList(wf_rows=[_ui_model_from_wf(wf) for wf in wf_runs])

--- a/src/orquestra/sdk/_base/cli/_ui/_corq_format/per_command.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_corq_format/per_command.py
@@ -9,7 +9,7 @@ from functools import singledispatch
 import pydantic
 import tabulate
 
-from orquestra.sdk._base import _dates
+from orquestra.sdk import dates
 from orquestra.sdk.schema import ir, responses, workflow_run
 
 
@@ -186,12 +186,12 @@ Workflow result {res_i}, returned from {fn_name}(), presented as
         print()
 
 
-def _format_datetime(dt: t.Optional[_dates.Instant]) -> str:
+def _format_datetime(dt: t.Optional[dates.Instant]) -> str:
     if dt is None:
         # Print empty table cell
         return ""
 
-    return _dates.isoformat(dt)
+    return dates.isoformat(dt)
 
 
 def _print_single_run(run: responses.WorkflowRun, project_dir: t.Optional[str]):

--- a/src/orquestra/sdk/_base/cli/_ui/_models.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_models.py
@@ -12,7 +12,7 @@ objects instead of date strings).
 import typing as t
 from dataclasses import dataclass
 
-from orquestra.sdk._base._dates import Instant
+from orquestra.sdk.dates import Instant
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.workflow_run import RunStatus, WorkflowRunId
 

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -18,8 +18,8 @@ from typing import Iterable, Iterator, List, Sequence
 import click
 from tabulate import tabulate
 
-from orquestra.sdk._base import _config, _dates, _env, _services, serde
-from orquestra.sdk._base._dates import Instant
+from orquestra.sdk import dates
+from orquestra.sdk._base import _env, _services, serde
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk.schema import responses
 from orquestra.sdk.schema.configs import ConfigName, RuntimeConfiguration, RuntimeName
@@ -329,7 +329,7 @@ class ConfigPresenter:
         )
 
 
-def _format_datetime(dt: t.Optional[Instant]) -> str:
+def _format_datetime(dt: t.Optional[dates.Instant]) -> str:
     return dt.astimezone().replace(tzinfo=None).ctime() if dt else ""
 
 
@@ -401,7 +401,7 @@ class PromptPresenter:
             wfs,
             key=lambda wf: wf.status.start_time
             if wf.status.start_time
-            else _dates.from_unix_time(0),
+            else dates.from_unix_time(0),
             reverse=True,
         )
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -16,12 +16,10 @@ import warnings
 from datetime import timedelta
 from pathlib import Path
 
-import pydantic
-
 from orquestra.sdk.schema.responses import WorkflowResult
 
-from .. import exceptions
-from .._base import _dates, _services, serde
+from .. import dates, exceptions
+from .._base import _services, serde
 from .._base._db import WorkflowDB
 from .._base._env import RAY_GLOBAL_WF_RUN_ID_ENV
 from .._base._logs._interfaces import LogReader
@@ -31,12 +29,10 @@ from ..schema import ir
 from ..schema.configs import RuntimeConfiguration
 from ..schema.local_database import StoredWorkflowRun
 from ..schema.workflow_run import (
-    ProjectId,
     RunStatus,
     State,
     TaskInvocationId,
     TaskRun,
-    TaskRunId,
     WorkflowRun,
     WorkflowRunId,
     WorkspaceId,
@@ -44,15 +40,15 @@ from ..schema.workflow_run import (
 from . import _client, _id_gen, _ray_logs
 from ._build_workflow import TaskResult, make_ray_dag
 from ._client import RayClient
-from ._wf_metadata import InvUserMetadata, WfUserMetadata, pydatic_to_json_dict
+from ._wf_metadata import WfUserMetadata, pydatic_to_json_dict
 
 
 def _instant_from_timestamp(
     unix_timestamp: t.Optional[float],
-) -> t.Optional[_dates.Instant]:
+) -> t.Optional[dates.Instant]:
     if unix_timestamp is None:
         return None
-    return _dates.from_unix_time(unix_timestamp)
+    return dates.from_unix_time(unix_timestamp)
 
 
 def _generate_wf_run_id(wf_def: ir.WorkflowDef):
@@ -498,7 +494,7 @@ class RayRuntime(RuntimeInterface):
         Returns:
                 A list of the workflow runs
         """
-        now = _dates.now()
+        now = dates.now()
 
         if state is not None:
             if not isinstance(state, list):

--- a/src/orquestra/sdk/dates/__init__.py
+++ b/src/orquestra/sdk/dates/__init__.py
@@ -1,0 +1,30 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+"""
+Single place to handle datetimes and timezones without shooting yourself in the
+foot.
+"""
+from ._dates import (
+    Instant,
+    from_comps,
+    from_isoformat,
+    from_unix_time,
+    isoformat,
+    local_isoformat,
+    now,
+    unix_time,
+    utc_from_comps,
+)
+
+__all__ = [
+    "Instant",
+    "from_comps",
+    "from_isoformat",
+    "from_unix_time",
+    "isoformat",
+    "local_isoformat",
+    "now",
+    "unix_time",
+    "utc_from_comps",
+]

--- a/src/orquestra/sdk/dates/_dates.py
+++ b/src/orquestra/sdk/dates/_dates.py
@@ -1,10 +1,6 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
-"""
-Single place to handle datetimes and timezones without shooting yourself in the
-foot.
-"""
 
 import typing as t
 from datetime import datetime, timedelta, timezone

--- a/src/orquestra/sdk/schema/workflow_run.py
+++ b/src/orquestra/sdk/schema/workflow_run.py
@@ -12,7 +12,7 @@ import typing as t
 
 from pydantic import BaseModel
 
-from orquestra.sdk._base._dates import Instant
+from orquestra.sdk.dates import Instant
 from orquestra.sdk.schema.ir import TaskInvocationId, WorkflowDef
 
 WorkflowRunId = str

--- a/tests/cli/test_arg_resolvers.py
+++ b/tests/cli/test_arg_resolvers.py
@@ -7,10 +7,9 @@ from unittest.mock import Mock, create_autospec
 
 import pytest
 
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _dates
+from orquestra.sdk import dates, exceptions
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
-from orquestra.sdk._base._spaces._structs import Project, ProjectRef, Workspace
+from orquestra.sdk._base._spaces._structs import Project, Workspace
 from orquestra.sdk._base.cli import _arg_resolvers, _repos
 from orquestra.sdk._base.cli._ui import _presenters, _prompts
 from orquestra.sdk.schema.configs import RuntimeConfiguration
@@ -402,7 +401,7 @@ class TestWFRunResolver:
             User didn't pass ``wf_run_id``.
             """
             # Given
-            current_time = _dates.now().astimezone()
+            current_time = dates.now().astimezone()
 
             def return_wf(id, time_delay_in_sec: int):
                 run = Mock()
@@ -498,7 +497,7 @@ class TestWFRunResolver:
             User didn't pass ``wf_run_id``.
             """
             # Given
-            current_time = _dates.now().astimezone()
+            current_time = dates.now().astimezone()
 
             def return_wf(id, time_delay_in_sec: int):
                 run = Mock()

--- a/tests/cli/test_repos.py
+++ b/tests/cli/test_repos.py
@@ -17,13 +17,12 @@ import pytest
 import requests
 
 from orquestra import sdk
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _dates, _db
+from orquestra.sdk import dates, exceptions
+from orquestra.sdk._base import _db
 from orquestra.sdk._base._config import SPECIAL_CONFIG_NAME_DICT
 from orquestra.sdk._base._driver._client import DriverClient
 from orquestra.sdk._base._logs._interfaces import WorkflowLogs
 from orquestra.sdk._base._qe._client import QEClient
-from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base._testing import _example_wfs
 from orquestra.sdk._base.cli import _repos
 from orquestra.sdk._base.cli._ui import _models as ui_models
@@ -37,8 +36,8 @@ from orquestra.sdk.schema.workflow_run import WorkflowRun as WorkflowRunModel
 from .. import reloaders
 from ..sdk.data.configs import TEST_CONFIG_JSON
 
-INSTANT_1 = _dates.from_comps(2023, 2, 24, 7, 26, 7, 704015, utc_hour_offset=1)
-INSTANT_2 = _dates.from_comps(2023, 2, 24, 7, 28, 37, 123, utc_hour_offset=1)
+INSTANT_1 = dates.from_comps(2023, 2, 24, 7, 26, 7, 704015, utc_hour_offset=1)
+INSTANT_2 = dates.from_comps(2023, 2, 24, 7, 28, 37, 123, utc_hour_offset=1)
 
 
 class TestWorkflowRunRepo:

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -11,12 +11,12 @@ import pytest
 
 from orquestra import sdk
 from orquestra.sdk._base import serde
-from orquestra.sdk._base._dates import Instant
 from orquestra.sdk._base._spaces._structs import Project, Workspace
 from orquestra.sdk._base.cli._ui import _errors
 from orquestra.sdk._base.cli._ui import _models as ui_models
 from orquestra.sdk._base.cli._ui import _presenters
 from orquestra.sdk._base.cli._ui._corq_format import per_command
+from orquestra.sdk.dates import Instant
 from orquestra.sdk.schema.configs import RuntimeConfiguration
 from orquestra.sdk.schema.ir import ArtifactFormat
 from orquestra.sdk.schema.responses import ResponseStatusCode, ServiceResponse

--- a/tests/cli/workflow/test_list.py
+++ b/tests/cli/workflow/test_list.py
@@ -9,8 +9,8 @@ from unittest.mock import Mock
 
 import pytest
 
+from orquestra.sdk import dates
 from orquestra.sdk import exceptions as exceptions
-from orquestra.sdk._base import _dates
 from orquestra.sdk._base.cli._workflow import _list
 from orquestra.sdk.schema.workflow_run import RunStatus, State
 
@@ -37,8 +37,8 @@ class TestAction:
             run.id = "fake id"
             run.status = RunStatus(
                 state=State.RUNNING,
-                start_time=_dates.from_unix_time(0),
-                end_time=_dates.from_unix_time(0),
+                start_time=dates.from_unix_time(0),
+                end_time=dates.from_unix_time(0),
             )
             run.task_runs = []
             return run

--- a/tests/runtime/corq/test_format.py
+++ b/tests/runtime/corq/test_format.py
@@ -7,8 +7,9 @@ from unittest.mock import Mock
 
 import pytest
 
-import orquestra.sdk as sdk
-from orquestra.sdk._base import _dates, _db
+from orquestra import sdk
+from orquestra.sdk import dates
+from orquestra.sdk._base import _db
 from orquestra.sdk._base.cli._ui._corq_format import per_command
 from orquestra.sdk.schema import local_database, responses, workflow_run
 
@@ -21,8 +22,8 @@ OK_META = responses.ResponseMetadata(
 
 OK_STATUS = workflow_run.RunStatus(
     state=workflow_run.State.SUCCEEDED,
-    start_time=_dates.from_isoformat("2022-07-19T09:59:03.144368+00:00"),
-    end_time=_dates.from_isoformat("2022-07-19T09:59:03.159318+00:00"),
+    start_time=dates.from_isoformat("2022-07-19T09:59:03.144368+00:00"),
+    end_time=dates.from_isoformat("2022-07-19T09:59:03.159318+00:00"),
 )
 
 

--- a/tests/runtime/qe/test_qe_date_conversion.py
+++ b/tests/runtime/qe/test_qe_date_conversion.py
@@ -3,8 +3,8 @@
 ################################################################################
 import pytest
 
-from orquestra.sdk._base._dates import Instant, utc_from_comps
 from orquestra.sdk._base._qe._qe_runtime import parse_date_or_none
+from orquestra.sdk.dates import Instant, utc_from_comps
 
 
 def test_with_none_date_str():

--- a/tests/runtime/qe/test_qe_runtime.py
+++ b/tests/runtime/qe/test_qe_runtime.py
@@ -16,8 +16,8 @@ import pytest
 import responses
 
 import orquestra.sdk as sdk
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _dates, _db, serde
+from orquestra.sdk import dates, exceptions
+from orquestra.sdk._base import _db, serde
 from orquestra.sdk._base._conversions._yaml_exporter import (
     pydantic_to_yaml,
     workflow_to_yaml,
@@ -643,8 +643,8 @@ class TestGetAvailableOutputs:
         assert result["invocation-0-task-make-greeting-message"] == expected_inv_0
 
 
-def _utc_instant(*args) -> _dates.Instant:
-    return _dates.utc_from_comps(*args)
+def _utc_instant(*args) -> dates.Instant:
+    return dates.utc_from_comps(*args)
 
 
 class TestGetWorkflowRunStatus:
@@ -1355,9 +1355,9 @@ class TestListWorkflowRuns:
         type(mock_status.status).start_time = PropertyMock(
             side_effect=[
                 None,
-                _dates.now() - datetime.timedelta(seconds=5),
-                _dates.now() - datetime.timedelta(seconds=5),
-                _dates.now() - datetime.timedelta(days=4),
+                dates.now() - datetime.timedelta(seconds=5),
+                dates.now() - datetime.timedelta(seconds=5),
+                dates.now() - datetime.timedelta(days=4),
             ]
         )
         monkeypatch.setattr(
@@ -1376,9 +1376,9 @@ class TestListWorkflowRuns:
         type(mock_status.status).start_time = PropertyMock(
             side_effect=[
                 None,
-                _dates.now() - datetime.timedelta(seconds=5),
-                _dates.now() - datetime.timedelta(seconds=5),
-                _dates.now() - datetime.timedelta(days=4),
+                dates.now() - datetime.timedelta(seconds=5),
+                dates.now() - datetime.timedelta(seconds=5),
+                dates.now() - datetime.timedelta(days=4),
             ]
         )
         monkeypatch.setattr(

--- a/tests/runtime/ray/ray_logs/test_ray_logs.py
+++ b/tests/runtime/ray/ray_logs/test_ray_logs.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import pytest
 
-from orquestra.sdk._base import _dates
+from orquestra.sdk import dates
 from orquestra.sdk._base._logs import _markers
 from orquestra.sdk._ray import _ray_logs
 
@@ -17,7 +17,7 @@ DATA_DIR = Path(__file__).parent / "data"
 TEST_RAY_TEMP = DATA_DIR / "ray_temp"
 
 
-SAMPLE_TIMESTAMP = _dates.utc_from_comps(2023, 2, 9, 11, 26, 7, 99382)
+SAMPLE_TIMESTAMP = dates.utc_from_comps(2023, 2, 9, 11, 26, 7, 99382)
 
 
 class TestIterUserLogPaths:
@@ -87,7 +87,7 @@ class TestIterTaskLogs:
     def start_marker():
         wf_run_id = "wf1"
         inv_id = "inv1"
-        timestamp = _dates.from_isoformat("2005-04-25T20:37:00+00:00")
+        timestamp = dates.from_isoformat("2005-04-25T20:37:00+00:00")
         return _markers.TaskStartMarker(wf_run_id, inv_id, timestamp)
 
     @staticmethod
@@ -95,7 +95,7 @@ class TestIterTaskLogs:
     def end_marker():
         wf_run_id = "wf1"
         inv_id = "inv1"
-        timestamp = _dates.from_isoformat("2005-04-25T20:37:01+00:00")
+        timestamp = dates.from_isoformat("2005-04-25T20:37:01+00:00")
         return _markers.TaskEndMarker(wf_run_id, inv_id, timestamp)
 
     @staticmethod
@@ -103,7 +103,7 @@ class TestIterTaskLogs:
     def start_marker2():
         wf_run_id = "wf1"
         inv_id = "inv2"
-        timestamp = _dates.from_isoformat("2005-04-25T20:38:00+00:00")
+        timestamp = dates.from_isoformat("2005-04-25T20:38:00+00:00")
         return _markers.TaskStartMarker(wf_run_id, inv_id, timestamp)
 
     @staticmethod
@@ -111,7 +111,7 @@ class TestIterTaskLogs:
     def end_marker2():
         wf_run_id = "wf1"
         inv_id = "inv2"
-        timestamp = _dates.from_isoformat("2005-04-25T20:38:01+00:00")
+        timestamp = dates.from_isoformat("2005-04-25T20:38:01+00:00")
         return _markers.TaskEndMarker(wf_run_id, inv_id, timestamp)
 
     @staticmethod

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -11,12 +11,10 @@ from unittest.mock import Mock, PropertyMock, create_autospec
 
 import pytest
 
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _dates
+from orquestra.sdk import dates, exceptions
 from orquestra.sdk._base._config import (
     LOCAL_RUNTIME_CONFIGURATION,
     RuntimeConfiguration,
-    RuntimeName,
 )
 from orquestra.sdk._base._db import WorkflowDB
 from orquestra.sdk._base._spaces._structs import ProjectRef
@@ -24,7 +22,7 @@ from orquestra.sdk._ray import _client, _dag, _ray_logs
 from orquestra.sdk.schema.local_database import StoredWorkflowRun
 from orquestra.sdk.schema.workflow_run import State
 
-TEST_TIME = _dates.now()
+TEST_TIME = dates.now()
 
 
 @pytest.fixture
@@ -343,9 +341,9 @@ class TestRayRuntime:
             type(mock_status.status).start_time = PropertyMock(
                 side_effect=[
                     None,
-                    _dates.now() - timedelta(seconds=5),
-                    _dates.now() - timedelta(seconds=5),
-                    _dates.now() - timedelta(days=4),
+                    dates.now() - timedelta(seconds=5),
+                    dates.now() - timedelta(seconds=5),
+                    dates.now() - timedelta(days=4),
                 ]
             )
             monkeypatch.setattr(
@@ -370,9 +368,9 @@ class TestRayRuntime:
             type(mock_status.status).start_time = PropertyMock(
                 side_effect=[
                     None,
-                    _dates.now() - timedelta(seconds=5),
-                    _dates.now() - timedelta(seconds=5),
-                    _dates.now() - timedelta(days=4),
+                    dates.now() - timedelta(seconds=5),
+                    dates.now() - timedelta(seconds=5),
+                    dates.now() - timedelta(days=4),
                 ]
             )
             monkeypatch.setattr(

--- a/tests/sdk/logs/test_markers.py
+++ b/tests/sdk/logs/test_markers.py
@@ -10,10 +10,10 @@ import sys
 
 import pytest
 
-from orquestra.sdk._base import _dates
+from orquestra.sdk import dates
 from orquestra.sdk._base._logs import _markers
 
-INSTANT = _dates.from_isoformat("2005-04-25T20:37:00+00:00")
+INSTANT = dates.from_isoformat("2005-04-25T20:37:00+00:00")
 
 
 class TestParseLine:

--- a/tests/sdk/test_dates.py
+++ b/tests/sdk/test_dates.py
@@ -2,7 +2,7 @@
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
 """
-Unit tests for ``orquestra.sdk._base._dates``.
+Unit tests for ``orquestra.sdk.dates``.
 """
 
 import re
@@ -10,14 +10,14 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from orquestra.sdk._base import _dates
+from orquestra.sdk import dates
 
 
 class TestNow:
     @staticmethod
     def test_is_tz_aware():
         # When
-        instant = _dates.now()
+        instant = dates.now()
 
         # Then
         assert instant.tzinfo is not None
@@ -30,7 +30,7 @@ class TestFromISOFormat:
         # Then
         with pytest.raises(ValueError):
             # When
-            _ = _dates.from_isoformat(formatted)
+            _ = dates.from_isoformat(formatted)
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -42,7 +42,7 @@ class TestFromISOFormat:
     )
     def test_has_timezone(formatted: str):
         # When
-        instant = _dates.from_isoformat(formatted)
+        instant = dates.from_isoformat(formatted)
 
         # Then
         assert instant.tzinfo is not None
@@ -56,20 +56,20 @@ class TestISOFormat:
         # Instant is supposed to represent only timezone-aware datetimes. This test case
         # deliberately uses timezone-naive object. Casting it to Instant anyway prevents
         # typechecker errors.
-        instant = _dates.Instant(dt)
+        instant = dates.Instant(dt)
 
         # Then
         with pytest.raises(ValueError):
             # When
-            _ = _dates.isoformat(instant)
+            _ = dates.isoformat(instant)
 
     @staticmethod
     def test_utc_input():
         # Given
-        instant = _dates.Instant(datetime.fromtimestamp(1687528083, timezone.utc))
+        instant = dates.Instant(datetime.fromtimestamp(1687528083, timezone.utc))
 
         # When
-        formatted = _dates.isoformat(instant)
+        formatted = dates.isoformat(instant)
 
         # Then
         assert formatted == "2023-06-23T13:48:03+00:00"
@@ -77,12 +77,12 @@ class TestISOFormat:
     @staticmethod
     def test_non_utc_input():
         # Given
-        instant = _dates.Instant(
+        instant = dates.Instant(
             datetime.fromtimestamp(1687528083, timezone(timedelta(hours=-4)))
         )
 
         # When
-        formatted = _dates.isoformat(instant)
+        formatted = dates.isoformat(instant)
 
         # Then
         assert formatted == "2023-06-23T09:48:03-04:00"
@@ -96,20 +96,20 @@ class TestLocalISOFormat:
         # Instant is supposed to represent only timezone-aware datetimes. This test case
         # deliberately uses timezone-naive object. Casting it to Instant anyway prevents
         # typechecker errors.
-        instant = _dates.Instant(dt)
+        instant = dates.Instant(dt)
 
         # Then
         with pytest.raises(ValueError):
             # When
-            _ = _dates.local_isoformat(instant)
+            _ = dates.local_isoformat(instant)
 
     @staticmethod
     def test_utc_input():
         # Given
-        instant = _dates.Instant(datetime.fromtimestamp(1687528083, timezone.utc))
+        instant = dates.Instant(datetime.fromtimestamp(1687528083, timezone.utc))
 
         # When
-        formatted = _dates.local_isoformat(instant)
+        formatted = dates.local_isoformat(instant)
 
         # Then
         # The output depends on the local time zone where the tests are run. We can work
@@ -119,12 +119,12 @@ class TestLocalISOFormat:
     @staticmethod
     def test_non_utc_input():
         # Given
-        instant = _dates.Instant(
+        instant = dates.Instant(
             datetime.fromtimestamp(1687528083, timezone(timedelta(hours=-4)))
         )
 
         # When
-        formatted = _dates.local_isoformat(instant)
+        formatted = dates.local_isoformat(instant)
 
         # Then
         # The output depends on the local time zone where the tests are run. We can work
@@ -140,19 +140,19 @@ class TestUnixTime:
         # Instant is supposed to represent only timezone-aware datetimes. This test case
         # deliberately uses timezone-naive object. Casting it to Instant anyway prevents
         # typechecker errors.
-        instant = _dates.Instant(dt)
+        instant = dates.Instant(dt)
 
         # Then
         with pytest.raises(ValueError):
             # When
-            _ = _dates.unix_time(instant)
+            _ = dates.unix_time(instant)
 
 
 class TestFromUnixTime:
     @staticmethod
     def test_has_timezone():
         # When
-        instant = _dates.from_unix_time(1687528083)
+        instant = dates.from_unix_time(1687528083)
 
         # Then
         assert instant.tzinfo is not None
@@ -161,10 +161,10 @@ class TestFromUnixTime:
     def test_roundtrip():
         # Given
         ts1 = 1687528083
-        instant = _dates.from_unix_time(ts1)
+        instant = dates.from_unix_time(ts1)
 
         # When
-        ts2 = _dates.unix_time(instant)
+        ts2 = dates.unix_time(instant)
 
         # Then
         assert ts2 == ts1
@@ -197,8 +197,8 @@ class TestFromComps:
     )
     def test_against_isoformat(kwargs, expected):
         # When
-        instant = _dates.from_comps(**kwargs)
-        formatted = _dates.isoformat(instant)
+        instant = dates.from_comps(**kwargs)
+        formatted = dates.isoformat(instant)
 
         # Then
         assert formatted == expected
@@ -230,8 +230,8 @@ class TestUTCFromComps:
     )
     def test_against_isoformat(kwargs, expected):
         # When
-        instant = _dates.utc_from_comps(**kwargs)
-        formatted = _dates.isoformat(instant)
+        instant = dates.utc_from_comps(**kwargs)
+        formatted = dates.isoformat(instant)
 
         # Then
         assert formatted == expected

--- a/tests/sdk/test_in_process_runtime.py
+++ b/tests/sdk/test_in_process_runtime.py
@@ -14,8 +14,8 @@ from unittest.mock import create_autospec
 import pytest
 
 from orquestra import sdk
-from orquestra.sdk import exceptions
-from orquestra.sdk._base import _dates, serde
+from orquestra.sdk import dates, exceptions
+from orquestra.sdk._base import serde
 from orquestra.sdk._base._in_process_runtime import InProcessRuntime
 from orquestra.sdk._base._spaces._structs import ProjectRef
 from orquestra.sdk._base._testing._example_wfs import (
@@ -234,7 +234,7 @@ class TestListWorkflowRuns:
         # Given
         run_id = runtime.create_workflow_run(wf_def, None)
         _ = runtime.create_workflow_run(wf_def, None)
-        runtime._start_time_store[run_id] = _dates.now() - timedelta(days=1)
+        runtime._start_time_store[run_id] = dates.now() - timedelta(days=1)
 
         # When
         wf_runs = runtime.list_workflow_runs(max_age=timedelta(minutes=1))


### PR DESCRIPTION
# The problem

`orquestra.sdk.schema.workflow_run.WorkflowRun` contained fields of type `Instant`. If a user manipulates `WorkflowRun` objects, they're likely to get into typecheck errors, because they need to work on `Instant` objects. However, `Instant` wasn't exposed in the public API, so the user would either have to:
1. Ignore the type checker error.
2. Import `Instant` from a private module, risking unwarranted breakage.

# This PR's solution

Exposes `dates` in the public API.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
