### PR TITLE
Fix: orq login --list properly handles missing or empty config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 🐛 *Bug Fixes*
 
+* `orq login --list` properly handles missing or empty config file
+
 💅 *Improvements*
 
 * Throw more informative exceptions if secret is used in any unintended way inside workflow function

--- a/src/orquestra/sdk/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_presenters.py
@@ -273,6 +273,13 @@ class ConfigPresenter:
         """
         Print a list of stored configs.
         """
+        if not configs:
+            click.echo(
+                "No remote configs available. Create new config using "
+                "`orq login -s <remote uri>` command"
+            )
+            return
+
         click.echo(message)
         click.echo(
             tabulate(

--- a/tests/cli/test_login_list.py
+++ b/tests/cli/test_login_list.py
@@ -57,3 +57,26 @@ class TestAction:
             ("<config name sentinel 2>",),
         ]
         prompter.assert_not_called()
+
+    def test_no_remote_configs(monkeypatch, capsys):
+        # Given
+        exception_presenter = Mock()
+        config_repo = Mock()
+        prompter = Mock()
+
+        config_repo.list_remote_config_names = Mock(return_value=[])
+
+        action = Action(
+            exception_presenter=exception_presenter,
+            config_repo=config_repo,
+            prompter=prompter,
+        )
+
+        # When
+        action._on_cmd_call_with_exceptions()
+
+        # Then
+        assert "No remote configs available" in capsys.readouterr().out
+        exception_presenter.assert_not_called()
+        config_repo.list_remote_config_names.assert_called_once_with()
+        prompter.assert_not_called()


### PR DESCRIPTION
# The problem

`orq login --list` threw non-readable exception when config file was empty or missing.
https://zapatacomputing.atlassian.net/browse/ORQSDK-961

# This PR's solution

Print out proper message

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
