### PR TITLE
feat: Rich CLI outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 * Adding `dry_run` parameter to `Workflow.run()`. It allows to test resources, dependencies and infrastructure while ignoring user task code.
 * Added `orq reset` as a shortcut for `orq down`, `orq up`
+* New CLI output formatting for a subset of commands.
 
 🧟 *Deprecations*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     inquirer~=3.0
     tabulate
     pygments~=2.0
+    rich~=13.5
     # For automatic login
     aiohttp~=3.8
     # Decoding JWTs

--- a/src/orquestra/sdk/_base/cli/_services/_down.py
+++ b/src/orquestra/sdk/_base/cli/_services/_down.py
@@ -1,6 +1,7 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
+import subprocess
 from typing import Optional
 
 from orquestra.sdk.schema.responses import ServiceResponse
@@ -39,13 +40,40 @@ class Action:
             manage_ray=manage_ray, manage_all=manage_all
         )
 
+        success = True
+        responses = []
+
         with self._presenter.progress_spinner("Stopping"):
             for service in resolved_services:
-                service.down()
+                try:
+                    service.down()
+                    responses.append(
+                        ServiceResponse(
+                            name=service.name,
+                            is_running=service.is_running(),
+                            info=None,
+                        )
+                    )
+                except subprocess.CalledProcessError as e:
+                    success = False
+                    responses.append(
+                        ServiceResponse(
+                            name=service.name,
+                            is_running=True,
+                            info="\n".join(
+                                [
+                                    "command:",
+                                    str(e.cmd),
+                                    "stdout:",
+                                    *e.stdout.decode().splitlines(),
+                                    "stderr:",
+                                    *e.stderr.decode().splitlines(),
+                                ]
+                            ),
+                        )
+                    )
 
-        services = [
-            ServiceResponse(name=svc.name, is_running=svc.is_running(), info=None)
-            for svc in resolved_services
-        ]
-
-        self._presenter.show_services(services=services)
+        if success:
+            self._presenter.show_services(responses)
+        else:
+            self._presenter.show_failure(responses)

--- a/src/orquestra/sdk/_base/cli/_services/_down.py
+++ b/src/orquestra/sdk/_base/cli/_services/_down.py
@@ -39,10 +39,8 @@ class Action:
             manage_ray=manage_ray, manage_all=manage_all
         )
 
-        with self._presenter.show_progress(
-            resolved_services, label="Stopping"
-        ) as progress:
-            for service in progress:
+        with self._presenter.progress_spinner("Stopping"):
+            for service in resolved_services:
                 service.down()
 
         services = [

--- a/src/orquestra/sdk/_base/cli/_services/_up.py
+++ b/src/orquestra/sdk/_base/cli/_services/_up.py
@@ -43,10 +43,8 @@ class Action:
         responses = []
         success = True
 
-        with self._presenter.show_progress(
-            resolved_services, label="Starting"
-        ) as progress:
-            for service in progress:
+        with self._presenter.progress_spinner("Starting"):
+            for service in resolved_services:
                 try:
                     service.up()
 

--- a/src/orquestra/sdk/_base/cli/_task/_logs.py
+++ b/src/orquestra/sdk/_base/cli/_task/_logs.py
@@ -21,7 +21,8 @@ class Action:
 
     def __init__(
         self,
-        presenter=_presenters.WrappedCorqOutputPresenter(),
+        logs_presenter=_presenters.LogsPresenter(),
+        error_presenter=_presenters.WrappedCorqOutputPresenter(),
         dumper=_dumpers.LogsDumper(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
@@ -43,14 +44,15 @@ class Action:
         )
 
         # output
-        self._presenter = presenter
+        self._logs_presenter = logs_presenter
+        self._error_presenter = error_presenter
         self._dumper = dumper
 
     def on_cmd_call(self, *args, **kwargs):
         try:
             self._on_cmd_call_with_exceptions(*args, **kwargs)
         except Exception as e:
-            self._presenter.show_error(e)
+            self._error_presenter.show_error(e)
 
     def _on_cmd_call_with_exceptions(
         self,
@@ -85,6 +87,6 @@ class Action:
                 wf_run_id=resolved_wf_run_id,
                 dir_path=download_dir,
             )
-            self._presenter.show_dumped_wf_logs(dump_path)
+            self._logs_presenter.show_dumped_wf_logs(dump_path)
         else:
-            self._presenter.show_logs(logs)
+            self._logs_presenter.show_logs(logs)

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -12,7 +12,7 @@ import webbrowser
 from contextlib import contextmanager
 from functools import singledispatchmethod
 from pathlib import Path
-from typing import Iterable, Iterator, Optional, Sequence
+from typing import Optional, Sequence
 
 import click
 from rich.box import SIMPLE_HEAVY
@@ -24,7 +24,7 @@ from rich.spinner import Spinner
 from rich.table import Column, Table
 from tabulate import tabulate
 
-from orquestra.sdk._base import _dates, _env, _services, serde
+from orquestra.sdk._base import _dates, _env, serde
 from orquestra.sdk._base._dates import Instant
 from orquestra.sdk._base._logs._interfaces import LogOutput, WorkflowLogs
 from orquestra.sdk.schema import responses

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -42,7 +42,9 @@ class RichPresenter:
 
     @contextmanager
     def progress_spinner(self, spinner_label: str = "Loading"):
-        with Live(Spinner("dots", spinner_label), transient=True) as live:
+        with Live(
+            Spinner("dots", spinner_label), console=self._console, transient=True
+        ) as live:
             yield live
 
 

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -6,14 +6,13 @@ Utilities for presenting human-readable text output from dorq commands. These ar
 mostly adapters over the corq's formatters.
 """
 import os
-import pprint
 import sys
 import typing as t
 import webbrowser
 from contextlib import contextmanager
 from functools import singledispatchmethod
 from pathlib import Path
-from typing import Iterable, Iterator, List, Sequence
+from typing import Iterable, Iterator, Optional, Sequence
 
 import click
 from rich.box import SIMPLE_HEAVY
@@ -31,16 +30,10 @@ from orquestra.sdk._base._logs._interfaces import LogOutput, WorkflowLogs
 from orquestra.sdk.schema import responses
 from orquestra.sdk.schema.configs import ConfigName, RuntimeConfiguration, RuntimeName
 from orquestra.sdk.schema.ir import ArtifactFormat
-from orquestra.sdk.schema.workflow_run import (
-    TaskInvocationId,
-    WorkflowRun,
-    WorkflowRunId,
-    WorkflowRunOnlyID,
-)
+from orquestra.sdk.schema.workflow_run import TaskInvocationId, WorkflowRunId
 
 from . import _errors
 from . import _models as ui_models
-from ._corq_format import per_command
 
 
 class RichPresenter:

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -75,11 +75,6 @@ class LogsPresenter(RichPresenter):
             )
         return Group(*renderables)
 
-    @_rich_logs.register(list)
-    @staticmethod
-    def _(logs: list) -> RenderableType:
-        return "\n".join(logs)
-
     @_rich_logs.register(LogOutput)
     @staticmethod
     def _(logs: LogOutput) -> RenderableType:

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -204,19 +204,6 @@ class ArtifactPresenter(RichPresenter):
 
 
 class ServicePresenter(RichPresenter):
-    @contextmanager
-    def show_progress(
-        self, services: Sequence[_services.Service], *, label: str
-    ) -> Iterator[Iterable[_services.Service]]:
-        """
-        Starts a progress bar on the context enter.
-
-        Yields an iterable of services; when you iterate over it, the progress bar is
-        advanced.
-        """
-        with Live(Spinner("dots", label), transient=True):
-            yield services
-
     def show_services(self, services: Sequence[responses.ServiceResponse]):
         status_table = Table(
             Column("Service", style="bold"),

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -149,7 +149,13 @@ class WrappedCorqOutputPresenter:
         click.echo(message=message)
 
 
-class ArtifactPresenter:
+class ArtifactPresenter(RichPresenter):
+    def _values_table(self, values: t.Sequence[t.Any]) -> Table:
+        table = Table("Index", "Type", "Pretty Printed", box=SIMPLE_HEAVY)
+        for i, value in enumerate(values):
+            table.add_row(str(i), f"{type(value)}", Pretty(value))
+        return table
+
     def show_task_outputs(
         self,
         values: t.Sequence[t.Any],
@@ -162,16 +168,8 @@ class ArtifactPresenter:
         Args:
             values: plain, deserialized artifact values.
         """
-        click.echo(
-            f"In workflow {wf_run_id}, task invocation {task_inv_id} produced "
-            f"{len(values)} outputs."
-        )
-
-        for value_i, value in enumerate(values):
-            click.echo()
-            click.echo(f"Output {value_i}. Object type: {type(value)}")
-            click.echo("Pretty printed value:")
-            click.echo(pprint.pformat(value))
+        header = f"In workflow {wf_run_id}, task invocation {task_inv_id} produced {len(values)} outputs."
+        self._console.print(Group(header, self._values_table(values)))
 
     def show_workflow_outputs(
         self, values: t.Sequence[t.Any], wf_run_id: WorkflowRunId
@@ -182,13 +180,8 @@ class ArtifactPresenter:
         Args:
             values: plain, deserialized artifact values.
         """
-        click.echo(f"Workflow run {wf_run_id} has {len(values)} outputs.")
-
-        for value_i, value in enumerate(values):
-            click.echo()
-            click.echo(f"Output {value_i}. Object type: {type(value)}")
-            click.echo("Pretty printed value:")
-            click.echo(pprint.pformat(value))
+        header = f"Workflow run {wf_run_id} has {len(values)} outputs."
+        self._console.print(Group(header, self._values_table(values)))
 
     def show_dumped_artifact(self, dump_details: serde.DumpDetails):
         """
@@ -207,7 +200,9 @@ class ArtifactPresenter:
         else:
             format_name = dump_details.format.name
 
-        click.echo(f"Artifact saved at {dump_details.file_path} " f"as {format_name}.")
+        self._console.print(
+            f"Artifact saved at {dump_details.file_path} " f"as {format_name}."
+        )
 
 
 class ServicePresenter(RichPresenter):

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -346,26 +346,10 @@ def _format_tasks_succeeded(summary: ui_models.WFRunSummary) -> str:
     return f"{summary.n_tasks_succeeded} / {summary.n_task_invocations_total}"
 
 
-class WFRunPresenter:
-    def show_wf_run(self, summary: ui_models.WFRunSummary):
-        click.echo("Workflow overview")
-        click.echo(
-            tabulate(
-                [
-                    ["workflow def name", summary.wf_def_name],
-                    ["run ID", summary.wf_run_id],
-                    ["status", summary.wf_run_status.state.name],
-                    [
-                        "start time",
-                        _format_datetime(summary.wf_run_status.start_time),
-                    ],
-                    [
-                        "end time",
-                        _format_datetime(summary.wf_run_status.end_time),
-                    ],
-                    ["tasks succeeded", _format_tasks_succeeded(summary)],
-                ]
-            )
+class WFRunPresenter(RichPresenter):
+    def show_submitted_wf_run(self, wf_run_id: WorkflowRunId):
+        self._console.print(
+            f"[green]Workflow Submitted![/green] Run ID: [bold]{wf_run_id}[/bold]"
         )
         click.echo()
 

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -99,7 +99,8 @@ class LogsPresenter(RichPresenter):
         Present logs to the user.
 
         Args:
-            logs: The logs to display, this may be in a dictionary or as a plain LogOutput object
+            logs: The logs to display, this may be in a dictionary or as a plain
+                LogOutput object
             log_type: An optional name used to split multiple log types
         """
         _logs = self._rich_logs(logs)
@@ -122,7 +123,8 @@ class LogsPresenter(RichPresenter):
             log_type: additional information identify the type of logs saved.
         """
         self._console.print(
-            f"Workflow {log_type.value + ' ' if log_type else ''}logs saved at [bold]{path}[/bold]"
+            f"Workflow {log_type.value + ' ' if log_type else ''}"
+            f"logs saved at [bold]{path}[/bold]"
         )
 
 
@@ -161,7 +163,10 @@ class ArtifactPresenter(RichPresenter):
         Args:
             values: plain, deserialized artifact values.
         """
-        header = f"In workflow {wf_run_id}, task invocation {task_inv_id} produced {len(values)} outputs."
+        header = (
+            f"In workflow {wf_run_id}, task invocation {task_inv_id} "
+            f"produced {len(values)} outputs."
+        )
         self._console.print(Group(header, self._values_table(values)))
 
     def show_workflow_outputs(
@@ -334,7 +339,7 @@ class WFRunPresenter(RichPresenter):
             f"[green]Workflow Submitted![/green] Run ID: [bold]{wf_run_id}[/bold]"
         )
 
-    def get_wf_run(self, summary: ui_models.WFRunSummary, live: bool = False):
+    def get_wf_run(self, summary: ui_models.WFRunSummary):
         summary_table = Table(
             Column(style="bold", justify="right"),
             Column(),
@@ -371,11 +376,7 @@ class WFRunPresenter(RichPresenter):
             )
         title = Rule("Workflow Overview", align="left")
         task_title = Rule("Task Details", align="left")
-        renderables = [title, summary_table, task_title, task_details]
-        if live:
-            l = f"Last updated: {_dates.local_isoformat(_dates.now())}\nPress ctrl+c to exit."
-            renderables.append(l)
-        return Group(*renderables)
+        return Group(title, summary_table, task_title, task_details)
 
     def show_wf_run(self, summary: ui_models.WFRunSummary):
         self._console.print(self.get_wf_run(summary))

--- a/src/orquestra/sdk/_base/cli/_workflow/_logs.py
+++ b/src/orquestra/sdk/_base/cli/_workflow/_logs.py
@@ -23,7 +23,8 @@ class Action:
 
     def __init__(
         self,
-        presenter=_presenters.WrappedCorqOutputPresenter(),
+        logs_presenter=_presenters.LogsPresenter(),
+        error_presenter=_presenters.WrappedCorqOutputPresenter(),
         dumper=_dumpers.LogsDumper(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.WFConfigResolver] = None,
@@ -41,7 +42,8 @@ class Action:
         )
 
         # output
-        self._presenter = presenter
+        self._logs_presenter = logs_presenter
+        self._error_presenter = error_presenter
         self._dumper = dumper
 
     def on_cmd_call(
@@ -65,7 +67,7 @@ class Action:
                 other=other,
             )
         except Exception as e:
-            self._presenter.show_error(e)
+            self._error_presenter.show_error(e)
 
     def _on_cmd_call_with_exceptions(
         self,
@@ -114,6 +116,6 @@ class Action:
                     log_type=log_type,
                 )
 
-                self._presenter.show_dumped_wf_logs(dump_path, log_type=log_type)
+                self._logs_presenter.show_dumped_wf_logs(dump_path, log_type=log_type)
             else:
-                self._presenter.show_logs(log, log_type=log_type)
+                self._logs_presenter.show_logs(log, log_type=log_type)

--- a/src/orquestra/sdk/_base/cli/_workflow/_submit.py
+++ b/src/orquestra/sdk/_base/cli/_workflow/_submit.py
@@ -23,7 +23,8 @@ class Action:
     def __init__(
         self,
         prompter=_prompts.Prompter(),
-        presenter=_presenters.WrappedCorqOutputPresenter(),
+        submit_presenter=_presenters.WFRunPresenter(),
+        error_presenter=_presenters.WrappedCorqOutputPresenter(),
         wf_def_repo=_repos.WorkflowDefRepo(),
         wf_run_repo=_repos.WorkflowRunRepo(),
         config_resolver: t.Optional[_arg_resolvers.ConfigResolver] = None,
@@ -31,7 +32,8 @@ class Action:
     ):
         # text IO
         self._prompter = prompter
-        self._presenter = presenter
+        self._submit_presenter = submit_presenter
+        self._error_presenter = error_presenter
 
         # data sources
         self._wf_run_repo = wf_run_repo
@@ -57,7 +59,7 @@ class Action:
                 module, name, config, workspace_id, project_id, force
             )
         except Exception as e:
-            self._presenter.show_error(e)
+            self._error_presenter.show_error(e)
 
     def _on_cmd_call_with_exceptions(
         self,
@@ -145,4 +147,4 @@ class Action:
                 # abort
                 return
 
-        self._presenter.show_submitted_wf_run(wf_run_id)
+        self._submit_presenter.show_submitted_wf_run(wf_run_id)

--- a/tests/cli/task/test_task_logs.py
+++ b/tests/cli/task/test_task_logs.py
@@ -18,7 +18,10 @@ from orquestra.sdk._base.cli._arg_resolvers import (
 from orquestra.sdk._base.cli._dumpers import LogsDumper
 from orquestra.sdk._base.cli._repos import WorkflowRunRepo
 from orquestra.sdk._base.cli._task import _logs
-from orquestra.sdk._base.cli._ui._presenters import WrappedCorqOutputPresenter
+from orquestra.sdk._base.cli._ui._presenters import (
+    LogsPresenter,
+    WrappedCorqOutputPresenter,
+)
 
 
 class TestAction:
@@ -44,7 +47,8 @@ class TestAction:
             resolved_invocation_id = "<resolved invocation id>"
 
             # Mocks
-            presenter = create_autospec(WrappedCorqOutputPresenter)
+            logs_presenter = create_autospec(LogsPresenter)
+            error_presenter = create_autospec(WrappedCorqOutputPresenter)
 
             dumper = create_autospec(LogsDumper)
             dumped_path = "<dumped path sentinel>"
@@ -65,7 +69,8 @@ class TestAction:
             task_inv_id_resolver.resolve.return_value = resolved_invocation_id
 
             return _logs.Action(
-                presenter=presenter,
+                logs_presenter=logs_presenter,
+                error_presenter=error_presenter,
                 dumper=dumper,
                 wf_run_repo=wf_run_repo,
                 config_resolver=config_resolver,
@@ -94,7 +99,7 @@ class TestAction:
 
             # Then
             # We should pass input CLI args to config resolver.
-            action._presenter.show_error.assert_not_called()
+            action._error_presenter.show_error.assert_not_called()
 
             action._config_resolver.resolve.assert_called_with(wf_run_id, config)
 
@@ -119,7 +124,7 @@ class TestAction:
 
             # We expect printing the workflow run returned from the repo.
             logs = action._wf_run_repo.get_task_logs.return_value
-            action._presenter.show_logs.assert_called_with(logs)
+            action._logs_presenter.show_logs.assert_called_with(logs)
 
             # We don't expect any dumps.
             assert action._dumper.dump.mock_calls == []
@@ -145,7 +150,7 @@ class TestAction:
 
             # Then
             # We should pass input CLI args to config resolver.
-            action._presenter.show_error.assert_not_called()
+            action._error_presenter.show_error.assert_not_called()
             action._config_resolver.resolve.assert_called_with(wf_run_id, config)
 
             # We should pass resolved_config to run ID resolver.
@@ -168,7 +173,7 @@ class TestAction:
             )
 
             # Do not print logs to stdout
-            action._presenter.show_logs.assert_not_called()
+            action._logs_presenter.show_logs.assert_not_called()
 
             # Expect dumping logs to the FS.
             logs = action._wf_run_repo.get_task_logs.return_value
@@ -177,4 +182,4 @@ class TestAction:
             )
 
             dumped_path = action._dumper.dump.return_value
-            action._presenter.show_dumped_wf_logs.assert_called_with(dumped_path)
+            action._logs_presenter.show_dumped_wf_logs.assert_called_with(dumped_path)

--- a/tests/cli/task/test_task_logs.py
+++ b/tests/cli/task/test_task_logs.py
@@ -6,7 +6,7 @@ Unit tests for 'orq task logs' glue code.
 """
 
 from pathlib import Path
-from unittest.mock import create_autospec
+from unittest.mock import Mock, create_autospec
 
 import pytest
 
@@ -183,3 +183,30 @@ class TestAction:
 
             dumped_path = action._dumper.dump.return_value
             action._logs_presenter.show_dumped_wf_logs.assert_called_with(dumped_path)
+
+        @staticmethod
+        def test_failure(action, monkeypatch):
+            # Given
+            # CLI inputs
+            wf_run_id = "<wf run ID sentinel>"
+            config = "<config sentinel>"
+            download_dir = Path("/tmp/my/awesome/dir")
+            task_inv_id = "<my inv ID>"
+            fn_name = "<my task fn name>"
+            exception = Exception("<exception sentinel>")
+            monkeypatch.setattr(
+                action, "_on_cmd_call_with_exceptions", Mock(side_effect=exception)
+            )
+
+            # When
+            action.on_cmd_call(
+                wf_run_id=wf_run_id,
+                config=config,
+                download_dir=download_dir,
+                fn_name=fn_name,
+                task_inv_id=task_inv_id,
+            )
+
+            # Then
+            # We should pass input CLI args to config resolver.
+            action._error_presenter.show_error.assert_called_with(exception)

--- a/tests/cli/ui/data/list_wf_runs.txt
+++ b/tests/cli/ui/data/list_wf_runs.txt
@@ -1,0 +1,6 @@
+                                                                                
+  Workflow Run ID   Status          Succeeded Tasks   Start Time                
+ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
+  wf1               mocked status   x/y               Fri Feb 24 08:26:07 2023  
+  wf2               mocked status   x/y                                         
+                                                                                

--- a/tests/cli/ui/data/wf_runs/running.txt
+++ b/tests/cli/ui/data/wf_runs/running.txt
@@ -1,15 +1,16 @@
-Workflow overview
------------------  ------------------------
-workflow def name  hello_orq
-run ID             wf.1
-status             RUNNING
-start time         Fri Feb 24 08:26:07 2023
-end time
-tasks succeeded    1 / 2
------------------  ------------------------
-
-Task details
-function       invocation ID    status     start_time                end_time                  message
--------------  ---------------  ---------  ------------------------  ------------------------  ---------
-generate_data  inv-1-gen-dat    SUCCEEDED  Fri Feb 24 08:26:07 2023  Fri Feb 24 08:26:07 2023
-train_model    inv-2-tra-mod    RUNNING    Fri Feb 24 08:26:07 2023
+Workflow Overview ──────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                
+  Workflow Def Name   hello_orq                 
+             Run ID   wf.1                      
+             Status   RUNNING                   
+         Start Time   Fri Feb 24 08:26:07 2023  
+           End Time                             
+    Succeeded Tasks   1 / 2                     
+                                                
+Task Details ───────────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                                                             
+  Function        Invocation ID   Status      Start Time                 End Time                   Message  
+ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
+  generate_data   inv-1-gen-dat   SUCCEEDED   Fri Feb 24 08:26:07 2023   Fri Feb 24 08:26:07 2023            
+  train_model     inv-2-tra-mod   RUNNING     Fri Feb 24 08:26:07 2023                                       
+                                                                                                             

--- a/tests/cli/ui/data/wf_runs/waiting.txt
+++ b/tests/cli/ui/data/wf_runs/waiting.txt
@@ -1,13 +1,14 @@
-Workflow overview
------------------  ------------------------
-workflow def name  hello_orq
-run ID             wf.1
-status             WAITING
-start time         Fri Feb 24 08:26:07 2023
-end time
-tasks succeeded    0 / 21
------------------  ------------------------
-
-Task details
-function    invocation ID    status    start_time    end_time    message
-----------  ---------------  --------  ------------  ----------  ---------
+Workflow Overview ──────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                
+  Workflow Def Name   hello_orq                 
+             Run ID   wf.1                      
+             Status   WAITING                   
+         Start Time   Fri Feb 24 08:26:07 2023  
+           End Time                             
+    Succeeded Tasks   0 / 21                    
+                                                
+Task Details ───────────────────────────────────────────────────────────────────────────────────────────────────────────
+                                                                       
+  Function   Invocation ID   Status   Start Time   End Time   Message  
+ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 
+                                                                       

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -433,37 +433,58 @@ class TestArtifactPresenter:
 
 class TestServicesPresenter:
     class TestShowServices:
-        def test_running(self, capsys):
+        def test_running(self, test_console):
             # Given
             services = [ServiceResponse(name="mocked", is_running=True, info=None)]
-            presenter = _presenters.ServicePresenter()
+            presenter = _presenters.ServicePresenter(console=test_console)
             # When
             presenter.show_services(services)
             # Then
-            captured = capsys.readouterr()
-            assert "mocked  Running" in captured.out
+            assert isinstance(test_console.file, StringIO)
+            output = test_console.file.getvalue()
+            expected = "\n".join([
+                '                       ',
+                '  mocked   Running     ',
+                '                       ',
+                "",
+            ])
+            assert output == expected
 
-        def test_not_running(self, capsys):
+        def test_not_running(self, test_console):
             # Given
             services = [ServiceResponse(name="mocked", is_running=False, info=None)]
-            presenter = _presenters.ServicePresenter()
+            presenter = _presenters.ServicePresenter(console=test_console)
             # When
             presenter.show_services(services)
             # Then
-            captured = capsys.readouterr()
-            assert "mocked  Not Running" in captured.out
+            assert isinstance(test_console.file, StringIO)
+            output = test_console.file.getvalue()
+            expected = "\n".join([
+                '                           ',
+                '  mocked   Not Running     ',
+                '                           ',
+                "",
+            ])
+            assert output == expected
 
-        def test_with_info(self, capsys):
+        def test_with_info(self, test_console):
             # Given
             services = [
                 ServiceResponse(name="mocked", is_running=False, info="something")
             ]
-            presenter = _presenters.ServicePresenter()
+            presenter = _presenters.ServicePresenter(console=test_console)
             # When
             presenter.show_services(services)
             # Then
-            captured = capsys.readouterr()
-            assert "mocked  Not Running  something" in captured.out
+            assert isinstance(test_console.file, StringIO)
+            output = test_console.file.getvalue()
+            expected = "\n".join([
+                '                                    ',
+                '  mocked   Not Running   something  ',
+                '                                    ',
+                "",
+            ])
+            assert output == expected
 
     @staticmethod
     def test_show_failure(capsys, sys_exit_mock):

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -325,110 +325,112 @@ class TestWrappedCorqOutputPresenter:
 class TestArtifactPresenter:
     class TestDumpedWFResult:
         @staticmethod
-        def test_json(capsys):
+        def test_json(test_console):
             # Given
             details = serde.DumpDetails(
                 file_path=Path("tests/some-path/wf.1234_1.json"),
                 format=ArtifactFormat.JSON,
             )
-            presenter = _presenters.ArtifactPresenter()
+            presenter = _presenters.ArtifactPresenter(console=test_console)
 
             # When
             presenter.show_dumped_artifact(details)
 
             # Then
-            captured = capsys.readouterr()
+            assert isinstance(test_console.file, StringIO)
+            output = test_console.file.getvalue()
             # We can't assert on the full path because separators are
             # platform-dependent.
-            assert "Artifact saved at tests" in captured.out
-            assert "wf.1234_1.json as a text json file." in captured.out
+            assert "Artifact saved at tests" in output
+            assert "wf.1234_1.json as a text json file." in output
 
         @staticmethod
-        def test_pickle(capsys):
+        def test_pickle(test_console):
             # Given
             details = serde.DumpDetails(
                 file_path=Path("tests/some-path/wf.1234_1.pickle"),
                 format=ArtifactFormat.ENCODED_PICKLE,
             )
-            presenter = _presenters.ArtifactPresenter()
+            presenter = _presenters.ArtifactPresenter(console=test_console)
 
             # When
             presenter.show_dumped_artifact(details)
 
             # Then
-            captured = capsys.readouterr()
+            assert isinstance(test_console.file, StringIO)
+            output = test_console.file.getvalue()
             # We can't assert on the full path because separators are
             # platform-dependent.
-            assert "Artifact saved at tests" in captured.out
-            assert "wf.1234_1.pickle as a binary pickle file." in captured.out
+            assert "Artifact saved at tests" in output
+            assert "wf.1234_1.pickle as a binary pickle file." in output
 
         @staticmethod
-        def test_other_format(capsys):
+        def test_other_format(test_console):
             # Given
             details = serde.DumpDetails(
                 file_path=Path("tests/some-path/wf.1234_1.npz"),
                 format=ArtifactFormat.NUMPY_ARRAY,
             )
-            presenter = _presenters.ArtifactPresenter()
+            presenter = _presenters.ArtifactPresenter(console=test_console)
 
             # When
             presenter.show_dumped_artifact(details)
 
             # Then
-            captured = capsys.readouterr()
+            assert isinstance(test_console.file, StringIO)
+            output = test_console.file.getvalue()
             # We can't assert on the full path because separators are
             # platform-dependent.
-            assert "Artifact saved at tests" in captured.out
-            assert "wf.1234_1.npz as NUMPY_ARRAY." in captured.out
+            assert "Artifact saved at tests" in output
+            assert "wf.1234_1.npz as NUMPY_ARRAY." in output
 
     @staticmethod
-    def test_show_workflow_outputs(capsys):
+    def test_show_workflow_outputs(test_console):
         # Given
         values = [set([21, 38]), {"hello": "there"}]
         wf_run_id = "wf.1234"
-        presenter = _presenters.ArtifactPresenter()
+        presenter = _presenters.ArtifactPresenter(console=test_console)
 
         # When
         presenter.show_workflow_outputs(values, wf_run_id)
 
         # Then
-        captured = capsys.readouterr()
-        assert (
-            "Workflow run wf.1234 has 2 outputs.\n"
-            "\n"
-            "Output 0. Object type: <class 'set'>\n"
-            "Pretty printed value:\n"
-            "{21, 38}\n"
-            "\n"
-            "Output 1. Object type: <class 'dict'>\n"
-            "Pretty printed value:\n"
-            "{'hello': 'there'}\n"
-        ) == captured.out
+        assert isinstance(test_console.file, StringIO)
+        output = test_console.file.getvalue()
+        expected = "\n".join([
+            'Workflow run wf.1234 has 2 outputs.',
+            '                                               ',
+            '  Index   Type             Pretty Printed      ',
+            ' ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ',
+            "  0       <class 'set'>    {21, 38}            ",
+            "  1       <class 'dict'>   {'hello': 'there'}  ",
+            '                                               ',
+            "",])
+        assert output == expected
 
     @staticmethod
-    def test_show_task_outputs(capsys):
+    def test_show_task_outputs(test_console):
         # Given
         values = [set([21, 38]), {"hello": "there"}]
         wf_run_id = "wf.1234"
         task_inv_id = "inv6"
-        presenter = _presenters.ArtifactPresenter()
+        presenter = _presenters.ArtifactPresenter(console=test_console)
 
         # When
         presenter.show_task_outputs(values, wf_run_id, task_inv_id)
 
         # Then
-        captured = capsys.readouterr()
-        assert (
-            "In workflow wf.1234, task invocation inv6 produced 2 outputs.\n"
-            "\n"
-            "Output 0. Object type: <class 'set'>\n"
-            "Pretty printed value:\n"
-            "{21, 38}\n"
-            "\n"
-            "Output 1. Object type: <class 'dict'>\n"
-            "Pretty printed value:\n"
-            "{'hello': 'there'}\n"
-        ) == captured.out
+        assert isinstance(test_console.file, StringIO)
+        output = test_console.file.getvalue()
+        expected = "\n".join(['In workflow wf.1234, task invocation inv6 produced 2 outputs.',
+            '                                               ',
+            '  Index   Type             Pretty Printed      ',
+            ' ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ',
+            "  0       <class 'set'>    {21, 38}            ",
+            "  1       <class 'dict'>   {'hello': 'there'}  ",
+            '                                               ',
+            "",])
+        assert output == expected
 
 
 class TestServicesPresenter:

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -386,6 +386,10 @@ class TestArtifactPresenter:
             assert "wf.1234_1.npz as NUMPY_ARRAY." in output
 
     @staticmethod
+    @pytest.mark.skipif(
+        sys.platform.startswith("win32"),
+        reason="Windows uses different symbols than macOS and Linux",
+    )
     def test_show_workflow_outputs(test_console: Console):
         # Given
         values = [set([21, 38]), {"hello": "there"}]
@@ -413,6 +417,10 @@ class TestArtifactPresenter:
         assert output == expected
 
     @staticmethod
+    @pytest.mark.skipif(
+        sys.platform.startswith("win32"),
+        reason="Windows uses different symbols than macOS and Linux",
+    )
     def test_show_task_outputs(test_console: Console):
         # Given
         values = [set([21, 38]), {"hello": "there"}]
@@ -658,6 +666,10 @@ class TestWorkflowRunPresenter:
         assert output == expected
 
     @staticmethod
+    @pytest.mark.skipif(
+        sys.platform.startswith("win32"),
+        reason="Windows uses different symbols than macOS and Linux",
+    )
     @pytest.mark.parametrize(
         "summary,expected_path",
         [
@@ -734,6 +746,10 @@ class TestWorkflowRunPresenter:
         assert output == expected
 
     @staticmethod
+    @pytest.mark.skipif(
+        sys.platform.startswith("win32"),
+        reason="Windows uses different symbols than macOS and Linux",
+    )
     def test_show_wf_list(monkeypatch: pytest.MonkeyPatch, test_console: Console):
         # Given
         expected_path = DATA_DIR / "list_wf_runs.txt"

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -733,6 +733,41 @@ class TestWorkflowRunPresenter:
         expected = expected_path.read_text()
         assert output == expected
 
+    @staticmethod
+    def test_show_wf_list(monkeypatch: pytest.MonkeyPatch, test_console: Console):
+        # Given
+        expected_path = DATA_DIR / "list_wf_runs.txt"
+        summary = ui_models.WFList(
+            wf_rows=[
+                ui_models.WFList.WFRow(
+                    workflow_run_id="wf1",
+                    status="mocked status",
+                    tasks_succeeded="x/y",
+                    start_time=UTC_INSTANT,
+                ),
+                ui_models.WFList.WFRow(
+                    workflow_run_id="wf2",
+                    status="mocked status",
+                    tasks_succeeded="x/y",
+                    start_time=None,
+                ),
+            ]
+        )
+        presenter = _presenters.WFRunPresenter(console=test_console)
+        monkeypatch.setattr(
+            _presenters,
+            "_format_datetime",
+            lambda x: "Fri Feb 24 08:26:07 2023" if x else "",
+        )
+        # When
+        presenter.show_wf_list(summary)
+
+        # Then
+        assert isinstance(test_console.file, StringIO)
+        output = test_console.file.getvalue()
+        expected = expected_path.read_text()
+        assert output == expected
+
 
 class TestPromptPresenter:
     class TestWorkspacesList:

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -19,7 +19,6 @@ from orquestra.sdk._base._spaces._structs import Project, Workspace
 from orquestra.sdk._base.cli._ui import _errors
 from orquestra.sdk._base.cli._ui import _models as ui_models
 from orquestra.sdk._base.cli._ui import _presenters
-from orquestra.sdk._base.cli._ui._corq_format import per_command
 from orquestra.sdk.schema.configs import RuntimeConfiguration
 from orquestra.sdk.schema.ir import ArtifactFormat
 from orquestra.sdk.schema.responses import ResponseStatusCode, ServiceResponse
@@ -64,7 +63,7 @@ class TestLogsPresenter:
         return _inner
 
     @staticmethod
-    def test_show_logs_with_dict(test_console):
+    def test_show_logs_with_dict(test_console: Console):
         # Given
         task_invocation = "my_task_invocation"
         task_logs = LogOutput(out=["my_log"], err=[])
@@ -83,10 +82,10 @@ class TestLogsPresenter:
         assert "my_log" in output
 
     @staticmethod
-    def test_show_logs_with_logoutput(test_console):
+    def test_show_logs_with_logoutput(test_console: Console):
         # Given
         logs = LogOutput(out=["my_log"], err=[])
-        presenter = _presenters.LogsPresenter(test_console)
+        presenter = _presenters.LogsPresenter(console=test_console)
 
         # When
         presenter.show_logs(logs)
@@ -98,7 +97,7 @@ class TestLogsPresenter:
         assert "my_log" in output
 
     @staticmethod
-    def test_print_stdout_when_available(test_console):
+    def test_print_stdout_when_available(test_console: Console):
         # Given
         logs = LogOutput(out=["my_log"], err=[])
         presenter = _presenters.LogsPresenter(console=test_console)
@@ -113,7 +112,7 @@ class TestLogsPresenter:
         assert "stderr" not in output
 
     @staticmethod
-    def test_print_stderr_when_available(test_console):
+    def test_print_stderr_when_available(test_console: Console):
         # Given
         logs = LogOutput(out=[], err=["my_log"])
         presenter = _presenters.LogsPresenter(console=test_console)
@@ -128,7 +127,7 @@ class TestLogsPresenter:
         assert "stderr" in output
 
     @staticmethod
-    def test_print_both_when_available(test_console):
+    def test_print_both_when_available(test_console: Console):
         # Given
         logs = LogOutput(out=["my_log"], err=["my_log"])
         presenter = _presenters.LogsPresenter(console=test_console)
@@ -143,7 +142,7 @@ class TestLogsPresenter:
         assert "stderr" in output
 
     @staticmethod
-    def test_show_dumped_wf_logs(test_console):
+    def test_show_dumped_wf_logs(test_console: Console):
         # Given
         dummy_path: Path = Path("/my/cool/path")
         presenter = _presenters.LogsPresenter(console=test_console)
@@ -186,7 +185,7 @@ class TestLogsPresenter:
         assert rule() not in output
 
     @staticmethod
-    def test_with_logoutput_logs(test_console):
+    def test_with_logoutput_logs(test_console: Console):
         # Given
         logs = LogOutput(out=["<log line 1 sentinel>", "<log line 2 sentinel>"], err=[])
         presenter = _presenters.LogsPresenter(console=test_console)
@@ -235,7 +234,7 @@ class TestLogsPresenter:
         assert expected == output
 
     @staticmethod
-    def test_stderr_output(test_console):
+    def test_stderr_output(test_console: Console):
         # Given
         logs = LogOutput(out=[], err=["<log line 1 sentinel>", "<log line 2 sentinel>"])
         presenter = _presenters.LogsPresenter(console=test_console)
@@ -258,7 +257,7 @@ class TestLogsPresenter:
         assert output == expected
 
     @staticmethod
-    def test_both_output(test_console):
+    def test_both_output(test_console: Console):
         # Given
         logs = LogOutput(out=["<log line 1 sentinel>"], err=["<log line 2 sentinel>"])
         presenter = _presenters.LogsPresenter(console=test_console)
@@ -327,7 +326,7 @@ class TestWrappedCorqOutputPresenter:
 class TestArtifactPresenter:
     class TestDumpedWFResult:
         @staticmethod
-        def test_json(test_console):
+        def test_json(test_console: Console):
             # Given
             details = serde.DumpDetails(
                 file_path=Path("tests/some-path/wf.1234_1.json"),
@@ -347,7 +346,7 @@ class TestArtifactPresenter:
             assert "wf.1234_1.json as a text json file." in output
 
         @staticmethod
-        def test_pickle(test_console):
+        def test_pickle(test_console: Console):
             # Given
             details = serde.DumpDetails(
                 file_path=Path("tests/some-path/wf.1234_1.pickle"),
@@ -367,7 +366,7 @@ class TestArtifactPresenter:
             assert "wf.1234_1.pickle as a binary pickle file." in output
 
         @staticmethod
-        def test_other_format(test_console):
+        def test_other_format(test_console: Console):
             # Given
             details = serde.DumpDetails(
                 file_path=Path("tests/some-path/wf.1234_1.npz"),
@@ -387,7 +386,7 @@ class TestArtifactPresenter:
             assert "wf.1234_1.npz as NUMPY_ARRAY." in output
 
     @staticmethod
-    def test_show_workflow_outputs(test_console):
+    def test_show_workflow_outputs(test_console: Console):
         # Given
         values = [set([21, 38]), {"hello": "there"}]
         wf_run_id = "wf.1234"
@@ -414,7 +413,7 @@ class TestArtifactPresenter:
         assert output == expected
 
     @staticmethod
-    def test_show_task_outputs(test_console):
+    def test_show_task_outputs(test_console: Console):
         # Given
         values = [set([21, 38]), {"hello": "there"}]
         wf_run_id = "wf.1234"
@@ -444,7 +443,7 @@ class TestArtifactPresenter:
 
 class TestServicesPresenter:
     class TestShowServices:
-        def test_running(self, test_console):
+        def test_running(self, test_console: Console):
             # Given
             services = [ServiceResponse(name="mocked", is_running=True, info=None)]
             presenter = _presenters.ServicePresenter(console=test_console)
@@ -463,7 +462,7 @@ class TestServicesPresenter:
             )
             assert output == expected
 
-        def test_not_running(self, test_console):
+        def test_not_running(self, test_console: Console):
             # Given
             services = [ServiceResponse(name="mocked", is_running=False, info=None)]
             presenter = _presenters.ServicePresenter(console=test_console)
@@ -482,7 +481,7 @@ class TestServicesPresenter:
             )
             assert output == expected
 
-        def test_with_info(self, test_console):
+        def test_with_info(self, test_console: Console):
             # Given
             services = [
                 ServiceResponse(name="mocked", is_running=False, info="something")
@@ -643,7 +642,7 @@ ET_INSTANT_2 = Instant(
 
 class TestWorkflowRunPresenter:
     @staticmethod
-    def test_show_submitted_wf_run(test_console):
+    def test_show_submitted_wf_run(test_console: Console):
         # Given
         wf_run_id = "wf.1"
 

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -42,7 +42,9 @@ def sys_exit_mock(monkeypatch):
     monkeypatch.setattr(sys, "exit", exit_mock)
     return exit_mock
 
+
 CONSOLE_WIDTH = 120
+
 
 @pytest.fixture
 def test_console():
@@ -397,15 +399,18 @@ class TestArtifactPresenter:
         # Then
         assert isinstance(test_console.file, StringIO)
         output = test_console.file.getvalue()
-        expected = "\n".join([
-            'Workflow run wf.1234 has 2 outputs.',
-            '                                               ',
-            '  Index   Type             Pretty Printed      ',
-            ' ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ',
-            "  0       <class 'set'>    {21, 38}            ",
-            "  1       <class 'dict'>   {'hello': 'there'}  ",
-            '                                               ',
-            "",])
+        expected = "\n".join(
+            [
+                "Workflow run wf.1234 has 2 outputs.",
+                "                                               ",
+                "  Index   Type             Pretty Printed      ",
+                " ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ",
+                "  0       <class 'set'>    {21, 38}            ",
+                "  1       <class 'dict'>   {'hello': 'there'}  ",
+                "                                               ",
+                "",
+            ]
+        )
         assert output == expected
 
     @staticmethod
@@ -422,14 +427,18 @@ class TestArtifactPresenter:
         # Then
         assert isinstance(test_console.file, StringIO)
         output = test_console.file.getvalue()
-        expected = "\n".join(['In workflow wf.1234, task invocation inv6 produced 2 outputs.',
-            '                                               ',
-            '  Index   Type             Pretty Printed      ',
-            ' ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ',
-            "  0       <class 'set'>    {21, 38}            ",
-            "  1       <class 'dict'>   {'hello': 'there'}  ",
-            '                                               ',
-            "",])
+        expected = "\n".join(
+            [
+                "In workflow wf.1234, task invocation inv6 produced 2 outputs.",
+                "                                               ",
+                "  Index   Type             Pretty Printed      ",
+                " ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ ",
+                "  0       <class 'set'>    {21, 38}            ",
+                "  1       <class 'dict'>   {'hello': 'there'}  ",
+                "                                               ",
+                "",
+            ]
+        )
         assert output == expected
 
 
@@ -444,12 +453,14 @@ class TestServicesPresenter:
             # Then
             assert isinstance(test_console.file, StringIO)
             output = test_console.file.getvalue()
-            expected = "\n".join([
-                '                       ',
-                '  mocked   Running     ',
-                '                       ',
-                "",
-            ])
+            expected = "\n".join(
+                [
+                    "                       ",
+                    "  mocked   Running     ",
+                    "                       ",
+                    "",
+                ]
+            )
             assert output == expected
 
         def test_not_running(self, test_console):
@@ -461,12 +472,14 @@ class TestServicesPresenter:
             # Then
             assert isinstance(test_console.file, StringIO)
             output = test_console.file.getvalue()
-            expected = "\n".join([
-                '                           ',
-                '  mocked   Not Running     ',
-                '                           ',
-                "",
-            ])
+            expected = "\n".join(
+                [
+                    "                           ",
+                    "  mocked   Not Running     ",
+                    "                           ",
+                    "",
+                ]
+            )
             assert output == expected
 
         def test_with_info(self, test_console):
@@ -480,12 +493,14 @@ class TestServicesPresenter:
             # Then
             assert isinstance(test_console.file, StringIO)
             output = test_console.file.getvalue()
-            expected = "\n".join([
-                '                                    ',
-                '  mocked   Not Running   something  ',
-                '                                    ',
-                "",
-            ])
+            expected = "\n".join(
+                [
+                    "                                    ",
+                    "  mocked   Not Running   something  ",
+                    "                                    ",
+                    "",
+                ]
+            )
             assert output == expected
 
     @staticmethod

--- a/tests/cli/workflow/test_logs.py
+++ b/tests/cli/workflow/test_logs.py
@@ -260,3 +260,30 @@ class TestAction:
 
             # Do not print logs to stdout
             action._logs_presenter.show_logs.assert_not_called()
+
+        @staticmethod
+        def test_failure(action, monkeypatch):
+            # Given
+            # CLI inputs
+            wf_run_id = "<wf run ID sentinel>"
+            config = "<config sentinel>"
+            download_dir = Path("/tmp/my/awesome/dir")
+            exception = Exception("<exception sentinel>")
+            monkeypatch.setattr(
+                action, "_on_cmd_call_with_exceptions", Mock(side_effect=exception)
+            )
+
+            # When
+            action.on_cmd_call(
+                wf_run_id=wf_run_id,
+                config=config,
+                download_dir=download_dir,
+                task="<task sentinel>",
+                system="<system sentinel>",
+                env_setup="<env sentinel>",
+                other="<other sentinel>",
+            )
+
+            # Then
+            # We should pass input CLI args to config resolver.
+            action._error_presenter.show_error.assert_called_with(exception)

--- a/tests/cli/workflow/test_submit.py
+++ b/tests/cli/workflow/test_submit.py
@@ -51,7 +51,8 @@ class TestAction:
             project = "project'"
 
             prompter = create_autospec(_prompts.Prompter)
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
 
             wf_run_id = "wf.test"
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
@@ -65,7 +66,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
             )
@@ -90,7 +92,7 @@ class TestAction:
             )
 
             # We expect telling the user the wf run ID.
-            presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+            submit_presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
 
     class TestOmittingName:
         @staticmethod
@@ -109,7 +111,8 @@ class TestAction:
             prompter = create_autospec(_prompts.Prompter)
             prompter.choice.return_value = selected_name
 
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
 
             wf_run_id = "wf.test"
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
@@ -125,7 +128,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
             )
@@ -151,7 +155,7 @@ class TestAction:
             )
 
             # We expect telling the user the wf run ID.
-            presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+            submit_presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
 
         @staticmethod
         @pytest.mark.parametrize("force", [False, True])
@@ -167,8 +171,8 @@ class TestAction:
 
             prompter = create_autospec(_prompts.Prompter)
 
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
 
             wf_run_id = "wf.test"
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
@@ -184,7 +188,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
             )
@@ -210,7 +215,7 @@ class TestAction:
             )
 
             # We expect telling the user the wf run ID.
-            presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+            submit_presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
 
         @staticmethod
         @pytest.mark.parametrize("force", [False, True])
@@ -223,7 +228,8 @@ class TestAction:
             project = "project"
 
             prompter = create_autospec(_prompts.Prompter)
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
             wf_def_repo = create_autospec(_repos.WorkflowDefRepo)
             wf_def_repo.get_worklow_names.side_effect = (
@@ -232,7 +238,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
             )
@@ -252,7 +259,7 @@ class TestAction:
 
             # We expect presenting the error.
             _assert_called_with_type(
-                presenter.show_error, exceptions.NoWorkflowDefinitionsFound
+                error_presenter.show_error, exceptions.NoWorkflowDefinitionsFound
             )
 
         @staticmethod
@@ -265,7 +272,8 @@ class TestAction:
             project = "project"
 
             prompter = create_autospec(_prompts.Prompter)
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
 
             sys_path = [module, "foo", "bar"]
@@ -278,7 +286,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
             )
@@ -298,7 +307,7 @@ class TestAction:
 
             # We expect telling the user about the error.
             _assert_called_with_type(
-                presenter.show_error, exceptions.WorkflowDefinitionModuleNotFound
+                error_presenter.show_error, exceptions.WorkflowDefinitionModuleNotFound
             )
 
     class TestDirtyRepo:
@@ -322,7 +331,8 @@ class TestAction:
             # Simulate a user saying "yes"
             prompter.confirm.return_value = True
 
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
 
             wf_run_id = "wf.test"
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
@@ -345,7 +355,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
             )
@@ -363,7 +374,7 @@ class TestAction:
             prompter.confirm.assert_called()
 
             # We expect telling the user the wf run ID.
-            presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+            submit_presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
 
         @staticmethod
         def test_force():
@@ -376,7 +387,8 @@ class TestAction:
             force = True
 
             prompter = create_autospec(_prompts.Prompter)
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
 
             wf_run_id = "wf.test"
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
@@ -399,7 +411,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
             )
@@ -417,7 +430,7 @@ class TestAction:
             prompter.confirm.assert_not_called()
 
             # We expect telling the user the wf run ID.
-            presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+            submit_presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
 
     class TestProjectResolve:
         @pytest.mark.parametrize("workspace_support", [True, False])
@@ -428,7 +441,8 @@ class TestAction:
             config = "cluster_z"
 
             prompter = create_autospec(_prompts.Prompter)
-            presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
+            submit_presenter = create_autospec(_presenters.WFRunPresenter)
+            error_presenter = create_autospec(_presenters.WrappedCorqOutputPresenter)
 
             wf_run_id = "wf.test"
             wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
@@ -454,7 +468,8 @@ class TestAction:
 
             action = _submit.Action(
                 prompter=prompter,
-                presenter=presenter,
+                submit_presenter=submit_presenter,
+                error_presenter=error_presenter,
                 wf_run_repo=wf_run_repo,
                 wf_def_repo=wf_def_repo,
                 spaces_resolver=spaces_resolver,
@@ -491,4 +506,4 @@ class TestAction:
                 )
 
             # We expect telling the user the wf run ID.
-            presenter.show_submitted_wf_run.assert_called_with(wf_run_id)
+            submit_presenter.show_submitted_wf_run.assert_called_with(wf_run_id)

--- a/tests/runtime/performance/test_cli_perf.py
+++ b/tests/runtime/performance/test_cli_perf.py
@@ -85,7 +85,7 @@ def orq_workflow_run(ray_cluster, orq_project_dir):
     output = _run_orq_command(["wf", "submit", "-c", "local", "workflow_defs"])
     # Parse the stdout to get the workflow ID
     stdout = output.stdout.decode()
-    match = re.match("Workflow submitted! Run ID: (?P<wf_run_id>.*)", stdout)
+    match = re.match("Workflow Submitted! Run ID: (?P<wf_run_id>.*)", stdout)
     assert match is not None
     workflow_id = match.groupdict().get("wf_run_id")
     assert workflow_id is not None

--- a/tests/sdk/test_consistent_return_shapes.py
+++ b/tests/sdk/test_consistent_return_shapes.py
@@ -25,6 +25,7 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 import tempfile
 import typing as t
 from pathlib import Path
@@ -427,6 +428,10 @@ class TestAPI:
     "ray",
     "mock_config_env_var",
     "mock_db_env_var",
+)
+@pytest.mark.skipif(
+    sys.platform.startswith("win32"),
+    reason="Windows uses different symbols than macOS and Linux",
 )
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.slow

--- a/tests/sdk/test_consistent_return_shapes.py
+++ b/tests/sdk/test_consistent_return_shapes.py
@@ -481,8 +481,8 @@ class TestCLI:
         assert [line.strip() for line in results_ce] == [
             f"Workflow run {mock_ce_run_single} has 1 outputs.",
             "",
-            'Index   Type             Pretty Printed',
-            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+            "Index   Type             Pretty Printed",
+            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
             "0       <class 'list'>   [1, 2, 3]",
             "",
             "",
@@ -540,8 +540,8 @@ class TestCLI:
         assert [line.strip() for line in results_ce] == [
             f"Workflow run {mock_ce_run_multiple} has 2 outputs.",
             "",
-            'Index   Type             Pretty Printed',
-            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+            "Index   Type             Pretty Printed",
+            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
             "0       <class 'list'>   [1, 2, 3]",
             "1       <class 'list'>   [1, 2, 3]",
             "",

--- a/tests/sdk/test_consistent_return_shapes.py
+++ b/tests/sdk/test_consistent_return_shapes.py
@@ -450,11 +450,11 @@ class TestCLI:
         )
 
         m = re.match(
-            r"Workflow submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
+            r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
         assert m is not None
         run_id_ray = m.group("run_id").strip()
-        assert "Workflow submitted!" in run_ce.stdout.decode()
+        assert "Workflow Submitted!" in run_ce.stdout.decode()
 
         # WHEN
         results_ray = (
@@ -481,9 +481,10 @@ class TestCLI:
         assert [line.strip() for line in results_ce] == [
             f"Workflow run {mock_ce_run_single} has 1 outputs.",
             "",
-            "Output 0. Object type: <class 'list'>",
-            "Pretty printed value:",
-            f"{single_result_vanilla}",
+            'Index   Type             Pretty Printed',
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+            "0       <class 'list'>   [1, 2, 3]",
+            "",
             "",
         ]
 
@@ -508,11 +509,11 @@ class TestCLI:
         )
 
         m = re.match(
-            r"Workflow submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
+            r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
         assert m is not None
         run_id_ray = m.group("run_id").strip()
-        assert "Workflow submitted!" in run_ce.stdout.decode()
+        assert "Workflow Submitted!" in run_ce.stdout.decode()
 
         # WHEN
         results_ray = (
@@ -539,13 +540,11 @@ class TestCLI:
         assert [line.strip() for line in results_ce] == [
             f"Workflow run {mock_ce_run_multiple} has 2 outputs.",
             "",
-            "Output 0. Object type: <class 'list'>",
-            "Pretty printed value:",
-            f"{multiple_result_vanilla[0]}",
+            'Index   Type             Pretty Printed',
+            '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+            "0       <class 'list'>   [1, 2, 3]",
+            "1       <class 'list'>   [1, 2, 3]",
             "",
-            "Output 1. Object type: <class 'list'>",
-            "Pretty printed value:",
-            f"{multiple_result_vanilla[1]}",
             "",
         ]
 
@@ -582,7 +581,7 @@ class TestCLIDownloadDir:
         ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
 
         m = re.match(
-            r"Workflow submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
+            r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
         assert m is not None
         run_id_ray = m.group("run_id").strip()
@@ -654,7 +653,7 @@ class TestCLIDownloadDir:
         )
 
         m = re.match(
-            r"Workflow submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
+            r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
         assert m is not None
         run_id_ray = m.group("run_id").strip()


### PR DESCRIPTION
# The problem

Our CLI outputs have been placeholder since we added them.

# This PR's solution

Adds a first round of Rich CLI outputs to help make it a bit easier.

- Workflow view
- Workflow list
- Workflow/task outputs
- Workflow/task logs
- Service up/down/status

https://github.com/zapatacomputing/orquestra-workflow-sdk/assets/70290797/b5d4283c-4dc3-4bbb-a4fc-e5a17674aea6

<img width="727" alt="Screenshot 2023-08-25 at 21 12 11" src="https://github.com/zapatacomputing/orquestra-workflow-sdk/assets/70290797/c26c0e5b-b10f-4cf2-ade4-13600101ab52">
<img width="886" alt="Screenshot 2023-08-25 at 21 12 33" src="https://github.com/zapatacomputing/orquestra-workflow-sdk/assets/70290797/a99e7826-3a55-4e49-aa5c-0bfcb21b075a">
<img width="681" alt="Screenshot 2023-08-25 at 21 13 06" src="https://github.com/zapatacomputing/orquestra-workflow-sdk/assets/70290797/93b41e68-4495-4597-b6eb-310e920d5060">


# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
