### PR TITLE
docs: Link Windows installation

### DIFF
--- a/docs/tutorials/installing-windows.rst
+++ b/docs/tutorials/installing-windows.rst
@@ -3,8 +3,7 @@ Installing on Windows
 =====================
 
 Installing developer packages on Windows can be a challenge.
-This tutorial is to assist anyone who wants to use the Workflow SDK
-natively on Windows.
+This tutorial is to assist anyone who wants to use the Workflow SDK natively on Windows.
 
 Prerequisites
 =============

--- a/docs/tutorials/jupyter-sdk.rst
+++ b/docs/tutorials/jupyter-sdk.rst
@@ -7,7 +7,7 @@ The Orquestra Workflow SDK can be used in Jupyter Notebooks!
 Prerequisites
 =============
 
-#. You've :doc:`installed Orquestra Workflow SDK<installing-macos-linux>`.
+#. You've installed Orquestra Workflow SDK (:doc:`macOS, Linux<installing-macos-linux>`, :doc:`Windows<installing-windows>`).
 
 Setup
 =====

--- a/docs/tutorials/parametrized-workflows.rst
+++ b/docs/tutorials/parametrized-workflows.rst
@@ -8,7 +8,7 @@ Examples given in this tutorial will run those workflows in a local Ray instance
 Prerequisites
 =============
 
-#. You've :doc:`installed Orquestra Workflow SDK<installing-macos-linux>`.
+#. You've installed Orquestra Workflow SDK (:doc:`macOS, Linux<installing-macos-linux>`, :doc:`Windows<installing-windows>`).
 #. You've :doc:`started Ray<ray>`.
 
 

--- a/docs/tutorials/quickstart.rst
+++ b/docs/tutorials/quickstart.rst
@@ -3,7 +3,12 @@ Quickstart
 ==========
 
 This example presents the shortest possible path to running a workflow with Orquestra from a Python script.
-It assumes you've :doc:`installed Orquestra Workflow SDK <installing-macos-linux>`.
+
+Prerequisites
+=============
+
+#. You've installed Orquestra Workflow SDK (:doc:`macOS, Linux<installing-macos-linux>`, :doc:`Windows<installing-windows>`).
+
 
 Define a task and a workflow
 ============================

--- a/docs/tutorials/ray.rst
+++ b/docs/tutorials/ray.rst
@@ -8,7 +8,7 @@ Ray executes your tasks in parallel!
 Prerequisites
 =============
 
-#. You've :doc:`installed Orquestra Workflow SDK<installing-macos-linux>`.
+#. You've installed Orquestra Workflow SDK (:doc:`macOS, Linux<installing-macos-linux>`, :doc:`Windows<installing-windows>`).
 #. You've :doc:`defined a task and a workflow<quickstart>` in a ``workflow_defs.py`` file.
 
 

--- a/docs/tutorials/remote.rst
+++ b/docs/tutorials/remote.rst
@@ -6,7 +6,7 @@ To access more compute power - you can submit your workflow to a remote runtime.
 Prerequisites
 =============
 
-#. You've :doc:`installed Orquestra Workflow SDK<installing-macos-linux>`.
+#. You've installed Orquestra Workflow SDK (:doc:`macOS, Linux<installing-macos-linux>`, :doc:`Windows<installing-windows>`).
 #. You have access to remote Orquestra cluster. Specifically you will require:
     * The email address and password for your Orquestra Account.
     * The URL of your Orquestra Cluster

--- a/docs/tutorials/secrets.rst
+++ b/docs/tutorials/secrets.rst
@@ -18,7 +18,7 @@ This is especially important when sending workflows for remote runs.
 Prerequisites
 =============
 
-#. You've :doc:`installed Orquestra Workflow SDK<installing-macos-linux>`.
+#. You've installed Orquestra Workflow SDK (:doc:`macOS, Linux<installing-macos-linux>`, :doc:`Windows<installing-windows>`).
 #. You're familiar with :doc:`running workflows remotely<remote>`.
 
 Accessing Secrets From Local Machine


### PR DESCRIPTION
# The problem

Our tutorials have pre-requisites. One pre-requisite is having the Orquestra Workflow SDK installed. The installation on UNIX-like systems and Windows differs. We only mentioned the first category in pre-requisites.

# This PR's solution

Mentions Windows alongside macOS or Linux.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
