### PR TITLE
ci: Lint changelog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,6 @@ github_actions:
 build-system-deps:
 	$(PYTHON) -m pip install wheel
 
-
 flake8:
 	$(PYTHON) -m flake8 --ignore=E203,E266,W503 --max-line-length=88 src tests docs/examples
 
@@ -90,6 +89,9 @@ black:
 
 isort:
 	$(PYTHON) -m isort --check src tests docs/examples
+
+pymarkdown:
+	$(PYTHON) -m pymarkdown scan CHANGELOG.md
 
 mypy:
 	$(PYTHON) -m mypy src tests
@@ -101,7 +103,7 @@ mypy:
 pyright:
 	$(PYTHON) -m pyright src tests
 
-style: flake8 black isort mypy
+style: pymarkdown flake8 black isort mypy
 	@echo This project passes style!
 
 

--- a/Makefile
+++ b/Makefile
@@ -78,27 +78,27 @@ github_actions:
 
 # Install deps required to build wheel. Used for release automation. See also:
 # https://github.com/zapatacomputing/cicd-actions/blob/67dd6765157e0baefee0dc874e0f46ccd2075657/.github/workflows/py-wheel-build-and-push.yml#L26
-.PHONY:
+.PHONY: build-system-deps
 build-system-deps:
 	$(PYTHON) -m pip install wheel
 
-.PHONY:
+.PHONY: flake8
 flake8:
 	$(PYTHON) -m flake8 --ignore=E203,E266,W503 --max-line-length=88 src tests docs/examples
 
-.PHONY:
+.PHONY: black
 black:
 	$(PYTHON) -m black --check src tests docs/examples
 
-.PHONY:
+.PHONY: isort
 isort:
 	$(PYTHON) -m isort --check src tests docs/examples
 
-.PHONY:
+.PHONY: pymarkdown
 pymarkdown:
 	$(PYTHON) -m pymarkdown scan CHANGELOG.md
 
-.PHONY:
+.PHONY: mypy
 mypy:
 	$(PYTHON) -m mypy src tests
 

--- a/Makefile
+++ b/Makefile
@@ -78,21 +78,27 @@ github_actions:
 
 # Install deps required to build wheel. Used for release automation. See also:
 # https://github.com/zapatacomputing/cicd-actions/blob/67dd6765157e0baefee0dc874e0f46ccd2075657/.github/workflows/py-wheel-build-and-push.yml#L26
+.PHONY:
 build-system-deps:
 	$(PYTHON) -m pip install wheel
 
+.PHONY:
 flake8:
 	$(PYTHON) -m flake8 --ignore=E203,E266,W503 --max-line-length=88 src tests docs/examples
 
+.PHONY:
 black:
 	$(PYTHON) -m black --check src tests docs/examples
 
+.PHONY:
 isort:
 	$(PYTHON) -m isort --check src tests docs/examples
 
+.PHONY:
 pymarkdown:
 	$(PYTHON) -m pymarkdown scan CHANGELOG.md
 
+.PHONY:
 mypy:
 	$(PYTHON) -m mypy src tests
 
@@ -103,10 +109,17 @@ mypy:
 pyright:
 	$(PYTHON) -m pyright src tests
 
-style: pymarkdown flake8 black isort mypy
+.PHONY:
+style:
+	@$(MAKE) pymarkdown
+	@$(MAKE) flake8
+	@$(MAKE) black
+	@$(MAKE) isort
+	@$(MAKE) mypy
 	@echo This project passes style!
 
 
+.PHONY:
 style-fix:
 	black src tests docs/examples
 	isort --profile=black src tests docs/examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ target-version = "py38"
 [tool.pymarkdown]
 # Our CHANGELOG.md violates all these rules. We can remove them one-by-one when
 # we fix the formatting.
-plugins.md004.enabled = false
 plugins.md007.enabled = false
 plugins.md012.enabled = false
 plugins.md013.enabled = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,18 @@ select = [
 ]
 ignore = ["E203","E266"]
 target-version = "py38"
+
+
+[tool.pymarkdown]
+# Our CHANGELOG.md violates all these rules. We can remove them one-by-one when
+# we fix the formatting.
+plugins.md004.enabled = false
+plugins.md007.enabled = false
+plugins.md012.enabled = false
+plugins.md013.enabled = false
+plugins.md019.enabled = false
+plugins.md022.enabled = false
+plugins.md031.enabled = false
+plugins.md032.enabled = false
+plugins.md034.enabled = false
+plugins.md036.enabled = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ target-version = "py38"
 
 [tool.pymarkdown]
 # Our CHANGELOG.md violates all these rules. We can remove them one-by-one when
-# we fix the formatting.
+# we fix the formatting. Rules reference:
+# https://github.com/jackdewinter/pymarkdown/blob/main/docs/rules.md
 plugins.md007.enabled = false
 plugins.md012.enabled = false
 plugins.md013.enabled = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,6 +87,7 @@ dev =
     mypy>=0.981
     numpy
     orquestra-python-dev # Provides standardized dev requirements.
+    pymarkdownlnt # Linter for markdown files.
     pyright
     pytest-dependency
     pytest_httpserver


### PR DESCRIPTION
# The problem

We've frequently made "typos" in the `CHANGELOG.md` file. The "typos" were valid markdown but it made the overall document inconsistent. Occasionally we had to fix it. Example: https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/295.


# This PR's solution

Extends `make style` with a markdown linter pointing at `CHANGELOG.md` file. It should be captured by our codestyle PR check.

`pymarkdownlnt` comes with a bunch of enabled rules by default. Our changelog doesn't pass them, but instead of fixing it right away I ignored these rules and plan to fix the formatting in other PRs to avoid too many changes at once.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
