### PR TITLE
docs: reference revised schema for TaskLogMessage.

### DIFF
--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -502,7 +502,7 @@ class TaskLogMessage(pydantic.BaseModel):
     """Represents a single line indexed by the server side log service.
 
     Based on:
-    https://github.com/zapatacomputing/workflow-driver/blob/c7685a579eca1f9cb3eb27e2a8c2a9757a3cd021/openapi/src/resources/task-run-logs.yaml#L16
+    https://github.com/zapatacomputing/workflow-driver/blob/f55bd3d5203a42ee42fc2405cd44cfaa94993f4a/openapi/src/resources/task-run-logs.yaml#L16
 
     The name is borrowed from Fluent Bit nomenclature:
     https://docs.fluentbit.io/manual/concepts/key-concepts#event-format.


### PR DESCRIPTION
[ORQSDK-958]

# The problem

In [OP-253](https://zapatacomputing.atlassian.net/browse/OP-253) , a new field was documented in the OpenAPI spec.

We use this field in our code already. We should add a reference to this field in our code.

# This PR's solution

References the new revision (https://github.com/zapatacomputing/workflow-driver/blob/f55bd3d5203a42ee42fc2405cd44cfaa94993f4a/openapi/src/resources/task-run-logs.yaml#L16) in TaskLogMessage.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


[ORQSDK-958]: https://zapatacomputing.atlassian.net/browse/ORQSDK-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-253]: https://zapatacomputing.atlassian.net/browse/OP-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ