### PR TITLE
feat!:  add orquestra sdk head node current version as a requirement in ray runtime environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 🚨 *Breaking Changes*
 
+* The `orquestra-sdk` version used to submit a workflow is automatically added as a dependency for task execution environments. Consequently, specifying the SDK as a dependency in the `sdk.task()` decorator is no longer supported, and such declarations will be ignored.
+
 🔥 *Features*
 
 🧟 *Deprecations*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 🚨 *Breaking Changes*
 
-* The `orquestra-sdk` version used to submit a workflow is automatically added as a dependency for task execution environments. Consequently, specifying the SDK as a dependency in the `sdk.task()` decorator is no longer supported, and such declarations will be ignored.
+* The `orquestra-sdk` version used to submit a workflow is automatically added as a dependency for task execution environments. Specifying the SDK as a dependency in the `sdk.task()` decorator will be ignored.
 
 🔥 *Features*
 

--- a/docs/guides/dependency-installation.rst
+++ b/docs/guides/dependency-installation.rst
@@ -39,7 +39,6 @@ The following sections give a more complete explanation of these importers and t
      - * Works well as a ``dependency_imports=[...]`` addition to ``InlineImport`` to allow using 3rd-party libraries.
        * Best suited for referencing libraries available on `PyPI <https://pypi.org/>`_ like ``torch``.
      - * Can't be reliably used to refer to an unpublished, WIP projects.
-       * Be cautious when including ``orquestra-sdk`` as a dependency - the version installed inside the task *must* match the version used to submit the workflow.
 
    * - ``GithubImport``
      - * Well-suited for unpublished, WIP projects.
@@ -92,7 +91,7 @@ See also `Imports In Detail`_ for more info about each one.
       # file: setup.cfg
       [options]
       install_requires =
-          orquestra-sdk>=0.51.0
+          scikit-learn~=1.3.1
           torch~=2.0
 
 
@@ -112,7 +111,7 @@ See also `Imports In Detail`_ for more info about each one.
       # file: setup.cfg
       [options]
       install_requires =
-          orquestra-sdk>=0.51.0
+          scikit-learn~=1.3.1
           torch~=2.0
 
 
@@ -180,13 +179,10 @@ The required packages can be specified as arguments, or listed in a ``requiremen
     :language: python
     :dedent: 8
 
-.. warning::
-    Take care when declaring ``orquestra-sdk`` as a dependency!
-    ``PythonImports`` allows you to install any available python package in the environment that executes the task.
-    Consequently, it is possible to create a situation where the environment that executes the task and the environment that submits a task have different versions of ``orquestra-sdk`` installed.
-    This will cause workflow runs to fail!
-
-    Note that this also applies to transitive dependencies - if you depend on a package with a strict dependency on an older version of ``orquestra-sdk`` then the mismatch will arise even if you don't declare a dependency on ``orquestra-sdk`` directly.
+.. note::
+    The surrent version of Orquestra SDK (i.e. the one being used to submit the workflow) is automatically included as a dependency for the task execution environments.
+    This is to prevent version mismatches between the various nodes.
+    Declarations of ``orquestra-sdk`` as a dependency will be ignored.
 
 
 
@@ -225,7 +221,7 @@ The remote runtime clones the repo and pip-installs the project when the workflo
    # file: setup.cfg
    [options]
    install_requires =
-       orquestra-sdk>=0.51.0
+       as a dependency
        torch~=2.0
 
 

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -502,7 +502,7 @@ class TaskLogMessage(pydantic.BaseModel):
     """Represents a single line indexed by the server side log service.
 
     Based on:
-    https://github.com/zapatacomputing/workflow-driver/blob/f55bd3d5203a42ee42fc2405cd44cfaa94993f4a/openapi/src/resources/task-run-logs.yaml#L16
+    https://github.com/zapatacomputing/workflow-driver/blob/c7685a579eca1f9cb3eb27e2a8c2a9757a3cd021/openapi/src/resources/task-run-logs.yaml#L16
 
     The name is borrowed from Fluent Bit nomenclature:
     https://docs.fluentbit.io/manual/concepts/key-concepts#event-format.

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -502,7 +502,7 @@ class TaskLogMessage(pydantic.BaseModel):
     """Represents a single line indexed by the server side log service.
 
     Based on:
-    https://github.com/zapatacomputing/workflow-driver/blob/c7685a579eca1f9cb3eb27e2a8c2a9757a3cd021/openapi/src/resources/task-run-logs.yaml#L16
+    https://github.com/zapatacomputing/workflow-driver/blob/f55bd3d5203a42ee42fc2405cd44cfaa94993f4a/openapi/src/resources/task-run-logs.yaml#L16
 
     The name is borrowed from Fluent Bit nomenclature:
     https://docs.fluentbit.io/manual/concepts/key-concepts#event-format.

--- a/src/orquestra/sdk/_base/_regex.py
+++ b/src/orquestra/sdk/_base/_regex.py
@@ -12,4 +12,4 @@ BUILD_METADATA = r"[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*"
 # VERSION_REGEX and SEMVER_REGEX are the same:
 # however, SEMVER_REGEX matches an entire line and includes group names.
 VERSION_REGEX = rf"({VERSION_NUMBER})\.({VERSION_NUMBER})\.({VERSION_NUMBER})(?:[-\.]({PRERELEASE}))?(?:\+({BUILD_METADATA}))?"  # noqa: E501
-SEMVER_REGEX = rf"^(?P<major>{VERSION_NUMBER})\.(?P<minor>{VERSION_NUMBER})\.(?P<patch>{VERSION_NUMBER})(?:[-\.](?P<prerelease>{PRERELEASE}))?(?:\+(?P<buildmetadata>{BUILD_METADATA}))?$"  # noqa: E501
+SEMVER_REGEX = rf"^(?P<major>{VERSION_NUMBER})\.(?P<minor>{VERSION_NUMBER})(?:\.(?P<patch>{VERSION_NUMBER}))?(?:[-\.](?P<prerelease>{PRERELEASE}))?(?:\+(?P<buildmetadata>{BUILD_METADATA}))?$"  # noqa: E501

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -8,11 +8,12 @@ import time
 import typing as t
 import warnings
 from functools import singledispatch
-from orquestra.sdk.packaging import get_installed_version
 from pathlib import Path
 
 import pydantic
 from typing_extensions import assert_never
+
+from orquestra.sdk.packaging import get_installed_version
 
 from .. import exceptions, secrets
 from .._base import _exec_ctx, _git_url_utils, _graphs, _services, dispatch, serde

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -342,10 +342,10 @@ def _import_pip_env(
 ) -> t.List[str]:
     """Gather a list of python imports required for the task.
 
-    The list will consist of the python imports declared in the task definition, and the
-    current Orquestra SDK version.
-    The latter is included to prevent tasks from executing with different SDK versions
-    to the head node.
+    Returns:
+        A list consisting of the python imports declared in the task definition, and the
+            current Orquestra SDK version. The latter is included to prevent tasks from
+            executing with different SDK versions to the head node.
     """
     task_def = wf.tasks[ir_invocation.task_id]
     imports = [

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -359,7 +359,7 @@ def _import_pip_env(
             *(task_def.dependency_import_ids or []),
         )
     ]
-    sdk_version = version("orquestra-sdk")
+    sdk_version = get_installed_version("orquestra-sdk")
 
     sdk_dependency = None
     pip_list = [

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -363,7 +363,7 @@ def _import_pip_env(
         )
     ]
 
-    current_sdk_version: t.Optional[str] = get_installed_version("orquestra-sdk")
+    current_sdk_version: str = get_installed_version("orquestra-sdk")
 
     sdk_dependency = None
     pip_list = [

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -390,6 +390,7 @@ def _import_pip_env(
 def _normalise_prerelease_version(version: str) -> str:
     """Remove prerelease version information from the version string."""
     match = re.match(SEMVER_REGEX, version)
+    assert match, f"Version {version} did not parse as valid SemVer."
     if match.group("prerelease"):
         return (
             f"{match.group('major')}"

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -378,7 +378,7 @@ def _import_pip_env(
             f"The current SDK version ({sdk_version}) is automatically installed in "
             "task environments. "
             "The specified dependency will be ignored.",
-            DeprecationWarning,
+            exceptions.OrquestraSDKVersionMismatchWarning,
         )
 
     return pip_list + [f"orquestra-sdk=={sdk_version}"]

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -342,6 +342,10 @@ def _import_pip_env(
 ) -> t.List[str]:
     """Gather a list of python imports required for the task.
 
+    Args:
+        ir_invocation: The task invocation to be executed in this environment.
+        wf: The overall workflow definition.
+
     Returns:
         A list consisting of the python imports declared in the task definition, and the
             current Orquestra SDK version. The latter is included to prevent tasks from

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -391,13 +391,13 @@ def _normalise_prerelease_version(version: str) -> str:
     """Remove prerelease version information from the version string."""
     match = re.match(SEMVER_REGEX, version)
     assert match, f"Version {version} did not parse as valid SemVer."
+    vernums = [int(match.group("major")), int(match.group("minor"))]
+    if match.group("patch"):
+        vernums.append(int(match.group("patch")))
     if match.group("prerelease"):
-        return (
-            f"{match.group('major')}"
-            f".{match.group('minor')}"
-            f".{int(match.group('patch')) - 1}"
-        )
-    return f"{match.group('major')}.{match.group('minor')}.{match.group('patch')}"
+        vernums[-1] -= 1
+
+    return ".".join([str(vernum) for vernum in vernums])
 
 
 def _gather_args(arg_ids, workflow_def, ray_futures):

--- a/src/orquestra/sdk/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_ray/_build_workflow.py
@@ -8,7 +8,7 @@ import time
 import typing as t
 import warnings
 from functools import singledispatch
-from importlib.metadata import version
+from orquestra.sdk.packaging import get_installed_version
 from pathlib import Path
 
 import pydantic

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -211,6 +211,10 @@ class WorkflowRunIDNotFoundError(NotFoundError):
     # We have a workflow but can't recover the ID: WorkflowRunIDNotFoundError
 
 
+class OrquestraSDKVersionMismatchWarning(Warning):
+    """Raised when there are multiple SDK dependency declarations for one task env."""
+
+
 # Auth Errors
 class UnauthorizedError(BaseRuntimeError):
     """Raised when the remote cluster rejects the auth token."""

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -433,9 +433,9 @@ def make_workflow_with_dependencies(deps):
 @pytest.mark.parametrize(
     "installed_sdk_version, expected_sdk_dependency",
     [
-        ("0.57.1.dev3+g3ef9f57.d20231003", "==0.57.0"),
-        ("1.2.3", "==1.2.3"),
-        ("0.1.dev1+g25df81e", ""),
+        ("0.57.1.dev3+g3ef9f57.d20231003", None),
+        ("1.2.3", "1.2.3"),
+        ("0.1.dev1+g25df81e", None),
     ],
 )
 class TestHandlingSDKVersions:
@@ -464,7 +464,10 @@ class TestHandlingSDKVersions:
         pip = _build_workflow._import_pip_env(task_inv, wf)
 
         # Then
-        assert pip == [f"orquestra-sdk{expected_sdk_dependency}"]
+        if expected_sdk_dependency:
+            assert pip == [f"orquestra-sdk=={expected_sdk_dependency}"]
+        else:
+            assert pip == []
 
     @staticmethod
     @pytest.mark.parametrize(
@@ -493,9 +496,12 @@ class TestHandlingSDKVersions:
         pip = _build_workflow._import_pip_env(task_inv, wf)
 
         # Then
-        assert sorted(pip) == sorted(
-            python_imports + [f"orquestra-sdk{expected_sdk_dependency}"]
-        )
+        if expected_sdk_dependency:
+            assert sorted(pip) == sorted(
+                python_imports + [f"orquestra-sdk=={expected_sdk_dependency}"]
+            )
+        else:
+            assert sorted(pip) == sorted(python_imports)
 
     @pytest.mark.parametrize(
         "sdk_import",
@@ -548,9 +554,12 @@ class TestHandlingSDKVersions:
             pip = _build_workflow._import_pip_env(task_inv, wf)
 
             # Then
-            assert sorted(pip) == sorted(
-                python_imports + [f"orquestra-sdk{expected_sdk_dependency}"]
-            )
+            if expected_sdk_dependency:
+                assert sorted(pip) == sorted(
+                    python_imports + [f"orquestra-sdk=={expected_sdk_dependency}"]
+                )
+            else:
+                assert sorted(pip) == sorted(python_imports)
 
         @staticmethod
         @pytest.mark.filterwarnings("error")

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -507,7 +507,9 @@ class TestHandlingSDKVersions:
     class TestHandlesSDKDependency:
         @staticmethod
         @pytest.mark.filterwarnings("ignore:The definition for task ")
-        def test_replaces_declared_sdk_dependency(sdk_import, python_imports, mock_sdk_version):
+        def test_replaces_declared_sdk_dependency(
+            sdk_import, python_imports, mock_sdk_version
+        ):
             # Given
             wf = make_workflow_with_dependencies(
                 [sdk.PythonImports(*python_imports + [sdk_import])]

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -455,7 +455,6 @@ class TestHandlingSDKVersions:
 
         # Then
         assert pip == [f"orquestra-sdk=={mock_sdk_version}"]
-        assert False
 
     @staticmethod
     @pytest.mark.parametrize(

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -495,7 +495,7 @@ class TestHandlingSDKVersions:
             ["MarkupSafe==1.0.0", "Jinja2==2.7.2"],
         ],
     )
-    class TestHandlesSDkDependency:
+    class TestHandlesSDKDependency:
         @staticmethod
         @pytest.mark.filterwarnings("ignore:The definition for task ")
         def test_replaces_declared_SDK_dependency(sdk_import, python_imports):

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -431,7 +431,11 @@ def make_workflow_with_dependencies(deps):
 
 @pytest.mark.parametrize(
     "installed_sdk_version, expected_sdk_dependency",
-    [("0.57.1.dev3+g3ef9f57.d20231003", "0.57.0"), ("1.2.3", "1.2.3")],
+    [
+        ("0.57.1.dev3+g3ef9f57.d20231003", "0.57.0"),
+        ("1.2.3", "1.2.3"),
+        ("0.1.dev1+g25df81e", "0.0"),
+    ],
 )
 class TestHandlingSDKVersions:
     """``_import_pip_env`` handles adding the current SDK version as a dependency.

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -456,7 +456,7 @@ class TestHandlingSDKVersions:
             ["MarkupSafe==1.0.0", "Jinja2==2.7.2"],
         ],
     )
-    def test_with_multiple_dependentest_with_dependencies(python_imports: List[str]):
+    def test_with_multiple_dependencies(python_imports: List[str]):
         # Given
         wf = make_workflow_with_dependencies([sdk.PythonImports(*python_imports)]).model
         task_inv = [inv for inv in iter_invocations_topologically(wf)][0]

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -13,6 +13,7 @@ from orquestra.sdk._base._testing._example_wfs import (
     workflow_parametrised_with_resources,
 )
 from orquestra.sdk._ray import _build_workflow, _client
+from orquestra.sdk.exceptions import OrquestraSDKVersionMismatchWarning
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.responses import WorkflowResult
 
@@ -535,13 +536,14 @@ class TestHandlingSDKVersions:
             task_inv = [inv for inv in iter_invocations_topologically(wf)][0]
 
             # When
-            with pytest.raises(DeprecationWarning) as e:
+            with pytest.raises(OrquestraSDKVersionMismatchWarning) as e:
                 _ = _build_workflow._import_pip_env(task_inv, wf)
 
             # Then
             warning: str = e.exconly()
             assert warning.startswith(
-                "DeprecationWarning: The definition for task `task-hello-orquestra-"
+                "orquestra.sdk.exceptions.OrquestraSDKVersionMismatchWarning: "
+                "The definition for task `task-hello-orquestra-"
             )
             assert warning.endswith(
                 f"` declares `{sdk_import.replace(' ', '')}` as a dependency. "

--- a/tests/runtime/ray/test_build_workflow.py
+++ b/tests/runtime/ray/test_build_workflow.py
@@ -498,7 +498,7 @@ class TestHandlingSDKVersions:
     class TestHandlesSDKDependency:
         @staticmethod
         @pytest.mark.filterwarnings("ignore:The definition for task ")
-        def test_replaces_declared_SDK_dependency(sdk_import, python_imports):
+        def test_replaces_declared_sdk_dependency(sdk_import, python_imports):
             # Given
             wf = make_workflow_with_dependencies(
                 [sdk.PythonImports(*python_imports + [sdk_import])]

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -67,7 +67,7 @@ def _poll_loop(
         time.sleep(interval)
 
 
-def _wait_to_finish_wf(run_id: str, runtime: RuntimeInterface, timeout=10.0):
+def _wait_to_finish_wf(run_id: str, runtime: RuntimeInterface, timeout=20.0):
     def _continue_condition():
         state = runtime.get_workflow_run_status(run_id).status.state
         return state in [

--- a/tests/sdk/test_consistent_return_shapes.py
+++ b/tests/sdk/test_consistent_return_shapes.py
@@ -592,6 +592,8 @@ class TestCLIDownloadDir:
         run_id_ray = m.group("run_id").strip()
         assert mock_ce_run_single in run_ce.stdout.decode()
 
+        sdk.WorkflowRun.by_id(run_id_ray).wait_until_finished()
+
         # WHEN
         run_ray = subprocess.run(
             [
@@ -604,9 +606,11 @@ class TestCLIDownloadDir:
                 "local",
                 run_id_ray,
             ],
-            check=True,
             capture_output=True,
         )
+        assert (
+            run_ray.returncode == 0
+        ), f"STDOUT: {run_ray.stdout.decode()}\n\nSTDERR: {run_ray.stderr.decode()}"
         run_ce = subprocess.run(
             [
                 "orq",
@@ -618,9 +622,11 @@ class TestCLIDownloadDir:
                 "CE",
                 mock_ce_run_single,
             ],
-            check=True,
             capture_output=True,
         )
+        assert (
+            run_ce.returncode == 0
+        ), f"STDOUT: {run_ce.stdout.decode()}\n\nSTDERR: {run_ce.stderr.decode()}"
 
         # THEN
         with open(


### PR DESCRIPTION
# The problem

When a workflow runs on CE/Ray, there is a head node and worker nodes. The head node will use the version of orquestra-sdk in the environment that launched Ray (or `orq up`). Each worker can install a new python environment per task.

It’s possible for the dependencies of a task to install the wrong version of orquestra-sdk inside a worker, e.g. by a wrong custom image or via poorly defined PythonImports.

The outcome of ORQSDK-848 was to add orquestra-sdk==<head node version>to the runtime environment of all tasks.

If a different version is brought in via the user’s imports, pip will complain and will quit. See the ADR in 848 for more details.

# This PR's solution

Adds the currently installed[^1] SDK version to the runtime environment pip requirements.

[^1]: In order to avoid trying to install `orquestra-sdk==0.57.1.dev3+g3ef9f57.d20231003`, we strip out prerelease versioning (in this example, the correct dependency `orquestra-sdk==0.57.0` would be added instead). This creates an issue in our CI where the installed SDK version detected by setuptools is `0.1-dev...`. I've therefore implemented an escape hatch where rather than the semantically nonsensical `orquestra-sdk==0.0`, this case adds `orquestra-sdk` without a version. This somewhat compromises the intent of this PR, but I can't think of a scenario outside our CI where this scenario would occur.

As a result of this change, specifying the SDK in the task dependencies is now meaningless - it will always be installed regardless of what you do. Therefore, before adding the current version to the list we check for a dependency on the SDK and, if it's there, remove it from the list and warn the user that it has been overruled. This means that rather than getting a pip error when listing the SDK as a requirement, the user gets an informative message and the workflow runs as intended. This is intended to reduce the confusion of pip telling them that there are multiple clashing requirements when they've only specified one.

I've also updated the `dependency installation` guide so it no longer indicates that people can specify sdk versions in their dependencies.



# Supplemental

I've also had to increase the polling timeout for integration tests - all tasks now require _at minimum_ the SDK to install, so they take a little longer.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).

[ORQSDK-937]

[ORQSDK-937]: https://zapatacomputing.atlassian.net/browse/ORQSDK-937?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ