### PR TITLE
feat: normalize end time for terminated workflows in SDK

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,7 @@ dev =
     diff_cover
     flake8>=4.0.0
     Flake8-pyproject>=1.2.3
+    freezegun
     isort~=5.9.0
     mlflow-skinny # Required for testing snippets in docs.
     mypy~=0.910  # bumping caused issues - ORQSDK-966

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -546,8 +546,6 @@ class RayRuntime(RuntimeInterface):
         This brought some issues on Workflow Driver, we so fill up the missing status
         fields with the current datetime for all terminated tasks and workflow.
         """
-        # TODO use SDK's dates module:
-        # https://zapatacomputing.atlassian.net/browse/ORQSDK-943
         now: _dates.Instant = _dates.now()
         new_model = model.copy(deep=True)
 

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -534,12 +534,12 @@ class RayRuntime(RuntimeInterface):
         )
 
         if model.status.state.is_completed():
-            model = self._normalize_endtime(model)
+            model = self._normalize_endtimes(model)
 
         return model
 
     @staticmethod
-    def _normalize_endtime(model: WorkflowRun) -> WorkflowRun:
+    def _normalize_endtimes(model: WorkflowRun) -> WorkflowRun:
         """Set the current time as end_time for tasks and workflows that don't have one.
 
         Ray doesn't provide an end time for terminated tasks and workflows.

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -478,7 +478,7 @@ class RayRuntime(RuntimeInterface):
 
         if wf_status == _client.WorkflowStatus.FAILED:
             # Set the default message. This is the fallback in case we can't determine
-            # any more precide information.
+            # any more precise information.
             message = (
                 "The workflow encountered an issue. "
                 "Please consult the logs for more information. "
@@ -509,7 +509,7 @@ class RayRuntime(RuntimeInterface):
                     )
                     break
 
-        return WorkflowRun(
+        model = WorkflowRun(
             id=workflow_run_id,
             workflow_def=wf_def,
             task_runs=[
@@ -532,6 +532,35 @@ class RayRuntime(RuntimeInterface):
             ),
             message=message,
         )
+
+        if model.status.state.is_completed():
+            model = self._normalize_endtime(model)
+
+        return model
+
+    @staticmethod
+    def _normalize_endtime(model: WorkflowRun) -> WorkflowRun:
+        """Set the current time as end_time for tasks and workflows that don't have one.
+
+        Ray doesn't provide an end time for terminated tasks and workflows.
+        This brought some issues on Workflow Driver, we so fill up the missing status
+        fields with the current datetime for all terminated tasks and workflow.
+        """
+        # TODO use SDK's dates module:
+        # https://zapatacomputing.atlassian.net/browse/ORQSDK-943
+        now: _dates.Instant = _dates.now()
+        new_model = model.copy(deep=True)
+
+        if model.status.start_time is not None and model.status.end_time is None:
+            assert now >= model.status.start_time
+            new_model.status.end_time = now
+
+        for task in new_model.task_runs:
+            if task.status.start_time is not None and task.status.end_time is None:
+                assert now >= task.status.start_time
+                task.status.end_time = now
+
+        return new_model
 
     def get_workflow_run_outputs_non_blocking(
         self, workflow_run_id: WorkflowRunId

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -12,9 +12,11 @@ import re
 import sys
 import time
 import typing as t
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
@@ -167,13 +169,14 @@ class TestRayRuntimeMethods:
                 res,
             )
 
+    @pytest.mark.parametrize("trial", range(5))
+    @pytest.mark.usefixtures("trial")
     class TestGetWorkflowRunStatus:
         """
         Tests that validate .get_workflow_run_status().
         """
 
-        @pytest.mark.parametrize("trial", range(5))
-        def test_status_right_after_start(self, runtime: _dag.RayRuntime, trial):
+        def test_status_right_after_start(self, runtime: _dag.RayRuntime):
             """
             Verifies that we report status correctly before workflow ends.
             It's difficult to synchronize, so there's a bunch of ifs in this
@@ -218,8 +221,7 @@ class TestRayRuntimeMethods:
                     assert status.start_time is not None
                     assert status.end_time is not None
 
-        @pytest.mark.parametrize("trial", range(5))
-        def test_status_after_awaiting(self, runtime: _dag.RayRuntime, trial):
+        def test_status_after_awaiting(self, runtime: _dag.RayRuntime):
             """
             Verifies that we report status correctly when all tasks are
             completed.
@@ -263,12 +265,60 @@ class TestRayRuntimeMethods:
                 # during start and finish of a task. Thus it is >=, not >
                 assert (status.end_time - status.start_time).total_seconds() >= 0
 
+        @freeze_time("9999-01-01")
+        def test_normalizes_end_times(self, runtime: _dag.RayRuntime):
+            # Given
+            wf_def = _example_wfs.serial_wf_with_slow_middle_task.model
+            run_id = runtime.create_workflow_run(wf_def, None, False)
+            runtime.stop_workflow_run(run_id)
+
+            # Block until wf completes
+            _wait_to_finish_wf(run_id, runtime)
+
+            # When
+            run = runtime.get_workflow_run_status(run_id)
+
+            # Then
+            assert run.id == run_id
+            assert (
+                run.status.state == State.TERMINATED
+            ), f"Invalid state. Full status: {run.status}. Task runs: {run.task_runs}"
+            assert run.status.start_time is not None
+            assert run.status.end_time is not None
+            assert run.workflow_def == wf_def
+
+            # The added end times should be 'now'
+            assert run.status.end_time == datetime(9999, 1, 1, tzinfo=timezone.utc)
+            # freeze_time doesn't affect the ray process, so the start times
+            # are real and therefore earlier than the end time (if this is
+            # untrue, hello from the distant past).
+            assert run.status.start_time < run.status.end_time
+
+            for task_run in run.task_runs:
+                assert task_run.invocation_id in wf_def.task_invocations.keys()
+
+                status = task_run.status
+
+                # We're only interested in tasks that were terminated while in process.
+                if not (
+                    task_run.status.state == State.TERMINATED
+                    and status.start_time is not None
+                ):
+                    continue
+
+                assert status.end_time is not None
+                assert status.start_time.tzinfo is not None
+                assert status.end_time.tzinfo is not None
+                assert (status.end_time - status.start_time).total_seconds() >= 0
+                assert task_run.status.end_time == datetime(
+                    9999, 1, 1, tzinfo=timezone.utc
+                )
+
         @pytest.mark.skipif(
             sys.platform.startswith("win32"), reason="File writing on windows is slow."
         )
-        @pytest.mark.parametrize("trial", range(5))
         def test_handles_ray_environment_setup_error(
-            self, runtime: _dag.RayRuntime, trial, shared_ray_conn
+            self, runtime: _dag.RayRuntime, shared_ray_conn
         ):
             # Given
             wf_def = _example_wfs.cause_env_setup_error.model

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -295,8 +295,6 @@ class TestRayRuntimeMethods:
             assert run.status.start_time < run.status.end_time
 
             for task_run in run.task_runs:
-                assert task_run.invocation_id in wf_def.task_invocations.keys()
-
                 status = task_run.status
 
                 # We're only interested in tasks that were terminated while in process.


### PR DESCRIPTION
# The problem

Ray doesn't provide end time for terminated tasks and workflows. We had to write [a workaround in WDR.](https://github.com/zapatacomputing/workflow-driver-ray/blob/3aa7f9c92336f9a9e7758ee61faf258bef70cfbe/src/driver/_statuses.py#L10)

It’s difficult to test. We have an integration test in WDR, but it’s difficult to maintain.

# This PR's solution

Implements the WDR heuristic in the SDK.

In persuading mypy to be happy about the changes, I think I also ended up implementing [ORQSDK-943](https://zapatacomputing.atlassian.net/browse/ORQSDK-943). If so, please confirm and I'll remove the TODO.

[This PR](https://github.com/zapatacomputing/workflow-driver-ray/pull/83) removes the heuristic from WDR.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).

[ORQSDK-960]

[ORQSDK-943]: https://zapatacomputing.atlassian.net/browse/ORQSDK-943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ORQSDK-960]: https://zapatacomputing.atlassian.net/browse/ORQSDK-960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ