### PR TITLE
Feat: Workflows continue to run after a failed task until all started tasks are complete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 * Removed model classes that used to define the shape of defunct `orq` CLI command outputs.
+* CE: When a task fails, the workflow will continue to be `RUNNING` while all other started tasks complete.
 
 🔥 *Features*
 
@@ -23,6 +24,7 @@
 🥷 *Internal*
 
 * Removed unused local cache code.
+* The Ray metadata for failed tasks now includes a `failed` field in addition to the start and end times.
 
 📃 *Docs*
 

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -5,6 +5,7 @@
 Translates IR workflow def into a Ray workflow.
 """
 import os
+import time
 import typing as t
 from functools import singledispatch
 from pathlib import Path
@@ -251,6 +252,14 @@ def _make_ray_dag_node(
 
                     wrapped_return = wrapped(*inner_args, **inner_kwargs)
                 except Exception as e:
+                    assert wf_run_id is not None
+                    assert task_inv_id is not None
+                    _client.save_task_postrun_metadata(
+                        wf_run_id,
+                        task_inv_id,
+                        {"end_time": time.time(), "failed": True},
+                    )
+
                     raise exceptions.UserTaskFailedError(
                         f"User task with task invocation id:{task_inv_id} failed.",
                         wf_run_id if wf_run_id else "",

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -13,6 +13,7 @@ try:
     import ray.workflow
     from ray import exceptions  # noqa: F401
     from ray.workflow import exceptions as workflow_exceptions  # noqa: F401
+    from ray.workflow.workflow_storage import WorkflowStorage
 except ModuleNotFoundError:
     if not t.TYPE_CHECKING:
         WorkflowStatus = None
@@ -30,11 +31,19 @@ else:
     TaskError = ray.exceptions.RayTaskError
     ObjectRef = ray.ObjectRef
     WorkflowStatus = ray.workflow.WorkflowStatus
+    WorkflowStorage = WorkflowStorage
     Storage = ray.workflow.storage.Storage
     RuntimeEnv = ray.runtime_env.RuntimeEnv
     FunctionNode = ray.dag.FunctionNode
     LogPrefixActorName = ray._private.ray_constants.LOG_PREFIX_ACTOR_NAME
     LogPrefixTaskName = ray._private.ray_constants.LOG_PREFIX_TASK_NAME
+
+    def save_task_postrun_metadata(
+        wf_run_id: str,
+        task_inv_id: str,
+        metadata: t.Dict[str, t.Any],
+    ):
+        WorkflowStorage(wf_run_id).save_task_postrun_metadata(task_inv_id, metadata)
 
     class RayClient:
         """

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -199,11 +199,15 @@ def _workflow_status_from_ray_meta(
         # there are tasks still running.
         _end_time = None
     elif state == State.FAILED:
-        # If the workflow failed, we'll pick the latest end_time from the tasks
-        # This is because the end_time stored with the workflow is
-        # when the workflow was marked as failed, not when the last task ended.
+        # If the workflow failed, we'll pick the latest end_time from the tasks.
+        # This is because the end_time stored with the workflow is when the workflow
+        # was marked as failed, not when the last task ended. Note that workflows can
+        # fail with waiting tasks, so we filter out any tasks that don't have a start
+        # time.
         _end_time = max(
-            task_meta["stats"].get("end_time") for task_meta in ray_task_metas
+            task_meta["stats"].get("end_time")
+            for task_meta in ray_task_metas
+            if task_meta["stats"].get("start_time")
         )
     else:
         # In all other scenarios, we can just use the end_time the workflow

--- a/src/orquestra/sdk/schema/workflow_run.py
+++ b/src/orquestra/sdk/schema/workflow_run.py
@@ -1,5 +1,5 @@
 ################################################################################
-# © Copyright 2022 Zapata Computing Inc.
+# © Copyright 2022 - 2023 Zapata Computing Inc.
 ################################################################################
 """Workflow Run model.
 
@@ -9,6 +9,7 @@ structure here is JSON-serializable.
 
 import enum
 import typing as t
+import warnings
 
 from pydantic import BaseModel
 
@@ -34,6 +35,25 @@ class State(enum.Enum):
     @classmethod
     def _missing_(cls, _):
         return cls.UNKNOWN
+
+    def is_completed(self) -> bool:
+        """
+        Check whether the state indicates that execution of the workflow run has ended.
+
+        Returns:
+            True if the execution has ended for any reason, False if the workflow run
+                is waiting or running.
+        """
+        if self == self.UNKNOWN:
+            warnings.warn("Cannot determine the workflow run state.")
+
+        return self in (
+            self.SUCCEEDED,
+            self.TERMINATED,
+            self.FAILED,
+            self.ERROR,
+            self.KILLED,
+        )
 
 
 class RunStatus(BaseModel):

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -84,6 +84,12 @@ task_state_cases = [
         (_client.WorkflowStatus.RUNNING, TEST_TIME, None, task_states, State.RUNNING)
         for task_states in task_state_cases
     ]
+    # the wf has an end time and no start time. Distrust the times and report as
+    # RUNNING.
+    + [
+        (_client.WorkflowStatus.RUNNING, None, TEST_TIME, task_states, State.RUNNING)
+        for task_states in task_state_cases
+    ]
     # the wf has a start and end time, but the status is still being reported as
     # 'running' - Ray hasn't updated the status yet. Report as SUCCEEDED.
     + [

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -65,6 +65,13 @@ task_state_cases = [
         for end in [None, TEST_TIME]
         for task_states in task_state_cases
     ]
+    # Resumable: report as FAILED
+    + [
+        (_client.WorkflowStatus.PENDING, start, end, task_states, State.WAITING)
+        for start in [None, TEST_TIME]
+        for end in [None, TEST_TIME]
+        for task_states in task_state_cases
+    ]
     # Running:
     # (defensive case for race conditions in Ray) status is running but no start time
     # reported. Report as WAITING

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -124,7 +124,7 @@ def test_workflow_state_from_ray_meta(
     mock_task_state: Mock = create_autospec(_dag._task_state_from_ray_meta)
     mock_task_state.side_effect = task_states
     mock_ray_meta = create_autospec(dict)
-    monkeypatch.setattr(_dag.__name__ + "._task_state_from_ray_meta", mock_task_state)
+    monkeypatch.setattr(_dag, "_task_state_from_ray_meta", mock_task_state)
     assert (
         _dag._workflow_state_from_ray_meta(
             ray_wf_status,

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -123,7 +123,7 @@ def test_workflow_state_from_ray_meta(
 ):
     mock_task_state: Mock = create_autospec(_dag._task_state_from_ray_meta)
     mock_task_state.side_effect = task_states
-    mock_ray_meta = create_autospec(dict)
+    mock_ray_meta = {"stats": {}}
     monkeypatch.setattr(_dag, "_task_state_from_ray_meta", mock_task_state)
     assert (
         _dag._workflow_state_from_ray_meta(

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -136,7 +136,7 @@ def test_workflow_state_from_ray_meta(
 ):
     mock_task_state: Mock = create_autospec(_dag._task_state_from_ray_meta)
     mock_task_state.side_effect = task_states
-    mock_ray_meta = {"stats": {}}
+    mock_ray_meta: dict = {"stats": {}}
     monkeypatch.setattr(_dag, "_task_state_from_ray_meta", mock_task_state)
     assert (
         _dag._workflow_state_from_ray_meta(

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -169,32 +169,35 @@ def test_workflow_state_from_ray_meta(
     # Any other workflow status, no failed flag, no start time: The task is waiting to
     # run.
     + [
-        (status, None, None, False, State.WAITING)
+        (status, None, None, failed, State.WAITING)
         for status in [
             _client.WorkflowStatus.SUCCESSFUL,
             _client.WorkflowStatus.RUNNING,
             _client.WorkflowStatus.FAILED,
         ]
+        for failed in [None, False]
     ]
     # Any other workflow status, no failed flag, a start time but no end time: The task
     # is in progress
     + [
-        (status, TEST_TIME, None, False, State.RUNNING)
+        (status, TEST_TIME, None, failed, State.RUNNING)
         for status in [
             _client.WorkflowStatus.SUCCESSFUL,
             _client.WorkflowStatus.RUNNING,
             _client.WorkflowStatus.FAILED,
         ]
+        for failed in [None, False]
     ]
     # Any other workflow status, no failed flag, start time and end time: The task
     # finished and didn't fail.
     + [
-        (status, TEST_TIME, TEST_TIME, False, State.SUCCEEDED)
+        (status, TEST_TIME, TEST_TIME, failed, State.SUCCEEDED)
         for status in [
             _client.WorkflowStatus.SUCCESSFUL,
             _client.WorkflowStatus.RUNNING,
             _client.WorkflowStatus.FAILED,
         ]
+        for failed in [None, False]
     ],
 )
 def test_task_state_from_ray_meta(

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -179,8 +179,8 @@ def test_workflow_state_from_ray_meta(
         for start in [None, TEST_TIME]
         for end in [None, TEST_TIME]
     ]
-    # Any other workflow status, no failed flag, no start time: The task is waiting to
-    # run.
+    # Any other workflow status, no failed flag, no start time, no end time: The task
+    # is waiting to run.
     + [
         (status, None, None, failed, State.WAITING)
         for status in [

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -201,6 +201,17 @@ def test_workflow_state_from_ray_meta(
         ]
         for failed in [None, False]
     ]
+    # Any other workflow status, no failed flag, no start time but an end time: The task
+    # is in progress
+    + [
+        (status, None, TEST_TIME, failed, State.WAITING)
+        for status in [
+            _client.WorkflowStatus.SUCCESSFUL,
+            _client.WorkflowStatus.RUNNING,
+            _client.WorkflowStatus.FAILED,
+        ]
+        for failed in [None, False]
+    ]
     # Any other workflow status, no failed flag, start time and end time: The task
     # finished and didn't fail.
     + [

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -65,7 +65,7 @@ task_state_cases = [
         for end in [None, TEST_TIME]
         for task_states in task_state_cases
     ]
-    # Resumable: report as FAILED
+    # Pending: report as WAITING
     + [
         (_client.WorkflowStatus.PENDING, start, end, task_states, State.WAITING)
         for start in [None, TEST_TIME]

--- a/tests/sdk/schema/test_workflow_run_model.py
+++ b/tests/sdk/schema/test_workflow_run_model.py
@@ -1,0 +1,52 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+
+"""
+Tests for the workflow run model.
+
+There are small pieces of logic contained in the workflow model schema. We test these
+here.
+"""
+
+import pytest
+
+from orquestra.sdk.schema.workflow_run import State
+
+
+class TestState:
+    class TestIsCompleted:
+        @staticmethod
+        @pytest.mark.parametrize(
+            "state",
+            [
+                State.SUCCEEDED,
+                State.TERMINATED,
+                State.FAILED,
+                State.ERROR,
+                State.KILLED,
+            ],
+        )
+        def test_returns_true_for_completed_states(state):
+            assert state.is_completed()
+
+        @staticmethod
+        @pytest.mark.parametrize("state", [State.WAITING, State.RUNNING])
+        def test_returns_false_for_non_completed_states(state):
+            assert not state.is_completed()
+
+        @staticmethod
+        def test_handles_unknown_state():
+            # GIVEN
+            state = State.UNKNOWN
+
+            # WHEN
+            with pytest.warns(UserWarning) as record:
+                assert not state.is_completed()
+
+            # THEN
+            assert len(record.list) == 1
+            assert (
+                str(record.list[0].message)
+                == "Cannot determine the workflow run state."
+            )


### PR DESCRIPTION
# The problem

When workflow fails, we immediately shut down WDR. If one task fails, we stop reporting logs and/or artifacts from other already running tasks (that might be even successful in the end). This is really confusing when other tasks have side-effects (like ml-flow logging) that suggest their completion, but CE reports them as failed

# This PR's solution

- implements `_client.save_task_postrun_metadata()` to write task metadata to WorkflowStorage.
- when tasks fail, `build_workflow` calls `_client.save_task_postrun_metadata()` to update the task metadata, along with a flag indicating that it has failed.
- The task status returned by the DAG now takes the failed flag into account. The mapping is now:
    <table>
      <tr>
        <td>wf status</td>
        <td>task failed flag</td>
        <td>task start time</td>
        <td>task end time</td>
        <td>returned task status</td>
      </tr>
      <tr>
        <td>RESUMABLE</td>
        <td colspan="3">any</td>
        <td>FAILED</td>
      </tr>
      <tr>
        <td>CANCELED</td>
        <td colspan="3">any</td>
        <td>TERMINATED</td>
      </tr>
      <tr>
        <td rowspan="5">any other status</td>
        <td>YES</td>
        <td colspan="2">any</td>
        <td>FAILED</td>
      </tr>
      <tr>
        <td rowspan="4">NO</td>
        <td>NO</td>
        <td>NO</td>
        <td>WAITING</td>
      </tr>
      <tr>
        <td>YES</td>
        <td>NO</td>
        <td>RUNNING</td>
      </tr>
      <tr>
        <td>YES</td>
        <td>YES</td>
        <td>SUCCEEDED</td>
      </tr>
      <tr>
        <td>NO</td>
        <td>YES</td>
        <td>WAITING<br>(shouldn't actually ever happen)</td>
      </tr>
    </table>
- The workflow status returned by the DAG now considers whether there are tasks that have started but not finished. The mapping is now:
    <table>
      <tr>
        <td>wf status</td>
        <td>tasks in progress</td>
        <td>wf start time</td>
        <td>wf end time</td>
        <td>returned wf status</td>
      </tr>
      <tr>
        <td rowspan="2">FAILED</td>
        <td>NO</td>
        <td colspan="2">any</td>
        <td>FAILED</td>
      </tr>
      <tr>
        <td>YES</td>
        <td colspan="2">any</td>
        <td>RUNNING</td>
      </tr>
      <tr>
        <td rowspan="4">RUNNING</td>
        <td rowspan="4">any</td>
        <td>YES</td>
        <td>YES</td>
        <td>SUCCEEDED</td>
      </tr>
      <tr>
        <td>NO</td>
        <td>NO</td>
        <td>WAITING</td>
      </tr>
      <tr>
        <td>YES</td>
        <td>NO</td>
        <td rowspan="2">RUNNING</td>
      </tr>
      <tr>
        <td>NO</td>
        <td>YES</td>
      </tr>
      <tr>
        <td>CANCELED</td>
        <td colspan="3" rowspan="4">any</td>
        <td>TERMINATED</td>
      </tr>
      <tr>
        <td>SUCCESSFUL</td>
        <td>SUCCEEDED</td>
      </tr>
      <tr>
        <td>RESUMABLE</td>
        <td>FAILED</td>
      </tr>
      <tr>
        <td>PENDING</td>
        <td>WAITING</td>
      </tr>
    </table>
    Note that WAITING tasks are not regarded as in progress for this logic.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).

[ORQSDK-934]

[ORQSDK-934]: https://zapatacomputing.atlassian.net/browse/ORQSDK-934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ