### PR TITLE
int: prototype makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,17 @@
 ################################################################################
-# © Copyright 2021-2022 Zapata Computing Inc.
+# © Copyright 2021-2023 Zapata Computing Inc.
 ################################################################################
-include subtrees/z_quantum_actions/Makefile
 
 # We need to override test commands in 'make test' and 'make coverage' to
 # specify PYTHONPATH & install required deps. This is needed to test scripts in
 # "./bin".
+
+# Use just "python" as the interpreter for all make tasks. It will use your
+# virtual environment if you activate it before running make. You can override
+# the interpreter path like:
+# make test PYTHON=/tmp/other/python/version
+PYTHON="python"
+
 
 # (override)
 test:
@@ -15,6 +21,10 @@ test:
 		--durations=10 \
 		docs/examples/tests \
 		tests
+
+
+# Min code-test coverage measured for the whole project required for CI checks to pass.
+MIN_COVERAGE=75
 
 
 # Option explanation:

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,6 @@
 # © Copyright 2021-2023 Zapata Computing Inc.
 ################################################################################
 
-# We need to override test commands in 'make test' and 'make coverage' to
-# specify PYTHONPATH & install required deps. This is needed to test scripts in
-# "./bin".
-
 # Use just "python" as the interpreter for all make tasks. It will use your
 # virtual environment if you activate it before running make. You can override
 # the interpreter path like:
@@ -13,7 +9,17 @@
 PYTHON="python"
 
 
-# (override)
+clean:
+	find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
+	find . -type d -name __pycache__ -exec rm -r {} \+
+	find . -type d -name '*.egg-info' -exec rm -rf {} +
+	find . -type d -name .mypy_cache -exec rm -r {} \+
+	rm -rf .pytest_cache;
+	rm -rf tests/.pytest_cache;
+	rm -rf dist build
+	rm -f .coverage*
+
+
 test:
 	PYTHONPATH="." $(PYTHON) -m pytest \
 		--ignore=tests/runtime/performance \
@@ -33,8 +39,6 @@ MIN_COVERAGE=75
 #    tools like 'python -m coverage report'
 # - '--cov-report xml' - in addition, generate an XML report and store it in
 #    coverage.xml file. It's required to upload stats to codecov.io.
-#
-# (override)
 coverage:
 	PYTHONPATH="." $(PYTHON) -m pytest \
 		--cov=src \
@@ -50,8 +54,6 @@ coverage:
 
 # Reads the code coverage stats from '.coverage' file and prints a textual,
 # human-readable report to stdout.
-#
-# (override)
 show-coverage-text-report:
 	$(PYTHON) -m coverage report --show-missing
 
@@ -70,61 +72,43 @@ user-typing:
 	$(PYTHON) -m pytest tests/sdk/typing
 
 
-# (override)
 github_actions:
 	$(PYTHON) -m pip install --upgrade pip
 	$(PYTHON) -m pip install -e '.[dev]'
 
 # Install deps required to build wheel. Used for release automation. See also:
 # https://github.com/zapatacomputing/cicd-actions/blob/67dd6765157e0baefee0dc874e0f46ccd2075657/.github/workflows/py-wheel-build-and-push.yml#L26
-#
-# (override)
 build-system-deps:
 	$(PYTHON) -m pip install wheel
 
 
-# The maketargets for codestyle we inherit from the subtree run "clean" each
-# time. This is bad for local development, because it breaks the editable
-# installations, and invalidates cache, so mypy takes a very long time to run.
-# The temporary fix is to override these targets here, and eventually propagate
-# it to the subtree repo.
-
-# (override)
 flake8:
 	$(PYTHON) -m flake8 --ignore=E203,E266,W503 --max-line-length=88 src tests docs/examples
 
-# (override)
 black:
 	$(PYTHON) -m black --check src tests docs/examples
 
-# (override)
 isort:
 	$(PYTHON) -m isort --check src tests docs/examples
 
-# For mypy we additionally need to exclude one of the testing directories.
-# (override)
 mypy:
 	$(PYTHON) -m mypy src tests
 
 
 # Type check the project. Alternative to mypy. We'll eventually make it
 # required but we need to gradually improve ourcodebase.
-# (no override)
 .PHONY:
 pyright:
 	$(PYTHON) -m pyright src tests
 
-# (override)
 style: flake8 black isort mypy
 	@echo This project passes style!
 
 
-# (no override)
 style-fix:
 	black src tests docs/examples
 	isort --profile=black src tests docs/examples
 
-# (no override)
 # Run tests, but discard the ones that exceptionally slow to run locally.
 test-fast:
 	PYTHONPATH="." $(PYTHON) -m pytest \

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ coverage:
 # Reads the code coverage stats from '.coverage' file and prints a textual,
 # human-readable report to stdout.
 #
-# (no override)
+# (override)
 show-coverage-text-report:
 	$(PYTHON) -m coverage report --show-missing
 

--- a/subtrees/z_quantum_actions/Makefile
+++ b/subtrees/z_quantum_actions/Makefile
@@ -35,6 +35,7 @@ $(info Python Modules Covered: $(PYTHON_MOD))
 $(info -------------------------------------------------------------------------------)
 endif
 
+# unused
 # Clean out all Pythonic cruft
 clean-default:
 	@find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
@@ -47,10 +48,12 @@ clean-default:
 	@rm -f .coverage*
 	@echo Finished cleaning out pythonic cruft...
 
+# unused
 install-default: clean
 	$(PYTHON) -m pip install --upgrade pip && \
 		$(PYTHON) -m pip install .
 
+# unused
 dev-default: clean
 	$(PYTHON) -m pip install -e .[dev]
 
@@ -63,25 +66,33 @@ dev-default: clean
 # This make task is used to create new virtual environment so we want to use
 # `python3` here as it's more explicit, because $(PYTHON) would evaluate to
 # something else after executing this task, which might be confusing.
+
+# overridden
 github_actions-default:
 	${PYTHON} -m pip install --upgrade pip
 	${PYTHON} -m pip install -e '.[dev]'
 
 # flake8p is a wrapper library that runs flake8 from config in pyproject.toml
 # we can now use it instead of flake8 to lint the code
+
+# overridden
 flake8p-default: clean
 	$(PYTHON) -m flake8p --ignore=E203,E266,F401,W503 --max-line-length=88 src tests
 
+# overridden
 mypy-default: clean
 	@echo scanning files with mypy: Please be patient....
 	$(PYTHON) -m mypy src tests
 
+# overridden
 black-default: clean
 	$(PYTHON) -m black --check src tests
 
+# overridden
 isort-default: clean
 	$(PYTHON) -m isort --check src tests
 
+# overridden
 test-default:
 	$(PYTHON) -m pytest tests
 
@@ -90,6 +101,8 @@ test-default:
 # - '--cov=src' - turn on measuring code coverage. It outputs the results in a
 #    '.coverage' binary file. It's passed to other commands like
 #    'python -m coverage report'
+
+# overridden
 coverage-default:
 	$(PYTHON) -m pytest \
 		--cov=src \
@@ -100,22 +113,29 @@ coverage-default:
 
 # Reads the code coverage stats from '.coverage' file and prints a textual,
 # human-readable report to stdout.
+
+# overridden
 show-coverage-text-report-default:
 	$(PYTHON) -m coverage report --show-missing
 
 
+# overridden
 style-default: flake8p mypy black isort
 	@echo This project passes style!
 
+# unused
 muster-default: style coverage
 	@echo This project passes muster!
 
+# overridden
 build-system-deps-default:
 	:
 
 # Gets the next version of an installed package
 # Note: on CI we only run this step, this means we use the github_actions target as a dependency.
 # Because of this, we don't update the $(PYTHON) variable and have to manually build the path to our venv Python.
+
+# unused
 get-next-version-default: github_actions
 	$(PYTHON) subtrees/z_quantum_actions/bin/get_next_version.py $(PACKAGE_NAME)
 

--- a/subtrees/z_quantum_actions/Makefile
+++ b/subtrees/z_quantum_actions/Makefile
@@ -35,7 +35,7 @@ $(info Python Modules Covered: $(PYTHON_MOD))
 $(info -------------------------------------------------------------------------------)
 endif
 
-# unused
+# overridden
 # Clean out all Pythonic cruft
 clean-default:
 	@find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;

--- a/subtrees/z_quantum_actions/Makefile
+++ b/subtrees/z_quantum_actions/Makefile
@@ -35,7 +35,6 @@ $(info Python Modules Covered: $(PYTHON_MOD))
 $(info -------------------------------------------------------------------------------)
 endif
 
-# overridden
 # Clean out all Pythonic cruft
 clean-default:
 	@find . -regex '^.*\(__pycache__\|\.py[co]\)$$' -delete;
@@ -48,12 +47,10 @@ clean-default:
 	@rm -f .coverage*
 	@echo Finished cleaning out pythonic cruft...
 
-# unused
 install-default: clean
 	$(PYTHON) -m pip install --upgrade pip && \
 		$(PYTHON) -m pip install .
 
-# unused
 dev-default: clean
 	$(PYTHON) -m pip install -e .[dev]
 
@@ -66,33 +63,25 @@ dev-default: clean
 # This make task is used to create new virtual environment so we want to use
 # `python3` here as it's more explicit, because $(PYTHON) would evaluate to
 # something else after executing this task, which might be confusing.
-
-# overridden
 github_actions-default:
 	${PYTHON} -m pip install --upgrade pip
 	${PYTHON} -m pip install -e '.[dev]'
 
 # flake8p is a wrapper library that runs flake8 from config in pyproject.toml
 # we can now use it instead of flake8 to lint the code
-
-# overridden
 flake8p-default: clean
 	$(PYTHON) -m flake8p --ignore=E203,E266,F401,W503 --max-line-length=88 src tests
 
-# overridden
 mypy-default: clean
 	@echo scanning files with mypy: Please be patient....
 	$(PYTHON) -m mypy src tests
 
-# overridden
 black-default: clean
 	$(PYTHON) -m black --check src tests
 
-# overridden
 isort-default: clean
 	$(PYTHON) -m isort --check src tests
 
-# overridden
 test-default:
 	$(PYTHON) -m pytest tests
 
@@ -101,8 +90,6 @@ test-default:
 # - '--cov=src' - turn on measuring code coverage. It outputs the results in a
 #    '.coverage' binary file. It's passed to other commands like
 #    'python -m coverage report'
-
-# overridden
 coverage-default:
 	$(PYTHON) -m pytest \
 		--cov=src \
@@ -113,29 +100,22 @@ coverage-default:
 
 # Reads the code coverage stats from '.coverage' file and prints a textual,
 # human-readable report to stdout.
-
-# overridden
 show-coverage-text-report-default:
 	$(PYTHON) -m coverage report --show-missing
 
 
-# overridden
 style-default: flake8p mypy black isort
 	@echo This project passes style!
 
-# unused
 muster-default: style coverage
 	@echo This project passes muster!
 
-# overridden
 build-system-deps-default:
 	:
 
 # Gets the next version of an installed package
 # Note: on CI we only run this step, this means we use the github_actions target as a dependency.
 # Because of this, we don't update the $(PYTHON) variable and have to manually build the path to our venv Python.
-
-# unused
 get-next-version-default: github_actions
 	$(PYTHON) subtrees/z_quantum_actions/bin/get_next_version.py $(PACKAGE_NAME)
 


### PR DESCRIPTION
# The problem

Our nested makefile with z-quantum-actions subtree is outdated and needs an overhaul. The original idea [described on Jira](https://zapatacomputing.atlassian.net/browse/ORQSDK-456) was to replace the subtree with a makefile fetched from another source.

Meanwhile, it doesn't make a lot of sense either. The makefile in this repo overrides all targets anyway (the only exception: `make clean`).

# This PR's solution

POC of an alternative solution, other than the one originally specified in the ticket.

* Removes the original makefile inheritance.
* Adds missing make variables.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
