### PR TITLE
int: fix docs warnings

### DIFF
--- a/docs/quickref/cli-reference.rst
+++ b/docs/quickref/cli-reference.rst
@@ -6,6 +6,6 @@ CLI Reference
 
 Orquestra Workflow SDK comes with a Command Line Interface (CLI) tool which can execute and manage workflows.
 
-.. click:: orquestra.sdk._base.cli._dorq._entry:dorq
+.. click:: orquestra.sdk._base.cli._entry:dorq
    :prog: orq
    :nested: full

--- a/src/orquestra/sdk/_base/_api/_task_run.py
+++ b/src/orquestra/sdk/_base/_api/_task_run.py
@@ -46,7 +46,7 @@ class TaskRun:
     ):
         """
         This object isn't intended to be directly initialized. Instead, please use
-        `WorkflowRun.get_tasks()`.
+        ``WorkflowRun.get_tasks()``.
         """
         self._task_run_id = task_run_id
         self._task_invocation_id = task_invocation_id
@@ -333,13 +333,12 @@ def current_run_ids() -> CurrentRunIDs:
 
     Task run ID is a globally unique identifier of executing an invocation exactly once.
 
-    This function is intended to be used within the task code in the following way:
-    ```
-    @sdk.task
-    def t():
-        wf_run_id, task_inv_id, task_run_id =  sdk.current_run_ids()
-        ...
-    ```
+    This function is intended to be used within the task code in the following way::
+
+        @sdk.task
+        def t():
+            wf_run_id, task_inv_id, task_run_id =  sdk.current_run_ids()
+            ...
 
     Returns:
         The IDs associated with the current run, in a named tuple. See: CurrentRunIDs

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -278,7 +278,7 @@ class WorkflowRun:
                 stderr.
 
         Returns:
-            State: The state of the finished workflow.
+            orquestra.sdk.schema.workflow_run.State: The state of the finished workflow.
         """
 
         assert frequency > 0.0, "Frequency must be a positive non-zero value"

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -219,10 +219,10 @@ class DriverClient:
         Stores a workflow definition for future submission
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDef:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDef
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
 
         Returns:
             the WorkflowDefID associated with the stored definition
@@ -262,9 +262,9 @@ class DriverClient:
         Lists all known workflow definitions
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
         resp = self._get(
             self._uri_provider.uri_for("list_workflow_defs"),
@@ -312,11 +312,11 @@ class DriverClient:
         Gets a stored workflow definition
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDefID:
-            orquestra.sdk._base._driver._exceptions.WorkflowDefNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDefID
+            orquestra.sdk._base._driver._exceptions.WorkflowDefNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
 
         Returns:
             a parsed WorkflowDef
@@ -346,11 +346,11 @@ class DriverClient:
         Gets a stored workflow definition
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDefID:
-            orquestra.sdk._base._driver._exceptions.WorkflowDefNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDefID
+            orquestra.sdk._base._driver._exceptions.WorkflowDefNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
         resp = self._delete(
             self._uri_provider.uri_for(
@@ -377,11 +377,11 @@ class DriverClient:
         Submit a workflow def to run in the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunRequest:
-            orquestra.sdk._base._driver._exceptions.UnsupportedSDKVersion:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunRequest
+            orquestra.sdk._base._driver._exceptions.UnsupportedSDKVersion
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
         resp = self._post(
             self._uri_provider.uri_for("create_workflow_run"),
@@ -420,9 +420,9 @@ class DriverClient:
         List workflow runs with a specified workflow def ID from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
         # Schema: https://github.com/zapatacomputing/workflow-driver/blob/fa3eb17f1132d9c7f4960331ffe7ddbd31e02f8c/openapi/src/resources/workflow-runs.yaml#L10 # noqa: E501
         resp = self._get(
@@ -461,11 +461,11 @@ class DriverClient:
         Gets the status of a workflow run from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._get(
@@ -499,10 +499,10 @@ class DriverClient:
             force: if the workflow should be forcefully terminated
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._post(
@@ -527,11 +527,11 @@ class DriverClient:
         Gets the workflow run artifact IDs of a workflow run from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._get(
@@ -563,11 +563,11 @@ class DriverClient:
         Gets workflow run artifacts from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunArtifactID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunArtifactNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunArtifactID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunArtifactNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._get(
@@ -597,11 +597,11 @@ class DriverClient:
         Gets the workflow run result IDs of a workflow run from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._get(
@@ -631,11 +631,11 @@ class DriverClient:
         Gets workflow run results from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunResultID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunResultNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunResultID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunResultNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._get(
@@ -683,12 +683,12 @@ class DriverClient:
         Gets the logs of a workflow run from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable
         """
 
         resp = self._get(
@@ -738,12 +738,12 @@ class DriverClient:
         Gets the logs of a task run from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
-            orquestra.sdk._base._driver._exceptions.TaskRunLogsNotFound:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID
+            orquestra.sdk._base._driver._exceptions.TaskRunLogsNotFound
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._get(
@@ -789,12 +789,12 @@ class DriverClient:
         Get the logs of a workflow run from the workflow driver.
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotFound:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotFound
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
             NotImplementedError: when a log object's source_type is not a recognised
                 value, or is a value for a schema has not been defined.
         """
@@ -882,11 +882,11 @@ class DriverClient:
         Gets the status of a workflow run from the workflow driver
 
         Raises:
-            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
-            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
-            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
-            orquestra.sdk._base._driver._exceptions.ForbiddenError:
-            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError
+            orquestra.sdk._base._driver._exceptions.ForbiddenError
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError
         """
 
         resp = self._get(

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -219,10 +219,10 @@ class DriverClient:
         Stores a workflow definition for future submission
 
         Raises:
-            InvalidWorkflowDef: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDef:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
 
         Returns:
             the WorkflowDefID associated with the stored definition
@@ -262,9 +262,9 @@ class DriverClient:
         Lists all known workflow definitions
 
         Raises:
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
         resp = self._get(
             self._uri_provider.uri_for("list_workflow_defs"),
@@ -312,11 +312,11 @@ class DriverClient:
         Gets a stored workflow definition
 
         Raises:
-            InvalidWorkflowDefID: see the exception's docstring
-            WorkflowDefNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDefID:
+            orquestra.sdk._base._driver._exceptions.WorkflowDefNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
 
         Returns:
             a parsed WorkflowDef
@@ -346,11 +346,11 @@ class DriverClient:
         Gets a stored workflow definition
 
         Raises:
-            InvalidWorkflowDefID: see the exception's docstring
-            WorkflowDefNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowDefID:
+            orquestra.sdk._base._driver._exceptions.WorkflowDefNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
         resp = self._delete(
             self._uri_provider.uri_for(
@@ -377,11 +377,11 @@ class DriverClient:
         Submit a workflow def to run in the workflow driver
 
         Raises:
-            InvalidWorkflowRunRequest: see the exception's docstring
-            UnsupportedSDKVersion: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunRequest:
+            orquestra.sdk._base._driver._exceptions.UnsupportedSDKVersion:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
         resp = self._post(
             self._uri_provider.uri_for("create_workflow_run"),
@@ -420,9 +420,9 @@ class DriverClient:
         List workflow runs with a specified workflow def ID from the workflow driver
 
         Raises:
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
         # Schema: https://github.com/zapatacomputing/workflow-driver/blob/fa3eb17f1132d9c7f4960331ffe7ddbd31e02f8c/openapi/src/resources/workflow-runs.yaml#L10 # noqa: E501
         resp = self._get(
@@ -461,11 +461,11 @@ class DriverClient:
         Gets the status of a workflow run from the workflow driver
 
         Raises:
-            InvalidWorkflowRunID: see the exception's docstring
-            WorkflowRunNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._get(
@@ -499,10 +499,10 @@ class DriverClient:
             force: if the workflow should be forcefully terminated
 
         Raises:
-            WorkflowRunNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._post(
@@ -527,11 +527,11 @@ class DriverClient:
         Gets the workflow run artifact IDs of a workflow run from the workflow driver
 
         Raises:
-            InvalidWorkflowRunID: see the exception's docstring
-            WorkflowRunNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._get(
@@ -563,11 +563,11 @@ class DriverClient:
         Gets workflow run artifacts from the workflow driver
 
         Raises:
-            InvalidWorkflowRunArtifactID: see the exception's docstring
-            WorkflowRunArtifactNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunArtifactID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunArtifactNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._get(
@@ -597,11 +597,11 @@ class DriverClient:
         Gets the workflow run result IDs of a workflow run from the workflow driver
 
         Raises:
-            InvalidWorkflowRunID: see the exception's docstring
-            WorkflowRunNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._get(
@@ -631,11 +631,11 @@ class DriverClient:
         Gets workflow run results from the workflow driver
 
         Raises:
-            InvalidWorkflowRunResultID: see the exception's docstring
-            WorkflowRunResultNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunResultID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunResultNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._get(
@@ -683,12 +683,12 @@ class DriverClient:
         Gets the logs of a workflow run from the workflow driver
 
         Raises:
-            InvalidWorkflowRunID: see the exception's docstring
-            WorkflowRunNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
-            WorkflowRunLogsNotReadable: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable:
         """
 
         resp = self._get(
@@ -738,12 +738,12 @@ class DriverClient:
         Gets the logs of a task run from the workflow driver
 
         Raises:
-            InvalidWorkflowRunID: see the exception's docstring
-            TaskRunLogsNotFound: see the exception's docstring
-            WorkflowRunLogsNotReadable: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
+            orquestra.sdk._base._driver._exceptions.TaskRunLogsNotFound:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._get(
@@ -789,12 +789,12 @@ class DriverClient:
         Get the logs of a workflow run from the workflow driver.
 
         Raises:
-            ForbiddenError: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            InvalidWorkflowRunID: see the exception's docstring
-            WorkflowRunLogsNotFound: see the exception's docstring
-            WorkflowRunLogsNotReadable: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotFound:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunLogsNotReadable:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
             NotImplementedError: when a log object's source_type is not a recognised
                 value, or is a value for a schema has not been defined.
         """
@@ -882,11 +882,11 @@ class DriverClient:
         Gets the status of a workflow run from the workflow driver
 
         Raises:
-            InvalidWorkflowRunID: see the exception's docstring
-            WorkflowRunNotFound: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            ForbiddenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk._base._driver._exceptions.InvalidWorkflowRunID:
+            orquestra.sdk._base._driver._exceptions.WorkflowRunNotFound:
+            orquestra.sdk._base._driver._exceptions.InvalidTokenError:
+            orquestra.sdk._base._driver._exceptions.ForbiddenError:
+            orquestra.sdk._base._driver._exceptions.UnknownHTTPError:
         """
 
         resp = self._get(

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -38,6 +38,7 @@ from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     import pip_api
+    import orquestra.sdk
 
 import wrapt  # type: ignore
 
@@ -468,7 +469,7 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
     def __init__(
         self,
         fn: Callable[_P, _R],
-        output_metadata: TaskOutputMetadata,
+        output_metadata: "orquestra.sdk._base._dsl.TaskOutputMetadata",
         source_import: Optional[Import] = None,
         parameters: Optional[OrderedDict] = None,
         dependency_imports: Optional[Tuple[Import, ...]] = None,
@@ -704,10 +705,10 @@ class ArtifactFuture:
 
     def __init__(
         self,
-        invocation: TaskInvocation,
+        invocation: orquestra.sdk._base._dsl.TaskInvocation,
         output_index: Optional[int] = None,
         custom_name: Optional[str] = DEFAULT_CUSTOM_NAME,
-        serialization_format: ArtifactFormat = DEFAULT_SERIALIZATION_FORMAT,
+        serialization_format: orquestra.sdk._base._dsl.ArtifactFormat = DEFAULT_SERIALIZATION_FORMAT,  # noqa: E501
     ):
         self.invocation = invocation
         # if the invocation returns multiple values, this the index in the output
@@ -774,21 +775,32 @@ class ArtifactFuture:
     def with_invocation_meta(
         self,
         *,
-        cpu: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
-        memory: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
-        disk: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
-        gpu: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
-        custom_image: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
+        cpu: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
+        memory: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
+        disk: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
+        gpu: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
+        custom_image: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
     ) -> "ArtifactFuture":
         """Assigns optional metadata related to task invocation used to generate this
         artifact.
 
         Doesn't modify existing invocations, returns a new one.
 
-        Example usage:
+        Example usage::
+
             text = capitalize("hello").with_invocation_meta(
-                cpu="1000m",custom_image="zapatacomputing/orquestra-qml:v0.1.0-cuda"
-                )
+                cpu="1000m", custom_image="zapatacomputing/orquestra-qml:v0.1.0-cuda"
+            )
 
         Args:
             cpu: amount of cpu assigned to the task invocation
@@ -842,17 +854,26 @@ class ArtifactFuture:
     def with_resources(
         self,
         *,
-        cpu: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
-        memory: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
-        disk: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
-        gpu: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
+        cpu: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
+        memory: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
+        disk: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
+        gpu: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
     ) -> "ArtifactFuture":
         """Assigns optional metadata related to task invocation used to generate this
         artifact.
 
         Doesn't modify existing invocations, returns a new one.
 
-        Example usage:
+        Example usage::
+
             text = capitalize("hello").with_resources(cpu="1000m")
 
         Args:
@@ -870,17 +891,20 @@ class ArtifactFuture:
 
     def with_custom_image(
         self,
-        custom_image: Optional[Union[str, Sentinel]] = Sentinel.NO_UPDATE,
+        custom_image: Optional[
+            Union[str, "orquestra.sdk._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
     ) -> "ArtifactFuture":
         """Assigns optional metadata related to task invocation used to generate this
         artifact.
 
         Doesn't modify existing invocations, returns a new one.
 
-        Example usage:
+        Example usage::
+
             text = capitalize("hello").with_custom_image(
                 "zapatacomputing/orquestra-qml:v0.1.0-cuda"
-                )
+            )
 
         Args:
             custom_image: docker image used to run the task invocation

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -38,9 +38,11 @@ from typing_extensions import ParamSpec
 
 if TYPE_CHECKING:
     import pip_api
-    import orquestra.sdk
 
 import wrapt  # type: ignore
+
+# Needed for fully-qualified type annotations.
+import orquestra.sdk
 
 from ..exceptions import DirtyGitRepo, InvalidTaskDefinitionError, WorkflowSyntaxError
 from ..kubernetes.quantity import parse_quantity
@@ -466,6 +468,9 @@ class TaskDef(Generic[_P, _R], wrapt.ObjectProxy):
     get the serializable form.
     """
 
+    # The fully-qualified type hint is a workaround for docs' autoapi not being able to
+    # resolve symbols.
+
     def __init__(
         self,
         fn: Callable[_P, _R],
@@ -772,6 +777,9 @@ class ArtifactFuture:
         """
         raise NotImplementedError("ArtifactFuture cannot be pickled")
 
+    # The fully-qualified type hint is a workaround for docs' autoapi not being able to
+    # resolve symbols.
+
     def with_invocation_meta(
         self,
         *,
@@ -851,6 +859,9 @@ class ArtifactFuture:
             serialization_format=self.serialization_format,
         )
 
+    # The fully-qualified type hint is a workaround for docs' autoapi not being able to
+    # resolve symbols.
+
     def with_resources(
         self,
         *,
@@ -888,6 +899,9 @@ class ArtifactFuture:
         )
 
         return self.with_invocation_meta(cpu=cpu, memory=memory, disk=disk, gpu=gpu)
+
+    # The fully-qualified type hint is a workaround for docs' autoapi not being able to
+    # resolve symbols.
 
     def with_custom_image(
         self,

--- a/src/orquestra/sdk/_base/_git_url_utils.py
+++ b/src/orquestra/sdk/_base/_git_url_utils.py
@@ -72,9 +72,10 @@ def parse_git_url(url: str) -> GitURL:
     """
     Parse a git URL from a string
     Accepted formats:
-        <protocol>://[<user>@]<host>[:<port>]/<path>[?<query>]
-        <user>@<host>:<path>
-        ssh://<user>@<host>:<repo>
+
+    * ``<protocol>://[<user>@]<host>[:<port>]/<path>[?<query>]``
+    * ``<user>@<host>:<path>``
+    * ``ssh://<user>@<host>:<repo>``
     """
     try:
         parsed = parse_url(url)

--- a/src/orquestra/sdk/_base/_jwt.py
+++ b/src/orquestra/sdk/_base/_jwt.py
@@ -14,8 +14,9 @@ def check_jwt_without_signature_verification(token: str):
     Only used as a sanity check when reading a token from the CLI.
 
     Raises:
-        ExpiredTokenError: if the current date is after the token's expiry
-        InvalidTokenError: if the token is not a JWT
+        orquestra.sdk.exceptions.ExpiredTokenError: if the current date is after the
+            token's expiry
+        orquestra.sdk.exceptions.InvalidTokenError: if the token is not a JWT
     """
     try:
         _ = jwt.decode(token, options={"verify_signature": False, "verify_exp": True})

--- a/src/orquestra/sdk/_base/_logs/_interfaces.py
+++ b/src/orquestra/sdk/_base/_logs/_interfaces.py
@@ -27,9 +27,11 @@ class WorkflowLogs:
     """
     A mapping with task logs. Each key-value pair corresponds to one task
     invocation.
-    - key: task invocation ID (see
-        orquestra.sdk._base.ir.WorkflowDef.task_invocations)
-    - value: log lines from running this task invocation
+
+    * key: task invocation ID (see
+      ``orquestra.sdk.schema.ir.WorkflowDef.task_invocations``)
+
+    * value: log lines from running this task invocation
     """
 
     env_setup: LogOutput

--- a/src/orquestra/sdk/_base/_retry.py
+++ b/src/orquestra/sdk/_base/_retry.py
@@ -14,7 +14,8 @@ def retry(
     """
     A decorator useful for when a function should be retried.
 
-    Usage:
+    Usage::
+
         @retry(attempts=2, allowed_exceptions=(RuntimeError, ConnectionError))
         def my_function_that_can_fail():
             ...

--- a/src/orquestra/sdk/_base/_spaces/_resolver.py
+++ b/src/orquestra/sdk/_base/_spaces/_resolver.py
@@ -19,9 +19,9 @@ def resolve_studio_ref(
     Resolve the workspace and project IDs from the passed args or environment vars.
 
     Raises:
-    ProjectInvalidError: when one but not both of the workspace and project id
-        arguments are specified - this is insufficient information to uniquely
-        identify a project.
+        orquestra.sdk.exceptions.ProjectInvalidError: when one but not both of the
+            workspace and project id arguments are specified - this is insufficient
+            information to uniquely identify a project.
     """
     current_workspace = resolve_studio_workspace_ref(workspace_id)
 

--- a/src/orquestra/sdk/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_base/_testing/_example_wfs.py
@@ -279,16 +279,19 @@ def add_with_error(a, b):
 @sdk.workflow
 def exception_wf_with_multiple_values():
     """
-       [1]
-        │
-        ▼
-       [2] => exception
-        │
-        ▼
-       [3] => won't run
-        │
-        ▼
-    [return]
+    ::
+
+           [1]
+            │
+            ▼
+           [2] => exception
+            │
+            ▼
+           [3] => won't run
+            │
+            ▼
+        [return]
+
     """
     future1 = add(37, 21)
     future2 = add_with_error(future1, future1)

--- a/src/orquestra/sdk/_base/_traversal.py
+++ b/src/orquestra/sdk/_base/_traversal.py
@@ -764,14 +764,14 @@ def flatten_graph(
 ) -> ir.WorkflowDef:
     """Traverse the nested linked list of futures and produce a flat graph.
 
-    Each `dsl.ArtifactFuture` is mapped to a single `model.ArtifactNode`.
-    Each `dsl.Constant` is mapped to a single `model.ConstantNode`.
-    Each `dsl.TaskInvocation` is mapped to a single `model.TaskInvocation`.
+    Each ``dsl.ArtifactFuture`` is mapped to a single ``model.ArtifactNode``.
+    Each ``dsl.Constant`` is mapped to a single ``model.ConstantNode``.
+    Each ``dsl.TaskInvocation`` is mapped to a single ``model.TaskInvocation``.
 
-    Unique task references from `dsl.TaskInvocation`s are mapped to `model.Task`s.
+    Unique task references from ``dsl.TaskInvocation`` s are mapped to ``model.Task`` s.
 
-    Each `model.TaskInvocation` refers to nodes from `tasks`, `artifact_nodes` &
-    `constant_nodes` by their ids. This allows deduplication of metadata if a single
+    Each ``model.TaskInvocation`` refers to nodes from ``tasks``, ``artifact_nodes`` &
+    ``constant_nodes`` by their ids. This allows deduplication of metadata if a single
     node is referenced by multiple invocations.
     """
     root_futures = futures

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -5,7 +5,6 @@ import ast
 import functools
 import inspect
 import warnings
-from enum import Enum
 from pathlib import Path
 from types import FunctionType
 from typing import (
@@ -174,7 +173,8 @@ class WorkflowDef(Generic[_R]):
             orquestra.sdk.exceptions.DirtyGitRepo: (warning) when a task def used by
                 this workflow def has a "GitImport" and the git repo that contains it
                 has uncommitted changes.
-            ProjectInvalidError: when only 1 out of project and workspace is passed
+            orquestra.sdk.exceptions.ProjectInvalidError: when only 1 out of project and
+                workspace is passed.
 
         """
         # The DirtyGitRepo warning can be raised here.
@@ -203,7 +203,8 @@ class WorkflowDef(Generic[_R]):
 
         Doesn't modify the existing workflow definition, returns a new one.
 
-        Example usage:
+        Example usage::
+
             wf_run = my_workflow().with_resources(
                 cpu="10", memory="10Gi"
             ).run("my_cluster")
@@ -394,8 +395,7 @@ class _CalledFunction(NamedTuple):
     line_no: Optional[int] = None
 
 
-class Sentinel(Enum):
-    NO_MODULE = object()
+NO_MODULE_SENTINEL = object()
 
 
 def _get_callable(
@@ -411,13 +411,13 @@ def _get_callable(
         _fn : Callable corresponding to the call_statement
         module_name : Name of the callable's module
     """
-    found_module = Sentinel.NO_MODULE
+    found_module: Any = NO_MODULE_SENTINEL
     _fn = None
     module_name = None
     for node in call_statement:
         if node.node_type is NodeReferenceType.CALL:
             # For CALL nodes we try to retrieve the callable object
-            if found_module is not Sentinel.NO_MODULE:
+            if found_module is not NO_MODULE_SENTINEL:
                 # This raises:
                 #    AttributeError if the function isn't found
                 try:
@@ -444,7 +444,7 @@ def _get_callable(
         else:
             # try to retrieve the module from where the callable is imported
             try:
-                if found_module is not Sentinel.NO_MODULE:
+                if found_module is not NO_MODULE_SENTINEL:
                     found_module = getattr(found_module, node.name)
                 else:
                     found_module = fn.__globals__[node.name]

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -87,9 +87,10 @@ class RuntimeInterface(ABC, LogReader):
 
         This method should return all output values for a task even if some of them
         aren't used in the workflow function. Reasons:
-        - Users might be interested in the computed value after running, even though
+
+        * Users might be interested in the computed value after running, even though
           the workflow didn't make an explicit use of it.
-        - Position in the task output tuple is significant. We can't just drop some of
+        * Position in the task output tuple is significant. We can't just drop some of
           the elements because this would shift indices.
 
         Careful: This method does NOT return status of a workflow. Verify it beforehand
@@ -213,9 +214,9 @@ class WorkflowRepo(ABC):
 
         Arguments:
             prefix (Optional): Only return workflow runs whose IDs start with the
-            prefix.
+                prefix.
             config_name (Optional): Only return workflow runs that use the
-            specified configuration name.
+                specified configuration name.
 
         Returns:
             A list of workflow runs for a given config. Includes: run ID, stored

--- a/src/orquestra/sdk/_base/cli/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_repos.py
@@ -514,8 +514,9 @@ class ConfigRepo:
         Saves the token in the config file
 
         Raises:
-            ExpiredTokenError: if the token is expired
-            InvalidTokenError: if the token is not a valid format
+            orquestra.sdk.exceptions.ExpiredTokenError: if the current date is after the
+                token's expiry
+            orquestra.sdk.exceptions.InvalidTokenError: if the token is not a JWT
         """
         check_jwt_without_signature_verification(token)
 

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -22,7 +22,6 @@ from .._base._logs import _markers
 from ..kubernetes.quantity import parse_quantity
 from ..schema import ir, responses, workflow_run
 from . import _client, _id_gen
-from ._client import RayClient
 from ._wf_metadata import InvUserMetadata, pydatic_to_json_dict
 
 DEFAULT_IMAGE_TEMPLATE = "hub.nexus.orquestra.io/zapatacomputing/orquestra-sdk-base:{}"
@@ -182,7 +181,7 @@ def _get_user_function(
 
 
 def _make_ray_dag_node(
-    client: RayClient,
+    client: _client.RayClient,
     ray_options: t.Mapping,
     ray_args: t.Iterable[t.Any],
     ray_kwargs: t.Mapping[str, t.Any],
@@ -199,7 +198,7 @@ def _make_ray_dag_node(
 
     Args:
         client: Ray API facade
-        ray_options: dict passed to RayClient.add_options()
+        ray_options: dict passed to _client.RayClient.add_options()
         ray_args: constants or futures required to build the DAG
         ray_kwargs: constants or futures required to build the DAG
         args_artifact_nodes: a map of positional arg index to artifact node
@@ -366,7 +365,7 @@ def _ray_resources_for_custom_image(image_name: str) -> t.Mapping[str, float]:
 
 
 def make_ray_dag(
-    client: RayClient,
+    client: _client.RayClient,
     workflow_def: ir.WorkflowDef,
     workflow_run_id: workflow_run.WorkflowRunId,
     dry_run: bool,

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -39,7 +39,6 @@ from ..schema.workflow_run import (
 )
 from . import _client, _id_gen, _ray_logs
 from ._build_workflow import TaskResult, make_ray_dag
-from ._client import RayClient
 from ._wf_metadata import WfUserMetadata, pydatic_to_json_dict
 
 
@@ -185,9 +184,9 @@ class RayRuntime(RuntimeInterface):
         self,
         config: RuntimeConfiguration,
         project_dir: Path,
-        client: t.Optional[RayClient] = None,
+        client: t.Optional[_client.RayClient] = None,
     ):
-        self._client = client or RayClient()
+        self._client = client or _client.RayClient()
 
         ray_params = RayParams(
             address=config.runtime_options["address"],
@@ -230,7 +229,7 @@ class RayRuntime(RuntimeInterface):
         logger = logging.getLogger("ray")
         logger.setLevel(logging.ERROR)
 
-        client = RayClient()
+        client = _client.RayClient()
         try:
             client.init(**dataclasses.asdict(ray_params))
         except ConnectionError as e:
@@ -262,7 +261,7 @@ class RayRuntime(RuntimeInterface):
 
         Safe to call multiple times in a row.
         """
-        client = RayClient()
+        client = _client.RayClient()
         client.shutdown()
 
     def create_workflow_run(

--- a/src/orquestra/sdk/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/mlflow/_connection_utils.py
@@ -43,11 +43,9 @@ def _get_mlflow_cr_name_and_port() -> Tuple[str, str]:
     - ORQ_MLFLOW_CR_NAME
     - ORQ_MLFLOW_PORT
 
-    Example usage:
+    Example usage::
 
-    ```python
-    mlflow_cr_name, mlflow_port = _get_mlflow_cr_name_and_port()
-    ```
+        mlflow_cr_name, mlflow_port = _get_mlflow_cr_name_and_port()
 
     Raises:
         EnvironmentError: when either of the environment variables are not set.

--- a/src/orquestra/sdk/schema/configs.py
+++ b/src/orquestra/sdk/schema/configs.py
@@ -41,9 +41,11 @@ class RuntimeConfigurationFile(BaseModel):
     """
     This schema is for the storage of "Runtime configurations".
     The major version number should be bumped when:
-        - The values inside the configuration file are modified, for example if the
-            `configs` option is renamed or the type is changed.
-        - The shape of `RuntimeConfiguration` changes
+
+    * The values inside the configuration file are modified, for example if
+      the ``configs`` option is renamed or the type is changed.
+
+    * The shape of ``RuntimeConfiguration`` changes.
     """
 
     version: str

--- a/src/orquestra/sdk/secrets/__init__.py
+++ b/src/orquestra/sdk/secrets/__init__.py
@@ -13,7 +13,7 @@ This module's behavior depends on the execution context (in a standalone REPL/sc
 in a workflow on the Local Runtime, in a workflow on Orquestra Platform).
 
 When you're using ``orquestra.sdk.secrets`` on your machine (inside a standalone script
- or with the Local Ray Runtime), this class uses cluster credentials read from your
+or with the Local Ray Runtime), this class uses cluster credentials read from your
 config file (set by ``orq login``).
 
 When ``orquestra.sdk.secrets`` is used inside a task running remotely on the Orquestra

--- a/src/orquestra/sdk/secrets/_client.py
+++ b/src/orquestra/sdk/secrets/_client.py
@@ -94,9 +94,9 @@ class SecretsClient:
     def get_secret(self, name: SecretName) -> SecretDefinition:
         """
         Raises:
-            SecretNotFoundError: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk.secrets._exceptions.SecretNotFoundError:
+            orquestra.sdk.secrets._exceptions.InvalidTokenError:
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
         """
         resp = self._get(API_ACTIONS["get_secret"].format(name))
 
@@ -112,8 +112,8 @@ class SecretsClient:
     ) -> t.Sequence[SecretNameObj]:
         """
         Raises:
-            InvalidTokenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk.secrets._exceptions.InvalidTokenError:
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
         """
         resp = self._get(
             API_ACTIONS["list_secrets"],
@@ -130,9 +130,9 @@ class SecretsClient:
     def create_secret(self, new_secret: SecretDefinition):
         """
         Raises:
-            SecretAlreadyExistsError: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk.secrets._exceptions.SecretAlreadyExistsError:
+            orquestra.sdk.secrets._exceptions.InvalidTokenError:
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
         """
         resp = self._post(
             API_ACTIONS["create_secret"],
@@ -147,9 +147,9 @@ class SecretsClient:
     def update_secret(self, name: SecretName, value: SecretValue):
         """
         Raises:
-            SecretNotFoundError: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk.secrets._exceptions.SecretNotFoundError:
+            orquestra.sdk.secrets._exceptions.InvalidTokenError:
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
         """
         obj = SecretValueObj(value=value)
         resp = self._post(
@@ -165,9 +165,9 @@ class SecretsClient:
     def delete_secret(self, name: SecretName):
         """
         Raises:
-            SecretNotFoundError: see the exception's docstring
-            InvalidTokenError: see the exception's docstring
-            UnknownHTTPError: see the exception's docstring
+            orquestra.sdk.secrets._exceptions.SecretNotFoundError:
+            orquestra.sdk.secrets._exceptions.InvalidTokenError:
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
         """
         resp = self._delete(API_ACTIONS["delete_secret"].format(name))
 

--- a/src/orquestra/sdk/secrets/_client.py
+++ b/src/orquestra/sdk/secrets/_client.py
@@ -94,9 +94,9 @@ class SecretsClient:
     def get_secret(self, name: SecretName) -> SecretDefinition:
         """
         Raises:
-            orquestra.sdk.secrets._exceptions.SecretNotFoundError:
-            orquestra.sdk.secrets._exceptions.InvalidTokenError:
-            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
+            orquestra.sdk.secrets._exceptions.SecretNotFoundError
+            orquestra.sdk.secrets._exceptions.InvalidTokenError
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError
         """
         resp = self._get(API_ACTIONS["get_secret"].format(name))
 
@@ -112,8 +112,8 @@ class SecretsClient:
     ) -> t.Sequence[SecretNameObj]:
         """
         Raises:
-            orquestra.sdk.secrets._exceptions.InvalidTokenError:
-            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
+            orquestra.sdk.secrets._exceptions.InvalidTokenError
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError
         """
         resp = self._get(
             API_ACTIONS["list_secrets"],
@@ -130,9 +130,9 @@ class SecretsClient:
     def create_secret(self, new_secret: SecretDefinition):
         """
         Raises:
-            orquestra.sdk.secrets._exceptions.SecretAlreadyExistsError:
-            orquestra.sdk.secrets._exceptions.InvalidTokenError:
-            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
+            orquestra.sdk.secrets._exceptions.SecretAlreadyExistsError
+            orquestra.sdk.secrets._exceptions.InvalidTokenError
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError
         """
         resp = self._post(
             API_ACTIONS["create_secret"],
@@ -147,9 +147,9 @@ class SecretsClient:
     def update_secret(self, name: SecretName, value: SecretValue):
         """
         Raises:
-            orquestra.sdk.secrets._exceptions.SecretNotFoundError:
-            orquestra.sdk.secrets._exceptions.InvalidTokenError:
-            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
+            orquestra.sdk.secrets._exceptions.SecretNotFoundError
+            orquestra.sdk.secrets._exceptions.InvalidTokenError
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError
         """
         obj = SecretValueObj(value=value)
         resp = self._post(
@@ -165,9 +165,9 @@ class SecretsClient:
     def delete_secret(self, name: SecretName):
         """
         Raises:
-            orquestra.sdk.secrets._exceptions.SecretNotFoundError:
-            orquestra.sdk.secrets._exceptions.InvalidTokenError:
-            orquestra.sdk.secrets._exceptions.UnknownHTTPError:
+            orquestra.sdk.secrets._exceptions.SecretNotFoundError
+            orquestra.sdk.secrets._exceptions.InvalidTokenError
+            orquestra.sdk.secrets._exceptions.UnknownHTTPError
         """
         resp = self._delete(API_ACTIONS["delete_secret"].format(name))
 

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -10,7 +10,7 @@ import pytest
 from orquestra.sdk._base._testing._example_wfs import (
     workflow_parametrised_with_resources,
 )
-from orquestra.sdk._ray import _build_workflow
+from orquestra.sdk._ray import _build_workflow, _client
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.responses import WorkflowResult
 
@@ -124,7 +124,7 @@ class TestResourcesInMakeDag:
 
     @pytest.fixture
     def client(self):
-        return create_autospec(_build_workflow.RayClient)
+        return create_autospec(_client.RayClient)
 
     @pytest.mark.parametrize(
         "resources, expected, types",

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -33,7 +33,7 @@ def wf_run_id():
 
 @pytest.fixture
 def client():
-    return create_autospec(_dag.RayClient)
+    return create_autospec(_client.RayClient)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# The problem

We often missed docs builds problems because the issues drowned in the warnings list.

# This PR's solution

Fixes all SDK-related docs warnings I could reproduce and find a solution for.

To reproduce, run the multi-repo docs build (it's in a different repo) and check the warnings related to Orquestra Workflow SDK. Before this PR there should be over 100 warnings, after this PR there should be under 3.

Alternatively, see also https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/307, however it doesn't capture `autoapi` issues.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
