### PR TITLE
feat: find config by querying runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 
 💅 *Improvements*
 
+* When the user doesn't pass `config` directly to `sdk.WorkflowRun.by_id(run_id="...")` and `orq` commands, the SDK will query all known runtimes about this workflow run. This change improves accessing workflow runs submitted by other users.
+
 🥷 *Internal*
 
 📃 *Docs*

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -20,6 +20,8 @@ from ...exceptions import (
     ConfigFileNotFoundError,
     ConfigNameNotFoundError,
     ProjectInvalidError,
+    RayNotRunningError,
+    RuntimeQuerySummaryError,
     UnauthorizedError,
     VersionMismatch,
     WorkflowRunCanNotBeTerminated,
@@ -99,12 +101,16 @@ class WorkflowRun:
                 the current working directory is assumed to be the project directory.
 
         Raises:
-            orquestra.sdk.exceptions.WorkflowRunNotFoundError: when the run_id doesn't
-                match a stored run ID.
-            orquestra.sdk.exceptions.UnauthorizedError: when authorization with the
-                remote runtime failed.
+            orquestra.sdk.exceptions.RuntimeQuerySummaryError: when ``config``
+                wasn't passed, and it wasn't possible to infer the runtime
+                matching ``wf_run_id``.
+            orquestra.sdk.exceptions.WorkflowRunNotFoundError: when ``config`` was
+                passed, but a matching workflow run couldn't be found.
+            orquestra.sdk.exceptions.UnauthorizedError: when ``config`` was passed,
+                but authorization with the remote runtime failed when getting the run
+                details.
             orquestra.sdk.exceptions.ConfigFileNotFoundError: when the config file
-                couldn't be read
+                couldn't be read.
             orquestra.sdk.exceptions.ConfigNameNotFoundError: when there's no
                 corresponding config entry in the config file.
         """
@@ -113,17 +119,17 @@ class WorkflowRun:
         # Resolve config
         resolved_config: RuntimeConfig
         if config is None:
-            # Shorthand: use the cached value.
-            # We need to read the config name from the local DB and load the config
-            # entry.
+            # Shorthand: query all known runtimes.
             try:
-                stored_run = cls._get_stored_run(_project_dir, run_id)
-            except WorkflowRunNotFoundError:
-                raise
-
-            try:
-                resolved_config = RuntimeConfig.load(stored_run.config_name)
-            except (ConfigFileNotFoundError, ConfigNameNotFoundError):
+                resolved_config = _ask_runtimes_for_config(
+                    wf_run_id=run_id,
+                    project_dir=_project_dir,
+                )
+            except (
+                RuntimeQuerySummaryError,
+                ConfigNameNotFoundError,
+                ConfigFileNotFoundError,
+            ):
                 raise
         else:
             resolved_config = resolve_config(config)
@@ -603,6 +609,63 @@ def _handle_common_listing_project_errors(
     # Null project - it is ignored by platform anyway - left as parameter for
     # backward compatibility only
     return None
+
+
+def _ask_runtimes_for_config(
+    wf_run_id: WorkflowRunId, project_dir: Path
+) -> RuntimeConfig:
+    not_found_configs: t.List[RuntimeConfig] = []
+    unauthorized_configs: t.List[RuntimeConfig] = []
+    not_running_configs: t.List[RuntimeConfig] = []
+
+    config_names = RuntimeConfig.list_configs()
+    for config_name in config_names:
+        config_obj = RuntimeConfig.load(config_name)
+        try:
+            runtime = config_obj._get_runtime(project_dir)
+        except RayNotRunningError:
+            # Ray connection is set up in `RayRuntime.__init__()`. We'll get the
+            # exception when runtime object is created.
+            not_running_configs.append(config_obj)
+            continue
+
+        try:
+            _ = runtime.get_workflow_run_status(wf_run_id)
+        except WorkflowRunNotFoundError:
+            not_found_configs.append(config_obj)
+            continue
+        except UnauthorizedError:
+            # TODO (ORQSDK-990): short circuit remote call by checking token validity
+            # on the client side
+            unauthorized_configs.append(config_obj)
+            continue
+
+        # We're here = the runtime knows about this run ID.
+        return config_obj
+
+    raise RuntimeQuerySummaryError(
+        wf_run_id=wf_run_id,
+        not_found_runtimes=[_make_runtime_info(config) for config in not_found_configs],
+        unauthorized_runtimes=[
+            _make_runtime_info(config) for config in unauthorized_configs
+        ],
+        not_running_runtimes=[
+            _make_runtime_info(config) for config in not_running_configs
+        ],
+    )
+
+
+def _make_runtime_info(config: RuntimeConfig) -> RuntimeQuerySummaryError.RuntimeInfo:
+    # TODO: add public properties to config
+    try:
+        uri = getattr(config, "uri")
+    except AttributeError:
+        uri = None
+    return RuntimeQuerySummaryError.RuntimeInfo(
+        runtime_name=config._runtime_name,
+        config_name=config.name,
+        server_uri=uri,
+    )
 
 
 def list_workflow_run_summaries(

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -121,7 +121,7 @@ class WorkflowRun:
         if config is None:
             # Shorthand: query all known runtimes.
             try:
-                resolved_config = _ask_runtimes_for_config(
+                resolved_config = _find_config_for_workflow(
                     wf_run_id=run_id,
                     project_dir=_project_dir,
                 )
@@ -611,7 +611,7 @@ def _handle_common_listing_project_errors(
     return None
 
 
-def _ask_runtimes_for_config(
+def _find_config_for_workflow(
     wf_run_id: WorkflowRunId, project_dir: Path
 ) -> RuntimeConfig:
     not_found_configs: t.List[RuntimeConfig] = []
@@ -656,7 +656,6 @@ def _ask_runtimes_for_config(
 
 
 def _make_runtime_info(config: RuntimeConfig) -> RuntimeQuerySummaryError.RuntimeInfo:
-    # TODO: add public properties to config
     try:
         uri = getattr(config, "uri")
     except AttributeError:

--- a/src/orquestra/sdk/_base/cli/_arg_resolvers.py
+++ b/src/orquestra/sdk/_base/cli/_arg_resolvers.py
@@ -112,17 +112,11 @@ class WFConfigResolver:
             return config
 
         if wf_run_id is not None:
-            # 1.1. Attempt to get config from local cache.
-            try:
-                stored_name = self._wf_run_repo.get_config_name_by_run_id(wf_run_id)
-                return stored_name
-            except exceptions.WorkflowRunNotFoundError:
-                # Ignore the exception and roll over to the "else" branch. We
-                # need to ask the user for the config.
-                pass
-
-        # 1.2. Prompt the user
-        return ConfigResolver(self._config_repo, self._prompter).resolve(config)
+            # 1.1. Attempt to find config by querying all runtimes.
+            return self._wf_run_repo.get_config_name_by_run_id(wf_run_id)
+        else:
+            # 1.2. Prompt the user
+            return ConfigResolver(self._config_repo, self._prompter).resolve(config)
 
 
 class SpacesResolver:

--- a/src/orquestra/sdk/_base/cli/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_repos.py
@@ -19,12 +19,11 @@ from typing_extensions import assert_never
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
-from orquestra.sdk._base import _config, _dates, _db, loader
+from orquestra.sdk._base import _config, _dates, loader
 from orquestra.sdk._base._driver._client import DriverClient, ExternalUriProvider
 from orquestra.sdk._base._jwt import check_jwt_without_signature_verification
 from orquestra.sdk._base._logs._interfaces import LogOutput, WorkflowLogs
 from orquestra.sdk._base.abc import ArtifactValue
-from orquestra.sdk.exceptions import WorkflowRunNotFoundError
 from orquestra.sdk.schema import _compat
 from orquestra.sdk.schema.configs import (
     ConfigName,
@@ -59,15 +58,36 @@ class WorkflowRunRepo:
             wf_run_id: ID of the workflow run.
 
         Raises:
-            orquestra.sdk.exceptions.WorkflowRunNotFoundError: when a matching record
-                couldn't be found.
+            orquestra.sdk.exceptions.RuntimeQuerySummaryError: when it wasn't possible
+                to infer the runtime matching ``wf_run_id``.
+            orquestra.sdk.exceptions.WorkflowRunNotFoundError: when it wasn't possible
+                to fetch run details.
+            orquestra.sdk.exceptions.UnauthorizedError: when authorization with the
+                remote runtime failed when getting the run details.
+            orquestra.sdk.exceptions.ConfigFileNotFoundError: when the config file
+                couldn't be read.
+            orquestra.sdk.exceptions.ConfigNameNotFoundError: when there's no
+                corresponding config entry in the config file.
         """
-        with _db.WorkflowDB.open_db() as db:
-            try:
-                stored_run = db.get_workflow_run(workflow_run_id=wf_run_id)
-            except WorkflowRunNotFoundError:
-                raise
-            return stored_run.config_name
+        try:
+            run = sdk.WorkflowRun.by_id(wf_run_id)
+        except (
+            exceptions.ConfigNameNotFoundError,
+            exceptions.ConfigFileNotFoundError,
+            exceptions.WorkflowRunNotFoundError,
+            exceptions.UnauthorizedError,
+            exceptions.RuntimeQuerySummaryError,
+        ):
+            raise
+        assert run.config is not None, (
+            "Workflow run without a config. It's only possible for in-process "
+            "runtime. However, it should never be a result of using by_id()"
+        )
+        # TODO: find when config name is None.
+        assert (
+            run.config.name is not None
+        ), "Config without a name. This shouldn't happen in normal circumstances"
+        return run.config.name
 
     def list_wf_run_summaries(
         self,

--- a/src/orquestra/sdk/_base/cli/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_repos.py
@@ -83,7 +83,6 @@ class WorkflowRunRepo:
             "Workflow run without a config. It's only possible for in-process "
             "runtime. However, it should never be a result of using by_id()"
         )
-        # TODO: find when config name is None.
         assert (
             run.config.name is not None
         ), "Config without a name. This shouldn't happen in normal circumstances"

--- a/src/orquestra/sdk/_base/cli/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_errors.py
@@ -176,3 +176,9 @@ def _(e: exceptions.WorkflowRunNotStarted) -> ResponseStatusCode:
 def _(e: exceptions.QERemoved) -> ResponseStatusCode:
     click.echo(e)
     return ResponseStatusCode.CONNECTION_ERROR
+
+
+@pretty_print_exception.register
+def _(e: exceptions.RuntimeQuerySummaryError) -> ResponseStatusCode:
+    click.echo(e)
+    return ResponseStatusCode.WORKFLOW_RUN_NOT_FOUND

--- a/src/orquestra/sdk/_base/cli/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_errors.py
@@ -6,6 +6,9 @@ import traceback
 from functools import singledispatch
 
 import click
+from rich.box import SIMPLE_HEAVY
+from rich.console import Console
+from rich.table import Column, Table
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base._config import IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_ALIAS
@@ -180,5 +183,35 @@ def _(e: exceptions.QERemoved) -> ResponseStatusCode:
 
 @pretty_print_exception.register
 def _(e: exceptions.RuntimeQuerySummaryError) -> ResponseStatusCode:
-    click.echo(e)
+    first_string = (
+        "Couldn't find a config that knows about workflow run ID "
+        f"[bold]{e.wf_run_id}[/bold]"
+    )
+    summary_table = Table(
+        Column("Config name", style="bold", justify="right"),
+        Column("Reason"),
+        box=SIMPLE_HEAVY,
+    )
+
+    for config in e.not_found_runtimes:
+        if config.config_name is not None:
+            summary_table.add_row(config.config_name, "Workflow run not found")
+
+    for config in e.unauthorized_runtimes:
+        if config.config_name is not None:
+            summary_table.add_row(
+                config.config_name, "Authorization error " "- Login expired"
+            )
+
+    for config in e.not_running_runtimes:
+        if config.config_name is not None:
+            summary_table.add_row(config.config_name, "Not running")
+
+    last_string = (
+        "Please make sure that the workflow ID is correct, "
+        "and you're logged in to the correct cluster.\n"
+    )
+
+    Console().print(first_string, summary_table, last_string)
+
     return ResponseStatusCode.WORKFLOW_RUN_NOT_FOUND

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -5,8 +5,9 @@
 """Custom exceptions for the SDK."""
 
 import typing as t
+from dataclasses import dataclass
 
-from orquestra.sdk.schema import ir
+from orquestra.sdk.schema import configs, ir
 from orquestra.sdk.schema.workflow_run import State, TaskInvocationId, WorkflowRunId
 
 
@@ -177,6 +178,51 @@ class WorkflowRunNotFoundError(NotFoundError):
     """Raised when no run with the specified ID is found."""
 
     pass
+
+
+class RuntimeQuerySummaryError(NotFoundError):
+    """Raised when of the queried runtimes could find this workflow run.
+
+    We need this class on the Python API layer to produce a pretty-printed visual
+    output in the CLI.
+
+    Args:
+        wf_run_id: identifier of the workflow run we were looking for.
+        not_found_runtimes: runtimes we queried and the reponse was "this workflow run
+            is not found"
+        unauthorized_runtimes: runtimes we queried and the reponse was "you're not
+            authorized to access this resource"
+        not_running_runtimes: runtimes we queried but the cluster wasn't running
+    """
+
+    @dataclass(frozen=True)
+    class RuntimeInfo:
+        runtime_name: configs.RuntimeName
+        config_name: t.Optional[configs.ConfigName]
+        server_uri: t.Optional[str]
+
+    def __init__(
+        self,
+        wf_run_id: WorkflowRunId,
+        not_found_runtimes: t.Sequence[RuntimeInfo],
+        unauthorized_runtimes: t.Sequence[RuntimeInfo],
+        not_running_runtimes: t.Sequence[RuntimeInfo],
+    ):
+        not_found_configs = [info.config_name for info in not_found_runtimes]
+        unauthorized_configs = [info.config_name for info in unauthorized_runtimes]
+        not_running_configs = [info.config_name for info in not_running_runtimes]
+        super().__init__(
+            message=(
+                "Couldn't find any runtime that knows about this workflow run ID. "
+                f"Runtimes with 'not found' response: {not_found_configs}. "
+                f"Runtimes with 'unauthorized' response: {unauthorized_configs}. "
+                f"Runtimes that weren't up: {not_running_configs}."
+            )
+        )
+        self.wf_run_id = wf_run_id
+        self.not_found_runtimes = not_found_runtimes
+        self.unauthorized_runtimes = unauthorized_runtimes
+        self.not_running_runtimes = not_running_runtimes
 
 
 class WorkflowRunNotStarted(WorkflowRunNotFoundError):

--- a/src/orquestra/sdk/exceptions.py
+++ b/src/orquestra/sdk/exceptions.py
@@ -213,10 +213,11 @@ class RuntimeQuerySummaryError(NotFoundError):
         not_running_configs = [info.config_name for info in not_running_runtimes]
         super().__init__(
             message=(
-                "Couldn't find any runtime that knows about this workflow run ID. "
-                f"Runtimes with 'not found' response: {not_found_configs}. "
-                f"Runtimes with 'unauthorized' response: {unauthorized_configs}. "
-                f"Runtimes that weren't up: {not_running_configs}."
+                "Couldn't find a config that knows about workflow run ID"
+                f" {wf_run_id} \n"
+                f"Configs with 'not found' response: {not_found_configs}.\n"
+                f"Configs with 'unauthorized' response: {unauthorized_configs}.\n"
+                f"Configs that weren't up: {not_running_configs}."
             )
         )
         self.wf_run_id = wf_run_id

--- a/tests/cli/test_arg_resolvers.py
+++ b/tests/cli/test_arg_resolvers.py
@@ -290,10 +290,10 @@ class TestWFConfigResolver:
             prompter.choice.assert_not_called()
 
         @staticmethod
-        def test_foreign_wf_run_id_passed():
+        def test_wf_not_found_in():
             """
             Example use case: ``orq wf stop wf-run`` but we've never logged in to this
-            cluster.
+            cluster or there is typo in wf-run-id
             """
             # Given
             wf_run_id = "<wf run ID sentinel>"

--- a/tests/cli/test_arg_resolvers.py
+++ b/tests/cli/test_arg_resolvers.py
@@ -13,7 +13,7 @@ from orquestra.sdk._base._logs._interfaces import LogOutput, WorkflowLogs
 from orquestra.sdk._base._spaces._structs import Project, Workspace
 from orquestra.sdk._base.cli import _arg_resolvers, _repos
 from orquestra.sdk._base.cli._ui import _presenters, _prompts
-from orquestra.sdk.schema.configs import RuntimeConfiguration
+from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
 from orquestra.sdk.schema.workflow_run import RunStatus, State
 
 
@@ -292,44 +292,57 @@ class TestWFConfigResolver:
         @staticmethod
         def test_foreign_wf_run_id_passed():
             """
-            Example use case: ``orq wf stop other-colleagues-wf-run``. We don't have
-            this workflow in the local DB, but it doesn't mean the workflow doesn't
-            exist on the cluster. We should ask the user for the config and proceed
-            with the action.
+            Example use case: ``orq wf stop wf-run`` but we've never logged in to this
+            cluster.
             """
             # Given
             wf_run_id = "<wf run ID sentinel>"
             config = None
 
-            config_repo = Mock()
+            config_repo = create_autospec(_repos.ConfigRepo)
             local_config_names = ["cfg1", "cfg2"]
             config_repo.list_config_names.return_value = local_config_names
 
-            wf_run_repo = Mock()
-            wf_run_repo.get_config_name_by_run_id.side_effect = (
-                exceptions.WorkflowRunNotFoundError()
+            # Set up workflow run repo. It raises RuntimeQuerySummaryError. All known
+            # runtimes have been queried, but none can be used to interact with this
+            # workflow run.
+            wf_run_repo = create_autospec(_repos.WorkflowRunRepo)
+            rt_info1 = exceptions.RuntimeQuerySummaryError.RuntimeInfo(
+                runtime_name=RuntimeName.RAY_LOCAL,
+                config_name="ray",
+                server_uri=None,
             )
-
-            prompter = Mock()
-            selected_config = local_config_names[1]
-            prompter.choice.return_value = selected_config
+            rt_info2 = exceptions.RuntimeQuerySummaryError.RuntimeInfo(
+                runtime_name=RuntimeName.CE_REMOTE,
+                config_name=local_config_names[0],
+                server_uri="foo",
+            )
+            rt_info3 = exceptions.RuntimeQuerySummaryError.RuntimeInfo(
+                runtime_name=RuntimeName.CE_REMOTE,
+                config_name=local_config_names[1],
+                server_uri="bar",
+            )
+            wf_run_repo.get_config_name_by_run_id.side_effect = (
+                exceptions.RuntimeQuerySummaryError(
+                    wf_run_id=wf_run_id,
+                    not_found_runtimes=[rt_info1],
+                    unauthorized_runtimes=[rt_info2],
+                    not_running_runtimes=[rt_info3],
+                )
+            )
 
             resolver = _arg_resolvers.WFConfigResolver(
                 wf_run_repo=wf_run_repo,
                 config_repo=config_repo,
-                prompter=prompter,
             )
-
-            # When
-            resolved_config = resolver.resolve(wf_run_id=wf_run_id, config=config)
 
             # Then
-            prompter.choice.assert_called_with(
-                local_config_names, message="Runtime config"
-            )
-
-            # Resolver should return the user's choice.
-            assert resolved_config == selected_config
+            # There should be an error presented to the user. There's no point in
+            # prompting for config selection, because apparently the user needs to log
+            # in, or there's a typo in the workflow run ID.
+            with pytest.raises(exceptions.RuntimeQuerySummaryError):
+                # When
+                _ = resolver.resolve(wf_run_id=wf_run_id, config=config)
 
         @staticmethod
         def test_no_wf_run_id():

--- a/tests/cli/ui/test_errors.py
+++ b/tests/cli/ui/test_errors.py
@@ -99,6 +99,15 @@ class TestPrettyPrintException:
                 "An issue submitting the workflow",
             ),
             (exceptions.QERemoved("<qe removal text>"), "<qe removal text>"),
+            (
+                exceptions.RuntimeQuerySummaryError(
+                    wf_run_id="wf.abc123.123",
+                    not_found_runtimes=[],
+                    unauthorized_runtimes=[],
+                    not_running_runtimes=[],
+                ),
+                "Couldn't find any runtime",
+            ),
         ],
     )
     def tests_prints_exception_without_traceback(capsys, exc, stdout_marker: str):

--- a/tests/cli/ui/test_errors.py
+++ b/tests/cli/ui/test_errors.py
@@ -106,7 +106,7 @@ class TestPrettyPrintException:
                     unauthorized_runtimes=[],
                     not_running_runtimes=[],
                 ),
-                "Couldn't find any runtime",
+                "Couldn't find a config",
             ),
         ],
     )

--- a/tests/sdk/test_exceptions.py
+++ b/tests/sdk/test_exceptions.py
@@ -1,0 +1,58 @@
+################################################################################
+# © Copyright 2023 Zapata Computing Inc.
+################################################################################
+
+"""Unit tests for ``orquestra.sdk.exceptions``.
+
+In general, exception classes shouldn't have any code apart from just data structures,
+so theorerically there should be nothing to test. However, there are occasional bits
+for unit testing, like checking if the exception message was generated correctly.
+
+Before extending this file with tests, please consider extracting your logic away from
+the exception class.
+"""
+
+from orquestra.sdk.exceptions import RuntimeQuerySummaryError
+from orquestra.sdk.schema.configs import RuntimeName
+
+
+class TestRuntimeQuerySummaryError:
+    @staticmethod
+    def test_found_in_ray():
+        # Given
+        wf_run_id = "wf.abcde12.hello"
+
+        exc = RuntimeQuerySummaryError(
+            wf_run_id=wf_run_id,
+            not_found_runtimes=[
+                RuntimeQuerySummaryError.RuntimeInfo(
+                    runtime_name=RuntimeName.CE_REMOTE,
+                    config_name="cluster1",
+                    server_uri="https://cluster1.example.com",
+                ),
+            ],
+            unauthorized_runtimes=[
+                RuntimeQuerySummaryError.RuntimeInfo(
+                    runtime_name=RuntimeName.CE_REMOTE,
+                    config_name="cluster2",
+                    server_uri="https1://cluster2.example.com",
+                ),
+            ],
+            not_running_runtimes=[
+                RuntimeQuerySummaryError.RuntimeInfo(
+                    runtime_name=RuntimeName.RAY_LOCAL,
+                    config_name="ray",
+                    server_uri=None,
+                ),
+            ],
+        )
+
+        # When
+        description = str(exc)
+
+        # Then
+        assert description == (
+            "Couldn't find any runtime that knows about this workflow run ID. Runtimes "
+            "with 'not found' response: ['cluster1']. Runtimes with 'unauthorized' "
+            "response: ['cluster2']. Runtimes that weren't up: ['ray']."
+        )

--- a/tests/sdk/test_exceptions.py
+++ b/tests/sdk/test_exceptions.py
@@ -52,7 +52,9 @@ class TestRuntimeQuerySummaryError:
 
         # Then
         assert description == (
-            "Couldn't find any runtime that knows about this workflow run ID. Runtimes "
-            "with 'not found' response: ['cluster1']. Runtimes with 'unauthorized' "
-            "response: ['cluster2']. Runtimes that weren't up: ['ray']."
+            "Couldn't find a config that knows about workflow run ID "
+            "wf.abcde12.hello \n"
+            "Configs with 'not found' response: ['cluster1'].\n"
+            "Configs with 'unauthorized' response: ['cluster2'].\n"
+            "Configs that weren't up: ['ray']."
         )


### PR DESCRIPTION
Split from https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/328.

# The problem

We want to eventually get rid of client-side workflow runs SQLite DB. We had a research spike few weeks ago. One of action items was to change the rules for resolving config name if the user didn't pass it explicitly.

# This PR's solution

If the user doesn't pass `config` directly, we ask all known runtimes for this `wf_run_id`. If no runtime says "yeah, I know this run", we present an error to the user. The error message contains a description of which runtimes have been queried. I don't consider this a breaking change. Affected APIs:
* `sdk.WorkflowRun.by_id(wf_run_id="...")`
* `orq wf view <wf_run_id>`

As discussed in https://github.com/zapatacomputing/orquestra-workflow-sdk/pull/328, I first implemented the functionality change as requested in the JIRA ticket. When this PR is merged, I'm planning to follow up with a refactor to make the tests more maintainable.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
