### PR TITLE
Feat!: ORQ_CURRENT_CONFIG as default config when using "auto" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
+
 * Allow to set default config in `ORQ_CURRENT_CONFIG` env variable which will be used locally when `auto` config is passed.
 
 🧟 *Deprecations*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
+* Allow to set default config in `ORQ_CURRENT_CONFIG` env variable which will be used locally when `auto` config is passed.
 
 🧟 *Deprecations*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 🚨 *Breaking Changes*
 
-🔥 *Features*
+* When `auto` config is passed from local machine, config set in `ORQ_CURRENT_CONFIG` env variable will be used. Using `auto` locally without that env variable set, will result in an error.
 
-* Allow to set default config in `ORQ_CURRENT_CONFIG` env variable which will be used locally when `auto` config is passed.
+🔥 *Features*
 
 🧟 *Deprecations*
 

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -138,6 +138,7 @@ class WorkflowRun:
         config: t.Union[RuntimeConfig, str],
         workspace_id: t.Optional[WorkspaceId] = None,
         project_id: t.Optional[ProjectId] = None,
+        project_dir: t.Optional[t.Union[str, Path]] = None,
     ):
         """
         Start workflow run from its IR representation
@@ -149,11 +150,12 @@ class WorkflowRun:
                 the name of a saved configuration.
             workspace_id: ID of the workspace for workflow - supported only on CE
             project_id: ID of the project for workflow - supported only on CE
-
+            project_dir: the path to the project directory. If omitted, the current
+                working directory is used.
         """
         _config = resolve_config(config)
 
-        runtime = _config._get_runtime()
+        runtime = _config._get_runtime(project_dir)
 
         assert runtime is not None
 

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -241,11 +241,14 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
     # On studio we short-circuit to use internal URIs
     if is_passport_file_available():
         return _resolve_remote_auto_config(config_name)
-
-    if CURRENT_CONFIG_ENV in os.environ:
+    elif CURRENT_CONFIG_ENV in os.environ:
         return _resolve_local_auto_config(os.environ[CURRENT_CONFIG_ENV])
-
-    return LOCAL_RUNTIME_CONFIGURATION
+    else:
+        # we are not in the cluster, and default config env was not set. Error out
+        raise exceptions.RuntimeConfigError(
+            f"Config {config_name} only works on the studio or when the "
+            f"{CURRENT_CONFIG_ENV} env variable is set."
+        )
 
 
 def _handle_config_name_special_cases(config_name: str) -> RuntimeConfiguration:

--- a/src/orquestra/sdk/_base/_config.py
+++ b/src/orquestra/sdk/_base/_config.py
@@ -246,8 +246,11 @@ def _resolve_auto_config(config_name) -> RuntimeConfiguration:
     else:
         # we are not in the cluster, and default config env was not set. Error out
         raise exceptions.RuntimeConfigError(
-            f"Config {config_name} only works on the studio or when the "
-            f"{CURRENT_CONFIG_ENV} env variable is set."
+            f"Using '{config_name}' as the config name requires that "
+            f"you're using Studio or that the '{CURRENT_CONFIG_ENV}' "
+            "environment variable is set.\n"
+            "For example, if you want to use a local Ray cluster, "
+            f"set `{CURRENT_CONFIG_ENV}=local`."
         )
 
 

--- a/src/orquestra/sdk/_base/_env.py
+++ b/src/orquestra/sdk/_base/_env.py
@@ -50,6 +50,11 @@ CURRENT_USER_ENV = "ORQ_CURRENT_USER"
 Set by Studio and CE to share current user
 """
 
+CURRENT_CONFIG_ENV = "ORQ_CURRENT_CONFIG"
+"""
+Can be set by the user to set default config when using "auto"
+"""
+
 ORQ_VERBOSE = "ORQ_VERBOSE"
 """
 If set to a truthy value, enables printing debug information when running the ``orq``

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -31,7 +31,6 @@ from orquestra.sdk.schema.workflow_run import ProjectId, WorkspaceId
 
 from .. import secrets
 from . import _api, _dsl, loader
-from ._api._config import resolve_config
 from ._ast import CallVisitor, NodeReference, NodeReferenceType, normalize_indents
 from ._dsl import (
     DataAggregation,
@@ -44,8 +43,6 @@ from ._dsl import (
     get_fn_ref,
     parse_custom_name,
 )
-from ._spaces._resolver import resolve_studio_ref
-from ._spaces._structs import ProjectRef
 
 
 # ----- Workflow exceptions  -----

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -178,29 +178,16 @@ class WorkflowDef(Generic[_R]):
             ProjectInvalidError: when only 1 out of project and workspace is passed
 
         """
-        _config = resolve_config(config)
-
-        runtime = _config._get_runtime(project_dir)
-
-        assert runtime is not None
-
-        # In close future there will be multiple ways of figuring out the
-        # appropriate runtime to use, based on `config`. Regardless of this
-        # logic, the runtime should always be resolved.
-        assert runtime is not None
-
-        _project: Optional[ProjectRef] = resolve_studio_ref(workspace_id, project_id)
-
         # The DirtyGitRepo warning can be raised here.
         wf_def_model = self.model
 
-        wf_run = _api.WorkflowRun._start(
+        return _api.WorkflowRun.start_from_ir(
             wf_def=wf_def_model,
-            runtime=runtime,
-            config=_config,
-            project=_project,
+            config=config,
+            workspace_id=workspace_id,
+            project_id=project_id,
+            project_dir=project_dir,
         )
-        return wf_run
 
     def with_resources(
         self,

--- a/tests/sdk/api/test_config.py
+++ b/tests/sdk/api/test_config.py
@@ -13,6 +13,7 @@ from unittest.mock import mock_open, patch
 
 import pytest
 
+from orquestra.sdk import exceptions
 from orquestra.sdk._base import _config
 from orquestra.sdk._base._api import _config as api_cfg
 from orquestra.sdk.exceptions import ConfigNameNotFoundError
@@ -298,41 +299,105 @@ class TestRuntimeConfiguration:
                 )
 
         class TestAutoConfig:
-            def test_on_cluster(self, monkeypatch, tmp_path):
-                token = "the best token you have ever seen"
-                pass_file = tmp_path / "pass.port"
-                pass_file.write_text(token)
-                monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
-                monkeypatch.setenv("ORQ_CURRENT_CLUSTER", "cluster.io")
+            class TestRemoteAuto:
+                def test_on_cluster(self, monkeypatch, tmp_path):
+                    token = "the best token you have ever seen"
+                    pass_file = tmp_path / "pass.port"
+                    pass_file.write_text(token)
+                    monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
+                    monkeypatch.setenv("ORQ_CURRENT_CLUSTER", "cluster.io")
 
-                cfg = api_cfg.RuntimeConfig.load(
-                    "auto",
-                )
-
-                assert cfg.token == token
-                assert cfg.uri == "https://cluster.io"
-
-            def test_no_cluster_uri(self, tmp_path, monkeypatch):
-                token = "the best token you have ever seen"
-                pass_file = tmp_path / "pass.port"
-                pass_file.write_text(token)
-                monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
-                with pytest.raises(EnvironmentError):
-                    api_cfg.RuntimeConfig.load(
+                    cfg = api_cfg.RuntimeConfig.load(
                         "auto",
                     )
 
-            def test_on_local_env(self):
-                assert api_cfg.RuntimeConfig.load("auto") == api_cfg.RuntimeConfig.load(
-                    "local"
-                )
+                    assert cfg.token == token
+                    assert cfg.uri == "https://cluster.io"
 
-            def test_no_file(self, monkeypatch):
-                monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", "non-existing-path")
-                with pytest.raises(FileNotFoundError):
-                    api_cfg.RuntimeConfig.load(
+                def test_on_cluster_with_default_config(self, monkeypatch, tmp_path):
+                    # default config does not change behaviour on cluster
+                    token = "the best token you have ever seen"
+                    pass_file = tmp_path / "pass.port"
+                    pass_file.write_text(token)
+                    monkeypatch.setenv("ORQ_CURRENT_CONFIG", "actual_name")
+                    monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
+                    monkeypatch.setenv("ORQ_CURRENT_CLUSTER", "cluster.io")
+
+                    cfg = api_cfg.RuntimeConfig.load(
                         "auto",
                     )
+
+                    assert cfg.token == token
+                    assert cfg.uri == "https://cluster.io"
+
+                def test_no_cluster_uri(self, tmp_path, monkeypatch):
+                    token = "the best token you have ever seen"
+                    pass_file = tmp_path / "pass.port"
+                    pass_file.write_text(token)
+                    monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", str(pass_file))
+                    with pytest.raises(EnvironmentError):
+                        api_cfg.RuntimeConfig.load(
+                            "auto",
+                        )
+
+                def test_no_file(self, monkeypatch):
+                    monkeypatch.setenv("ORQUESTRA_PASSPORT_FILE", "non-existing-path")
+                    with pytest.raises(FileNotFoundError):
+                        api_cfg.RuntimeConfig.load(
+                            "auto",
+                        )
+
+            class TestLocalAuto:
+                def test_on_local_env_no_default_config(self):
+                    assert api_cfg.RuntimeConfig.load(
+                        "auto"
+                    ) == api_cfg.RuntimeConfig.load("local")
+
+                def test_on_local_env_default_config(
+                    self, monkeypatch, tmp_default_config_json
+                ):
+                    # given
+                    existing_config = "actual_name"
+                    monkeypatch.setenv("ORQ_CURRENT_CONFIG", existing_config)
+
+                    # when
+                    config = api_cfg.RuntimeConfig.load("auto")
+
+                    # then
+                    assert config.name == existing_config
+                    assert config.token == "this_token_best_token"
+                    assert config.uri == "http://actual_name.domain"
+
+                def test_on_local_env_default_config_set_to_local(self, monkeypatch):
+                    # given
+                    existing_config = "local"
+                    monkeypatch.setenv("ORQ_CURRENT_CONFIG", existing_config)
+
+                    # when
+                    config = api_cfg.RuntimeConfig.load("auto")
+
+                    # then
+                    assert config == api_cfg.RuntimeConfig.load("local")
+
+                def test_on_local_env_non_existing_default_config(
+                    self, monkeypatch, tmp_default_config_json
+                ):
+                    # given
+                    existing_config = "non_existing"
+                    monkeypatch.setenv("ORQ_CURRENT_CONFIG", existing_config)
+
+                    # then
+                    with pytest.raises(exceptions.RuntimeConfigError):
+                        api_cfg.RuntimeConfig.load("auto")
+
+                def test_on_local_env_auto_default_config(self, monkeypatch):
+                    # given
+                    existing_config = "auto"
+                    monkeypatch.setenv("ORQ_CURRENT_CONFIG", existing_config)
+
+                    # then
+                    with pytest.raises(exceptions.RuntimeConfigError):
+                        api_cfg.RuntimeConfig.load("auto")
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/api/test_config.py
+++ b/tests/sdk/api/test_config.py
@@ -348,11 +348,6 @@ class TestRuntimeConfiguration:
                         )
 
             class TestLocalAuto:
-                def test_on_local_env_no_default_config(self):
-                    assert api_cfg.RuntimeConfig.load(
-                        "auto"
-                    ) == api_cfg.RuntimeConfig.load("local")
-
                 def test_on_local_env_default_config(
                     self, monkeypatch, tmp_default_config_json
                 ):
@@ -396,6 +391,10 @@ class TestRuntimeConfiguration:
                     monkeypatch.setenv("ORQ_CURRENT_CONFIG", existing_config)
 
                     # then
+                    with pytest.raises(exceptions.RuntimeConfigError):
+                        api_cfg.RuntimeConfig.load("auto")
+
+                def test_on_local_env_no_default_config(self):
                     with pytest.raises(exceptions.RuntimeConfigError):
                         api_cfg.RuntimeConfig.load("auto")
 


### PR DESCRIPTION
# The problem

Task authors like the QML team have to hardcode the config name in the task decorator, if they’re using GithubImport with private repos.
https://zapatacomputing.atlassian.net/browse/ORQSDK-942

# This PR's solution

Allow to set ORQ_CURRENT_CONFIG env variable which will be used locally when "auto" config is used.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
