### PR TITLE
feat!: bump Dockerfiles to Python 3.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 * The `orquestra-sdk` version used to submit a workflow is automatically added as a dependency for task execution environments. Specifying the SDK as a dependency in the `sdk.task()` decorator will be ignored.
+* The base image for workflows is now Python 3.11.6. Submitting a remote workflow with this version of the SDK with a different version of Python may result in failed workflows.
 
 🔥 *Features*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.5
 # Base image for running Orquestra tasks.
 # Published at hub.nexus.orquestra.io/zapatacomputing/orquestra-sdk-base
-FROM python:3.9-slim-bullseye
+FROM python:3.11.6-slim-bullseye
 ARG SDK_REQUIREMENT
 
 # Set by BuildKit


### PR DESCRIPTION
# The problem
We want to switch the default image from Python 3.9 to 3.11.

# This PR's solution

- Updates the CPU `orquestra-sdk-base` to build from `python:3.11.6-slim-bullseye`.
- Rewrites the GPU `orquestra-sdk-base` to build from `nvidia/cuda:11.8.0-runtime-ubuntu22.04` and installs Python 3.11.6 via Pyenv. This is based on an internal QML image.

I've tested both of these images by building and deploying the new head node from these base images (see release docs) and using the the dev versions of these images as the `custom_image` inside the task decorator.

I still need to confirm GPUs are actually working because AFAIK the cluster I tested on is CPU only. Awaiting confirmation...

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
