### PR TITLE
chore: remove UnsavedConfigChangesError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 🥷 *Internal*
 * Reformatted docs source files to put each sentence on its own line.
+* Removed `UnsavedConfigChangesError`
 
 📃 *Docs*
 

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -67,12 +67,6 @@ class RuntimeConfigError(BaseRuntimeError):
     pass
 
 
-class UnsavedConfigChangesError(BaseRuntimeError):
-    """Raised when there are unsaved clashing changes to the token."""
-
-    pass
-
-
 class LocalConfigLoginError(BaseRuntimeError):
     """Raised when trying to log in using a config that relates to local execution."""
 


### PR DESCRIPTION
# The problem

Thanks to @SebastianMorawiec's simplification of configurations, we have an excetion, UnsavedConfigChangesError, that relates to a circumstance that can no longer occur.

# This PR's solution

Removes UnsavedConfigChangesError.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
