### PR TITLE
chore: Bump coverage Python and remove Windows coverage tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -26,8 +26,8 @@ jobs:
     # Run jobs for a couple of Python versions and OSes.
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-        python: ["3.8", "3.9"]
+        os: ["ubuntu-latest"]
+        python: ["3.9", "3.10", "3.11"]
         # Extend the matrix with a job that prints coverage.
         # Because { os: "ubuntu-latest", python: "3.9" } is already in the matrix,
         # print_coverage: true is added to that job.

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,11 +29,11 @@ jobs:
         os: ["ubuntu-latest"]
         python: ["3.9", "3.10", "3.11"]
         # Extend the matrix with a job that prints coverage.
-        # Because { os: "ubuntu-latest", python: "3.9" } is already in the matrix,
+        # Because { os: "ubuntu-latest", python: "3.11" } is already in the matrix,
         # print_coverage: true is added to that job.
         include:
           - os: "ubuntu-latest"
-            python: "3.9"
+            python: "3.11"
             print_coverage: true
 
     timeout-minutes: 25

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,7 +26,7 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.8", "3.9"]
+        python: ["3.9", "3.10", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
     timeout-minutes: 25

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,5 +4,8 @@ log_cli=True
 markers =
    slow: Tests that take long time to run locally. Skipped by 'make test-fast'.
 # By default, treat warnings as errors
+# TODO(ORQSDK-992): Remove this filter when we figure out what to do with pip_api
+# pip_api imports `sre_constants`, however it's marked as deprecated in Python 3.11
 filterwarnings =
     error
+    ignore:module 'sre_constants' is deprecated:DeprecationWarning

--- a/src/orquestra/sdk/schema/configs.py
+++ b/src/orquestra/sdk/schema/configs.py
@@ -17,6 +17,9 @@ class RuntimeName(str, Enum):
     QE_REMOTE = "QE_REMOTE"
     IN_PROCESS = "IN_PROCESS"
 
+    def __format__(self, format_spec: str) -> str:
+        return format(self.value, format_spec)
+
 
 RemoteRuntime = Literal[RuntimeName.CE_REMOTE]
 

--- a/tests/runtime/ray/data/python_package/python_package_dependent_workflow.json
+++ b/tests/runtime/ray/data/python_package/python_package_dependent_workflow.json
@@ -1,106 +1,106 @@
 {
-    "name": "wf",
-    "fn_ref": {
-        "module": "__main__",
-        "function_name": "wf",
-        "file_path": "tests/runtime/ray/data/python_package/original_workflow.py",
-        "line_number": 18,
-        "type": "MODULE_FUNCTION_REF"
+  "name": "wf",
+  "fn_ref": {
+    "module": "__main__",
+    "function_name": "wf",
+    "file_path": "original_workflow.py",
+    "line_number": 18,
+    "type": "MODULE_FUNCTION_REF"
+  },
+  "imports": {
+    "inline-import-1": {
+      "id": "inline-import-1",
+      "type": "INLINE_IMPORT"
     },
-    "imports": {
-        "inline-import-1": {
-            "id": "inline-import-1",
-            "type": "INLINE_IMPORT"
-        },
-        "python-import-dac5d03ef0": {
-            "id": "python-import-dac5d03ef0",
-            "packages": [
-                {
-                    "name": "polars",
-                    "extras": [],
-                    "version_constraints": [
-                        "==0.17.3"
-                    ],
-                    "environment_markers": ""
-                }
-            ],
-            "pip_options": [],
-            "type": "PYTHON_IMPORT"
+    "python-import-bd8cf950ad": {
+      "id": "python-import-bd8cf950ad",
+      "packages": [
+        {
+          "name": "polars",
+          "extras": [],
+          "version_constraints": [
+            "==0.17.3"
+          ],
+          "environment_markers": ""
         }
-    },
-    "tasks": {
-        "task-my-fn-6d73c7e55a": {
-            "id": "task-my-fn-6d73c7e55a",
-            "fn_ref": {
-                "function_name": "my_fn",
-                "encoded_function": [
-                    "gASVYwQAAAAAAACMF2Nsb3VkcGlja2xlLmNsb3VkcGlja2xllIwOX21ha2VfZnVuY3Rpb26Uk5Qo\naACMDV9idWlsdGluX3R5cGWUk5SMCENvZGVUeXBllIWUUpQoSwFLAEsASwFLAktDQwh8AKAAoQBT\nAJROhZSMBGl0ZW2UhZSMAmRmlIWUjIUvVXNlcnMvYWxleC9Db2RlL3phcGF0YS9ldmFuZ2VsaXNt\nLXdvcmtmbG93cy92ZW5kb3Ivb3JxdWVzdHJhLXdvcmtmbG93LXNkay90ZXN0cy9ydW50aW1lL3Jh\neS9kYXRhL3B5dGhvbl9wYWNrYWdlL29yaWdpbmFsX3dvcmtmbG93LnB5lIwFbXlfZm6USwpDAgAF\nlCkpdJRSlH2UKIwLX19wYWNrYWdlX1+UTowIX19uYW1lX1+UjAhfX21haW5fX5SMCF9fZmlsZV9f\nlGgOdU5OTnSUUpSMHGNsb3VkcGlja2xlLmNsb3VkcGlja2xlX2Zhc3SUjBJfZnVuY3Rpb25fc2V0\nc3RhdGWUk5RoGX2UKIwXX1Rhc2tEZWZfX3Nka190YXNrX2JvZHmUaBmMB19mbl9yZWaUjBhvcnF1\nZXN0cmEuc2RrLl9iYXNlLl9kc2yUjBFJbmxpbmVGdW5jdGlvblJlZpSTlGgPaBmGlIGUjAhfZm5f\nbmFtZZRoD4wQX291dHB1dF9tZXRhZGF0YZRoIIwSVGFza091dHB1dE1ldGFkYXRhlJOUiUsBhpSB\nlIwLX3BhcmFtZXRlcnOUjAtjb2xsZWN0aW9uc5SMC09yZGVyZWREaWN0lJOUKVKUaAxoIIwNVGFz\na1BhcmFtZXRlcpSTlGgMaCCMDVBhcmFtZXRlcktpbmSUk5SMFVBPU0lUSU9OQUxfT1JfS0VZV09S\nRJSFlFKUhpSBlHOMCl9yZXNvdXJjZXOUaCCMCVJlc291cmNlc5STlChOTk5OTnSUgZSMDV9jdXN0\nb21faW1hZ2WUTowMX2N1c3RvbV9uYW1llE6ME19kZXBlbmRlbmN5X2ltcG9ydHOUaCCMDVB5dGhv\nbkltcG9ydHOUk5QpgZR9lCiMBV9maWxllE6MCV9wYWNrYWdlc5SMDnBvbGFycz09MC4xNy4zlIWU\ndWKFlIwfX3VzZV9kZWZhdWx0X2RlcGVuZGVuY3lfaW1wb3J0c5SJjA5fc291cmNlX2ltcG9ydJRo\nIIwMSW5saW5lSW1wb3J0lJOUKYGUjBpfdXNlX2RlZmF1bHRfc291cmNlX2ltcG9ydJSJdX2UKGgV\naA+MDF9fcXVhbG5hbWVfX5RoD4wPX19hbm5vdGF0aW9uc19flH2UjA5fX2t3ZGVmYXVsdHNfX5RO\njAxfX2RlZmF1bHRzX1+UTowKX19tb2R1bGVfX5RoFowHX19kb2NfX5ROjAtfX2Nsb3N1cmVfX5RO\njBdfY2xvdWRwaWNrbGVfc3VibW9kdWxlc5RdlIwLX19nbG9iYWxzX1+UfZR1hpSGUjAu\n"
-                ],
-                "type": "INLINE_FUNCTION_REF"
-            },
-            "parameters": [
-                {
-                    "name": "df",
-                    "kind": "POSITIONAL_OR_KEYWORD"
-                }
-            ],
-            "output_metadata": {
-                "is_subscriptable": false,
-                "n_outputs": 1
-            },
-            "source_import_id": "inline-import-1",
-            "dependency_import_ids": [
-                "python-import-dac5d03ef0"
-            ]
-        }
-    },
-    "artifact_nodes": {
-        "artifact-0-my-fn": {
-            "id": "artifact-0-my-fn",
-            "serialization_format": "AUTO"
-        }
-    },
-    "constant_nodes": {
-        "constant-0": {
-            "id": "constant-0",
-            "chunks": [
-                "gASVeAAAAAAAAACMFnBvbGFycy5kYXRhZnJhbWUuZnJhbWWUjAlEYXRhRnJhbWWUk5QpgZRdlIwU\ncG9sYXJzLnNlcmllcy5zZXJpZXOUjAZTZXJpZXOUk5QpgZRDIKNkbmFtZWFhaGRhdGF0eXBlZUlu\ndDY0ZnZhbHVlc4EVlGJhYi4=\n"
-            ],
-            "serialization_format": "ENCODED_PICKLE",
-            "value_preview": "shape: (1, 1"
-        }
-    },
-    "secret_nodes": {},
-    "task_invocations": {
-        "invocation-0-task-my-fn": {
-            "id": "invocation-0-task-my-fn",
-            "task_id": "task-my-fn-6d73c7e55a",
-            "args_ids": [
-                "constant-0"
-            ],
-            "kwargs_ids": {},
-            "output_ids": [
-                "artifact-0-my-fn"
-            ]
-        }
-    },
-    "output_ids": [
-        "artifact-0-my-fn"
-    ],
-    "metadata": {
-        "sdk_version": {
-            "original": "0.47.1.dev21+g54ad067",
-            "major": 0,
-            "minor": 47,
-            "patch": 1,
-            "is_prerelease": true
-        },
-        "python_version": {
-            "original": "3.9.16 (main, May  8 2023, 17:01:20) \n[Clang 14.0.3 (clang-1403.0.22.14.1)]",
-            "major": 3,
-            "minor": 9,
-            "patch": 16,
-            "is_prerelease": false
-        }
+      ],
+      "pip_options": [],
+      "type": "PYTHON_IMPORT"
     }
+  },
+  "tasks": {
+    "task-my-fn-40bbab0916": {
+      "id": "task-my-fn-40bbab0916",
+      "fn_ref": {
+        "function_name": "my_fn",
+        "encoded_function": [
+          "gASVqAQAAAAAAACMF2Nsb3VkcGlja2xlLmNsb3VkcGlja2xllIwOX21ha2VfZnVuY3Rpb26Uk5Qo\naACMDV9idWlsdGluX3R5cGWUk5SMCENvZGVUeXBllIWUUpQoSwFLAEsASwFLAksDQyqXAHwAoAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAKYAAACrAAAAAAAAAAAAUwCUToWUjARpdGVtlIWUjAJkZpSFlIx8\nL1VzZXJzL2phbWVzY2xhcmsvRG9jdW1lbnRzL2NvZGUvcHl0aG9uMzExL29ycXVlc3RyYS13b3Jr\nZmxvdy1zZGsvdGVzdHMvcnVudGltZS9yYXkvZGF0YS9weXRob25fcGFja2FnZS9vcmlnaW5hbF93\nb3JrZmxvdy5weZSMBW15X2ZulGgPSwpDEoAA8AoADA6PN4o3iTmMOdAEFJRDAJQpKXSUUpR9lCiM\nC19fcGFja2FnZV9flE6MCF9fbmFtZV9flIwIX19tYWluX1+UjAhfX2ZpbGVfX5RoDnVOTk50lFKU\njBxjbG91ZHBpY2tsZS5jbG91ZHBpY2tsZV9mYXN0lIwSX2Z1bmN0aW9uX3NldHN0YXRllJOUaBp9\nlCiMF19UYXNrRGVmX19zZGtfdGFza19ib2R5lGgajAdfZm5fcmVmlIwYb3JxdWVzdHJhLnNkay5f\nYmFzZS5fZHNslIwRSW5saW5lRnVuY3Rpb25SZWaUk5RoD2gahpSBlIwIX2ZuX25hbWWUaA+MEF9v\ndXRwdXRfbWV0YWRhdGGUaCGMElRhc2tPdXRwdXRNZXRhZGF0YZSTlIlLAYaUgZSMC19wYXJhbWV0\nZXJzlIwLY29sbGVjdGlvbnOUjAtPcmRlcmVkRGljdJSTlClSlGgMaCGMDVRhc2tQYXJhbWV0ZXKU\nk5RoDIwIYnVpbHRpbnOUjAdnZXRhdHRylJOUaCGMDVBhcmFtZXRlcktpbmSUk5SMFVBPU0lUSU9O\nQUxfT1JfS0VZV09SRJSGlFKUhpSBlHOMCl9yZXNvdXJjZXOUaCGMCVJlc291cmNlc5STlChOTk5O\nTnSUgZSMDV9jdXN0b21faW1hZ2WUTowMX2N1c3RvbV9uYW1llE6ME19kZXBlbmRlbmN5X2ltcG9y\ndHOUaCGMDVB5dGhvbkltcG9ydHOUk5QpgZR9lCiMBV9maWxllE6MCV9wYWNrYWdlc5SMDnBvbGFy\ncz09MC4xNy4zlIWUdWKFlIwfX3VzZV9kZWZhdWx0X2RlcGVuZGVuY3lfaW1wb3J0c5SJjA5fc291\ncmNlX2ltcG9ydJRoIYwMSW5saW5lSW1wb3J0lJOUKYGUjBpfdXNlX2RlZmF1bHRfc291cmNlX2lt\ncG9ydJSJdX2UKGgWaA+MDF9fcXVhbG5hbWVfX5RoD4wPX19hbm5vdGF0aW9uc19flH2UjA5fX2t3\nZGVmYXVsdHNfX5ROjAxfX2RlZmF1bHRzX1+UTowKX19tb2R1bGVfX5RoF4wHX19kb2NfX5ROjAtf\nX2Nsb3N1cmVfX5ROjBdfY2xvdWRwaWNrbGVfc3VibW9kdWxlc5RdlIwLX19nbG9iYWxzX1+UfZR1\nhpSGUjAu\n"
+        ],
+        "type": "INLINE_FUNCTION_REF"
+      },
+      "parameters": [
+        {
+          "name": "df",
+          "kind": "POSITIONAL_OR_KEYWORD"
+        }
+      ],
+      "output_metadata": {
+        "is_subscriptable": false,
+        "n_outputs": 1
+      },
+      "source_import_id": "inline-import-1",
+      "dependency_import_ids": [
+        "python-import-bd8cf950ad"
+      ]
+    }
+  },
+  "artifact_nodes": {
+    "artifact-0-my-fn": {
+      "id": "artifact-0-my-fn",
+      "serialization_format": "AUTO"
+    }
+  },
+  "constant_nodes": {
+    "constant-0": {
+      "id": "constant-0",
+      "chunks": [
+        "gASVeAAAAAAAAACMFnBvbGFycy5kYXRhZnJhbWUuZnJhbWWUjAlEYXRhRnJhbWWUk5QpgZRdlIwU\ncG9sYXJzLnNlcmllcy5zZXJpZXOUjAZTZXJpZXOUk5QpgZRDIKNkbmFtZWFhaGRhdGF0eXBlZUlu\ndDY0ZnZhbHVlc4EVlGJhYi4=\n"
+      ],
+      "serialization_format": "ENCODED_PICKLE",
+      "value_preview": "shape: (1, 1"
+    }
+  },
+  "secret_nodes": {},
+  "task_invocations": {
+    "invocation-0-task-my-fn": {
+      "id": "invocation-0-task-my-fn",
+      "task_id": "task-my-fn-40bbab0916",
+      "args_ids": [
+        "constant-0"
+      ],
+      "kwargs_ids": {},
+      "output_ids": [
+        "artifact-0-my-fn"
+      ]
+    }
+  },
+  "output_ids": [
+    "artifact-0-my-fn"
+  ],
+  "metadata": {
+    "sdk_version": {
+      "original": "0.57.1.dev8+g1768a3b.d20231024",
+      "major": 0,
+      "minor": 57,
+      "patch": 1,
+      "is_prerelease": true
+    },
+    "python_version": {
+      "original": "3.11.4 (main, Jun 29 2023, 18:06:53) [Clang 14.0.0 (clang-1400.0.29.202)]",
+      "major": 3,
+      "minor": 11,
+      "patch": 4,
+      "is_prerelease": false
+    }
+  }
 }

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -698,6 +698,7 @@ class Test3rdPartyLibraries:
     # likely to be different from the one we're using for development. The SDK shows a
     # warning when deserializing a workflow def like this.
     @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="Pickle internals changed in Python 3.11")
     def test_constants_and_inline_imports(runtime: _dag.RayRuntime):
         """
         This test uses already generated workflow def from json file. If necessary, it

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -698,7 +698,9 @@ class Test3rdPartyLibraries:
     # likely to be different from the one we're using for development. The SDK shows a
     # warning when deserializing a workflow def like this.
     @pytest.mark.filterwarnings("ignore::orquestra.sdk.exceptions.VersionMismatch")
-    @pytest.mark.skipif(sys.version_info < (3, 11), reason="Pickle internals changed in Python 3.11")
+    @pytest.mark.skipif(
+        sys.version_info < (3, 11), reason="Pickle internals changed in Python 3.11"
+    )
     def test_constants_and_inline_imports(runtime: _dag.RayRuntime):
         """
         This test uses already generated workflow def from json file. If necessary, it


### PR DESCRIPTION
# The problem

We're targeting Python 3.11 so we need to test on it.
Windows tests are broken and we don't plan on fixing them.

# This PR's solution

Bump Python version.
Remove Windows tests

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
