### PR TITLE
feat: add `orq restart` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 🔥 *Features*
 
 * Adding `dry_run` parameter to `Workflow.run()`. It allows to test resources, dependencies and infrastructure while ignoring user task code.
+* Added `orq reset` as a shortcut for `orq down`, `orq up`
 
 🧟 *Deprecations*
 

--- a/src/orquestra/sdk/_base/cli/_entry.py
+++ b/src/orquestra/sdk/_base/cli/_entry.py
@@ -407,6 +407,28 @@ def down(ray: t.Optional[bool], all: t.Optional[bool]):
 
 
 @cloup.command()
+@cloup.option_group(
+    "Services",
+    cloup.option("--ray", is_flag=True, default=None, help="Stop a Ray cluster"),
+    cloup.option("--all", is_flag=True, default=None, help="Stop all known services"),
+)
+def restart(ray: t.Optional[bool], all: t.Optional[bool]):
+    """
+    Stops and then restarts managed services required to execute workflows locally.
+
+    By default, this command only restarts the ray cluster.
+    """
+    from ._services._down import Action as DownAction
+    from ._services._up import Action as UpAction
+
+    down_action = DownAction()
+    up_action = UpAction()
+
+    down_action.on_cmd_call(manage_ray=ray, manage_all=all)
+    up_action.on_cmd_call(manage_ray=ray, manage_all=all)
+
+
+@cloup.command()
 def status():
     """
     Prints the status of known services.
@@ -424,6 +446,7 @@ dorq.section(
     up,
     down,
     status,
+    restart,
 )
 
 

--- a/tests/cli/test_entrypoint.py
+++ b/tests/cli/test_entrypoint.py
@@ -13,6 +13,7 @@ import pytest
 
 from orquestra.sdk._base.cli import _entry
 from orquestra.sdk._base.cli._login import _login
+from orquestra.sdk._base.cli._services import _down, _up
 from orquestra.sdk._base.cli._workflow import _list
 from orquestra.sdk.schema.configs import RuntimeName
 
@@ -59,6 +60,7 @@ class TestCommandTreeAssembly:
             ["up"],
             ["down"],
             ["status"],
+            ["restart"],
             ["login"],
         ],
     )
@@ -296,3 +298,46 @@ class TestVersion:
 
         captured = capsys.readouterr()
         assert captured.out.startswith("Orquestra Workflow SDK, version ")
+
+
+class TestRestart:
+    @pytest.fixture
+    def mock_up_action(self, monkeypatch: pytest.MonkeyPatch):
+        action_mock = Mock()
+        monkeypatch.setattr(_up.Action, "on_cmd_call", action_mock)
+        return action_mock
+
+    @pytest.fixture
+    def mock_down_action(self, monkeypatch: pytest.MonkeyPatch):
+        action_mock = Mock()
+        monkeypatch.setattr(_down.Action, "on_cmd_call", action_mock)
+        return action_mock
+
+    @staticmethod
+    @pytest.mark.parametrize("ray_arg, ray_value", [([], None), (["--ray"], True)])
+    @pytest.mark.parametrize("all_arg, all_value", [([], None), (["--all"], True)])
+    def test_calls_down_up(
+        entrypoint,
+        mock_up_action,
+        mock_down_action,
+        monkeypatch,
+        ray_arg,
+        ray_value,
+        all_arg,
+        all_value,
+    ):
+        # Given
+        mock_exit = Mock()
+        monkeypatch.setattr(sys, "exit", mock_exit)
+        entrypoint(["restart"] + ray_arg + all_arg)
+
+        # When
+        _entry.main()
+
+        # Then
+        mock_down_action.assert_called_once_with(
+            manage_ray=ray_value, manage_all=all_value
+        )
+        mock_up_action.assert_called_once_with(
+            manage_ray=ray_value, manage_all=all_value
+        )


### PR DESCRIPTION
# The problem

I do `orq down && orq up` pretty regularly. I would like to type between some and many fewer characters.

# This PR's solution

Adds `orq restart` as a wrapper for `down` and `up`. It takes and handles additional arguments identically to the existing `down` and `up` commands.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
