### PR TITLE
docs: fix typo in resource management - 10k is not 10^7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,14 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
-* `orq wf *` and `orq task *` commands (other than `orq wf submit`) wont prompt for project parameter anymore, as it was ignored anyway 
+* `orq wf *` and `orq task *` commands (other than `orq wf submit`) won't prompt for project parameter anymore, as it was ignored anyway
 
 🥷 *Internal*
 
 📃 *Docs*
 * Corrected unclear language in `Secrets` docs.
 * Corrected unclear language in the quickstart guide.
+* Fixed resource management doc incorrectly stating that 10k == 10^7.
 
 ## v0.54.0
 

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -28,7 +28,9 @@ Required hardware resources are configured on a per-task basis by setting the ``
 * ``disk``: disk space (bytes).
 * ``gpu``: whether access to a gpu unit is required (``1`` if a GPU is required, ``0`` otherwise).
 
-Amounts of CPU and memory resources are specified by a string comprising a floating point value, and, optionally, a modifier to the base unit ('byte' in the case of ``memory`` and ``disk`` requests, 'cores' in the case of ``cpu`` requests). The modifier can be a SI (metric), or IEC (binary) multiplier as detailed in the table below. So ``disk="10k"`` will be interpreted as '10 kilobytes', while ``cpu="10k"`` would request 10^7 cores.
+Amounts of CPU and memory resources are specified by a string comprising a floating point value, and, optionally, a modifier to the base unit ('byte' in the case of ``memory`` and ``disk`` requests, 'cores' in the case of ``cpu`` requests).
+The modifier can be a SI (metric), or IEC (binary) multiplier as detailed in the table below.
+So ``disk="10k"`` will be interpreted as '10 kilobytes', while ``cpu="10k"`` would request 10^4 cores.
 
 .. table:: Unit multipliers
     :widths: auto

--- a/docs/guides/resource-management.rst
+++ b/docs/guides/resource-management.rst
@@ -29,7 +29,7 @@ Required hardware resources are configured on a per-task basis by setting the ``
 * ``gpu``: whether access to a gpu unit is required (``1`` if a GPU is required, ``0`` otherwise).
 
 Amounts of CPU and memory resources are specified by a string comprising a floating point value, and, optionally, a modifier to the base unit ('byte' in the case of ``memory`` and ``disk`` requests, 'cores' in the case of ``cpu`` requests).
-The modifier can be a SI (metric), or IEC (binary) multiplier as detailed in the table below.
+The modifier can be an SI (metric), or IEC (binary) multiplier as detailed in the table below.
 So ``disk="10k"`` will be interpreted as '10 kilobytes', while ``cpu="10k"`` would request 10^4 cores.
 
 .. table:: Unit multipliers


### PR DESCRIPTION
[ORQSDK-877]

# The problem

The example given in the resource management doc incorrectly states that 10k is equal to 10^7.

# This PR's solution

Corrects 10^7 to 10^4.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


[ORQSDK-877]: https://zapatacomputing.atlassian.net/browse/ORQSDK-877?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ