### PR TITLE
Imp: Proper error when secrets are used as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 💅 *Improvements*
 
+* Throw more informative exceptions if secret is used in any unintended way inside workflow function
+
 🥷 *Internal*
 
 📃 *Docs*

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -88,6 +88,28 @@ class Secret(NamedTuple):
     # specific workspace.
     workspace_id: Optional[str] = None
 
+    _secret_as_string_error = (
+        "Invalid usage of a Secret object. Secrets are not "
+        "available when building the workflow graph and cannot"
+        " be used as strings. If you need to use a Secret's"
+        " value, this must be done inside of a task."
+    )
+
+    def __getattr__(self, item):
+        try:
+            return self.__getattribute__(item)
+        except AttributeError as e:
+            raise AttributeError(self._secret_as_string_error) from e
+
+    def __getitem__(self, item):
+        raise AttributeError(self._secret_as_string_error)
+
+    def __str__(self):
+        raise AttributeError(self._secret_as_string_error)
+
+    def __iter__(self):
+        raise AttributeError(self._secret_as_string_error)
+
 
 @dataclass(frozen=True, eq=True)
 class GitImportWithAuth:

--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -76,6 +76,13 @@ Constant = Any
 # function calls).
 Argument = Union[Constant, "ArtifactFuture", "Secret"]
 
+_secret_as_string_error = (
+    "Invalid usage of a Secret object. Secrets are not "
+    "available when building the workflow graph and cannot"
+    " be used as strings. If you need to use a Secret's"
+    " value, this must be done inside of a task."
+)
+
 
 class Secret(NamedTuple):
     name: str
@@ -88,27 +95,20 @@ class Secret(NamedTuple):
     # specific workspace.
     workspace_id: Optional[str] = None
 
-    _secret_as_string_error = (
-        "Invalid usage of a Secret object. Secrets are not "
-        "available when building the workflow graph and cannot"
-        " be used as strings. If you need to use a Secret's"
-        " value, this must be done inside of a task."
-    )
-
     def __getattr__(self, item):
         try:
             return self.__getattribute__(item)
         except AttributeError as e:
-            raise AttributeError(self._secret_as_string_error) from e
+            raise AttributeError(_secret_as_string_error) from e
 
     def __getitem__(self, item):
-        raise AttributeError(self._secret_as_string_error)
+        raise AttributeError(_secret_as_string_error)
 
     def __str__(self):
-        raise AttributeError(self._secret_as_string_error)
+        raise AttributeError(_secret_as_string_error)
 
     def __iter__(self):
-        raise AttributeError(self._secret_as_string_error)
+        raise AttributeError(_secret_as_string_error)
 
 
 @dataclass(frozen=True, eq=True)

--- a/tests/sdk/test_dsl.py
+++ b/tests/sdk/test_dsl.py
@@ -761,3 +761,49 @@ class TestResources:
 
         # should not raise
         wf().model
+
+
+class TestSecretAsString:
+    def test_basic_secret_as_string_usage(self):
+        @sdk.workflow()
+        def wf():
+            my_secret = sdk.secrets.get("w/e", workspace_id="w/e")
+            my_secret.split()
+
+        with pytest.raises(AttributeError) as e:
+            wf().model
+
+        assert "Invalid usage of a Secret object" in str(e)
+
+    def test_secret_subscribe_as_string(self):
+        @sdk.workflow()
+        def wf():
+            my_secret = sdk.secrets.get("w/e", workspace_id="w/e")[0]
+
+        with pytest.raises(AttributeError) as e:
+            wf().model
+
+        assert "Invalid usage of a Secret object" in str(e)
+
+    def test_secret_translated_to_string(self):
+        @sdk.workflow()
+        def wf():
+            my_secrets = sdk.secrets.get("w/e", workspace_id="w/e")
+            print(my_secrets)
+
+        with pytest.raises(AttributeError) as e:
+            wf().model
+
+        assert "Invalid usage of a Secret object" in str(e)
+
+    def test_secret_as_iterable(self):
+        @sdk.workflow()
+        def wf():
+            my_secrets = sdk.secrets.get("w/e", workspace_id="w/e")
+            for letter in my_secrets:
+                print(letter)
+
+        with pytest.raises(AttributeError) as e:
+            wf().model
+
+        assert "Invalid usage of a Secret object" in str(e)

--- a/tests/sdk/test_dsl.py
+++ b/tests/sdk/test_dsl.py
@@ -778,7 +778,7 @@ class TestSecretAsString:
     def test_secret_subscribe_as_string(self):
         @sdk.workflow()
         def wf():
-            my_secret = sdk.secrets.get("w/e", workspace_id="w/e")[0]
+            sdk.secrets.get("w/e", workspace_id="w/e")[0]
 
         with pytest.raises(AttributeError) as e:
             wf().model
@@ -788,8 +788,8 @@ class TestSecretAsString:
     def test_secret_translated_to_string(self):
         @sdk.workflow()
         def wf():
-            my_secrets = sdk.secrets.get("w/e", workspace_id="w/e")
-            print(my_secrets)
+            my_secret = sdk.secrets.get("w/e", workspace_id="w/e")
+            print(my_secret)
 
         with pytest.raises(AttributeError) as e:
             wf().model


### PR DESCRIPTION
# The problem

Users might want to use secrets as strings, which is no good

# This PR's solution

throw informative exception if secret is used in any unintended way.
This PR wont cover solution like
`"".join[sdk.secrets.get(...)]` or any other that strictly checks the type, but should be good enough for most of the cases

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
