### PR TITLE
chore: add missing mypy stubs.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -119,5 +119,7 @@ dev =
     ruff
     scikit-learn
     types-psutil
+    types-Pygments
     types-requests
+    types-setuptools
     types-tabulate


### PR DESCRIPTION
# The problem

After a clean dev install of the sdk, mypy was missing a few library stubs:

```
venv/lib/python3.9/site-packages/rich/traceback.py:23: error: Library stubs not installed for "pygments.lexers"  [import]
venv/lib/python3.9/site-packages/rich/traceback.py:23: note: Hint: "python3 -m pip install types-Pygments"
venv/lib/python3.9/site-packages/rich/traceback.py:24: error: Library stubs not installed for "pygments.token"  [import]
venv/lib/python3.9/site-packages/rich/traceback.py:27: error: Library stubs not installed for "pygments.util"  [import]
venv/lib/python3.9/site-packages/_pytest/_io/terminalwriter.py:201: error: Library stubs not installed for "pygments.formatters.terminal"  [import]
venv/lib/python3.9/site-packages/_pytest/_io/terminalwriter.py:203: error: Library stubs not installed for "pygments"  [import]
venv/lib/python3.9/site-packages/ray/_private/parameter.py:4: error: Library stubs not installed for "pkg_resources"  [import]
venv/lib/python3.9/site-packages/ray/_private/utils.py:1761: error: Library stubs not installed for "pkg_resources._vendor.packaging.version"  [import]
venv/lib/python3.9/site-packages/ray/__init__.py:27: error: Library stubs not installed for "pkg_resources"  [import]
venv/lib/python3.9/site-packages/ray/__init__.py:27: note: Hint: "python3 -m pip install types-setuptools"
venv/lib/python3.9/site-packages/ray/__init__.py:27: note: (or run "mypy --install-types" to install all missing stub packages)
venv/lib/python3.9/site-packages/ray/__init__.py:27: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
venv/lib/python3.9/site-packages/ray/air/util/tensor_extensions/arrow.py:5: error: Library stubs not installed for "pkg_resources._vendor.packaging.version"  [import]
venv/lib/python3.9/site-packages/ray/air/_internal/remote_storage.py:8: error: Library stubs not installed for "pkg_resources"  [import]
venv/lib/python3.9/site-packages/ray/data/_internal/util.py:65: error: Library stubs not installed for "pkg_resources._vendor.packaging.version"  [import]
venv/lib/python3.9/site-packages/ray/data/_internal/arrow_block.py:187: error: Library stubs not installed for "pkg_resources._vendor.packaging.version"  [import]
venv/lib/python3.9/site-packages/ray/rllib/algorithms/algorithm.py:13: error: Library stubs not installed for "pkg_resources"  [import]
venv/lib/python3.9/site-packages/_pytest/monkeypatch.py:308: error: Library stubs not installed for "pkg_resources"  [import]
Found 14 errors in 11 files (checked 219 source files)
```

# This PR's solution

Adds the missing stubs to our dev install requirements.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
