### PR TITLE
docs: make requirement of matching orquestra-sdk versions explicit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,6 @@
 
 * Fixed formatting errors in docstrings preventing them from rendering correctly in docs.
 * Updated the "Dependency Installation" guide to reflect the requirement of matching `orquestra-sdk` versions between worker and head nodes.
-* ```
 
 ## v0.56.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,8 @@
 📃 *Docs*
 
 * Fixed formatting errors in docstrings preventing them from rendering correctly in docs.
-* Updated the Dependency Installation guide to reflect the requirement of matching `orquestra-sdk` versions betweek worker and head nodes.
+* Updated the "Dependency Installation" guide to reflect the requirement of matching `orquestra-sdk` versions between worker and head nodes.
+* ```
 
 ## v0.56.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 📃 *Docs*
 
 * Fixed formatting errors in docstrings preventing them from rendering correctly in docs.
+* Updated the Dependency Installation guide to reflect the requirement of matching `orquestra-sdk` versions betweek worker and head nodes.
 
 ## v0.56.0
 

--- a/docs/guides/dependency-installation.rst
+++ b/docs/guides/dependency-installation.rst
@@ -39,7 +39,7 @@ The following sections give a more complete explanation of these importers and t
      - * Works well as a ``dependency_imports=[...]`` addition to ``InlineImport`` to allow using 3rd-party libraries.
        * Best suited for referencing libraries available on `PyPI <https://pypi.org/>`_ like ``torch``.
      - * Can't be reliably used to refer to an unpublished, WIP projects.
-     - * Be cautious when including ``orquestra-sdk`` as a dependency - the version installed inside the task *must* match the version used to submit the workflow.
+       * Be cautious when including ``orquestra-sdk`` as a dependency - the version installed inside the task *must* match the version used to submit the workflow.
 
    * - ``GithubImport``
      - * Well-suited for unpublished, WIP projects.

--- a/docs/guides/dependency-installation.rst
+++ b/docs/guides/dependency-installation.rst
@@ -186,6 +186,8 @@ The required packages can be specified as arguments, or listed in a ``requiremen
     Consequently, it is possible to create a situation where the environment that executes the task and the environment that submits a task have different versions of ``orquestra-sdk`` installed.
     This will cause workflow runs to fail!
 
+    Note that this also applies to transitive dependencies - if you depend on a package with a strict dependency on an older version of ``orquestra-sdk`` then the mismatch will arise even if you don't declare a dependency on ``orquestra-sdk`` directly.
+
 
 
 ``GithubImport`` With A Private Repo

--- a/docs/guides/dependency-installation.rst
+++ b/docs/guides/dependency-installation.rst
@@ -39,6 +39,7 @@ The following sections give a more complete explanation of these importers and t
      - * Works well as a ``dependency_imports=[...]`` addition to ``InlineImport`` to allow using 3rd-party libraries.
        * Best suited for referencing libraries available on `PyPI <https://pypi.org/>`_ like ``torch``.
      - * Can't be reliably used to refer to an unpublished, WIP projects.
+     - * Be cautious when including ``orquestra-sdk`` as a dependency - the version installed inside the task *must* match the version used to submit the workflow.
 
    * - ``GithubImport``
      - * Well-suited for unpublished, WIP projects.
@@ -178,6 +179,13 @@ The required packages can be specified as arguments, or listed in a ``requiremen
     :end-before: </snippet>
     :language: python
     :dedent: 8
+
+.. warning::
+    Take care when declaring ``orquestra-sdk`` as a dependency!
+    ``PythonImports`` allows you to install any available python package in the environment that executes the task.
+    Consequently, it is possible to create a situation where the environment that executes the task and the environment that submits a task have different versions of ``orquestra-sdk`` installed.
+    This will cause workflow runs to fail!
+
 
 
 ``GithubImport`` With A Private Repo


### PR DESCRIPTION
[ORQSDK-938]

# The problem

It’s possible to install an incompatible version of orquestra-sdk inside the runtime environment of tasks.

The outcome of https://zapatacomputing.atlassian.net/browse/ORQSDK-848 was to make a REQUIREMENT that the version of orquestra-sdk inside tasks  is the same as on the head node (i.e. the version of orquestra-sdk that submitted the workflow).

We should let our users know that this is a requirement.

# This PR's solution

Adds language to the docs making this requirement clear and warning against creating mismatches.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


[ORQSDK-938]: https://zapatacomputing.atlassian.net/browse/ORQSDK-938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ