### PR TITLE
fix: sdk.Secret not pickling

### DIFF
--- a/src/orquestra/sdk/_base/_dsl.py
+++ b/src/orquestra/sdk/_base/_dsl.py
@@ -95,6 +95,12 @@ class Secret(NamedTuple):
     # specific workspace.
     workspace_id: Optional[str] = None
 
+    def __reduce__(self) -> str | tuple[Any, ...]:
+        # We need to override the pickling behaviour for Secret
+        # This is because we override other dunder methods which cause the normal
+        # picling behaviour to fail.
+        return (self.__class__, (self.name, self.config_name, self.workspace_id))
+
     def __getattr__(self, item):
         try:
             return self.__getattribute__(item)

--- a/tests/sdk/test_dsl.py
+++ b/tests/sdk/test_dsl.py
@@ -15,6 +15,7 @@ import pytest
 
 import orquestra.sdk as sdk
 from orquestra.sdk._base import _dsl, loader
+from orquestra.sdk._base.serde import deserialize_pickle, serialize_pickle
 from orquestra.sdk.exceptions import DirtyGitRepo, InvalidTaskDefinitionError
 
 DEFAULT_LOCAL_REPO_PATH = Path(__file__).parent.resolve()
@@ -761,6 +762,15 @@ class TestResources:
 
         # should not raise
         wf().model
+
+
+def test_secret_pickles():
+    secret = sdk.Secret("name", config_name="cfg", workspace_id="workspace")
+
+    pkl = serialize_pickle(secret)
+    de_pkl = deserialize_pickle(pkl)
+
+    assert secret == de_pkl
 
 
 class TestSecretAsString:


### PR DESCRIPTION
# The problem

A previous (unreleased) PR broke the Pickling of `sdk.Secret`.

# This PR's solution

Adds a `__reduce__` method on `sdk.Secret` that allows `sdk.Secret` to be pickled.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
