### PR TITLE
internal: Print coverage only on matrix jobs with print_coverage set

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.8", "3.9"]
+        # Extend the matrix with a job that prints coverage.
+        # Because { os: "ubuntu-latest", python: "3.9" } is already in the matrix,
+        # print_coverage: true is added to that job.
         include:
           - os: "ubuntu-latest"
             python: "3.9"
@@ -59,6 +62,8 @@ jobs:
         run: make coverage
 
       - name: Comment with code coverage
+        # Conditionally run this step to prevent multiple comments
+        # Occasionally, multiple jobs could post at the same time.
         if: matrix.print_coverage
         uses: zapatacomputing/command-pr-comment@baca4fb9246eaaee3e47f35f296764acc394fae7
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,6 +28,10 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "windows-latest"]
         python: ["3.8", "3.9"]
+        include:
+          - os: "ubuntu-latest"
+            python: "3.9"
+            print_coverage: true
 
     timeout-minutes: 25
 
@@ -55,6 +59,7 @@ jobs:
         run: make coverage
 
       - name: Comment with code coverage
+        if: matrix.print_coverage
         uses: zapatacomputing/command-pr-comment@baca4fb9246eaaee3e47f35f296764acc394fae7
         with:
           command: make github-actions-coverage-report


### PR DESCRIPTION
# The problem

Our code coverage action could post twice, due to a race condition when two jobs completed at the same time.

# This PR's solution

Added an extra item to the matrix that means coverage printing only runs on the `{ os: "ubuntu-latest", python: "3.9" }` job.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
