### PR TITLE
chore: fix space around arithmetic operators.

### DIFF
--- a/docs/examples/tests/test_parametrized_workflows.py
+++ b/docs/examples/tests/test_parametrized_workflows.py
@@ -153,4 +153,4 @@ class TestSnippets:
         proc.check_returncode()
         std_out = str(proc.stdout, "utf-8")
         for i in range(5):
-            assert f"{i*2+1}" in std_out
+            assert f"{i * 2 + 1}" in std_out

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -406,8 +406,8 @@ def migrate_config_file():
     print(
         f"Successfully migrated file {_config_file_path} to version "
         f"{CONFIG_FILE_CURRENT_VERSION}. "
-        f"Updated {len(changed)} entr{'y' if len(changed)==1 else 'ies'}"
-        f"{'.' if len(changed)==0 else ':'}"
+        f"Updated {len(changed)} entr{'y' if len(changed) == 1 else 'ies'}"
+        f"{'.' if len(changed) == 0 else ':'}"
     )
     for config_name in changed:
         print(f" - {config_name}")

--- a/tests/cli/ui/test_presenters.py
+++ b/tests/cli/ui/test_presenters.py
@@ -58,7 +58,7 @@ class TestLogsPresenter:
             line = "─" * CONSOLE_WIDTH
             if prefix is None:
                 return line
-            return f"{prefix} {line[len(prefix)+1:]}"
+            return f"{prefix} {line[len(prefix) + 1:]}"
 
         return _inner
 

--- a/tests/sdk/test_ast.py
+++ b/tests/sdk/test_ast.py
@@ -1,5 +1,5 @@
 ################################################################################
-# © Copyright 2022 Zapata Computing Inc.
+# © Copyright 2022 - 2023 Zapata Computing Inc.
 ################################################################################
 import ast
 import inspect
@@ -45,7 +45,7 @@ def function_with_calls():
     print(artifact.custom_name)
     artifact.with_resources(cpu="2000m")
     for ii in range(5):
-        artifact.with_resources(cpu=f"{ii*5}000m")
+        artifact.with_resources(cpu=f"{ii * 5}000m")
 
 
 # Calls inside the 'function_with_calls' function


### PR DESCRIPTION
# The problem

Ruff doesn't like arithmetic operators without whitespace.

# This PR's solution

Adds whitespace to the offending expressions.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
