### PR TITLE
chore: remove deprecationwarning for 'None' workspace_ids in secrets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 🧟 *Deprecations*
 
+* Un-deprecated not passing `workspace_id` when accessing secrets.
+
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -3,7 +3,6 @@
 ################################################################################
 """Code for user-facing utilities related to secrets."""
 import typing as t
-import warnings
 
 from .. import exceptions as sdk_exc
 from .._base import _dsl, _exec_ctx
@@ -14,15 +13,6 @@ from . import _auth, _exceptions, _models
 def _translate_to_zri(workspace_id: WorkspaceId, secret_name: str) -> str:
     """Create ZRI from workspace_id and secret_name."""
     return f"zri:v1::0:{workspace_id}:secret:{secret_name}"
-
-
-def _raise_warning_for_none_workspace(workspace: t.Optional[WorkspaceId]):
-    if workspace is None:
-        warnings.warn(
-            "Please specify workspace ID directly for accessing secrets."
-            " Support for default workspaces will be sunset in the future.",
-            FutureWarning,
-        )
 
 
 def get(
@@ -56,8 +46,6 @@ def get(
             this function will return a "future" which will be used to retrieve the
             secret at execution time.
     """
-    _raise_warning_for_none_workspace(workspace_id)
-
     if _exec_ctx.global_context == _exec_ctx.ExecContext.WORKFLOW_BUILD:
         return t.cast(
             str,
@@ -103,8 +91,6 @@ def list(
         orquestra.sdk.exceptions.UnauthorizedError: when the authorization with the
             remote vault failed.
     """
-    _raise_warning_for_none_workspace(workspace_id)
-
     try:
         client = _auth.authorized_client(config_name)
     except sdk_exc.ConfigNameNotFoundError:
@@ -141,8 +127,6 @@ def set(
         orquestra.sdk.exceptions.UnauthorizedError: when the authorization with the
             remote vault failed.
     """
-    _raise_warning_for_none_workspace(workspace_id)
-
     try:
         client = _auth.authorized_client(config_name)
     except sdk_exc.ConfigNameNotFoundError:
@@ -188,8 +172,6 @@ def delete(
         orquestra.sdk.exceptions.UnauthorizedError: when the authorization with the
             remote vault failed.
     """
-    _raise_warning_for_none_workspace(workspace_id)
-
     try:
         client = _auth.authorized_client(config_name)
     except sdk_exc.ConfigNameNotFoundError:

--- a/tests/sdk/secrets/test_api.py
+++ b/tests/sdk/secrets/test_api.py
@@ -1,5 +1,5 @@
 ################################################################################
-# © Copyright 2022 Zapata Computing Inc.
+# © Copyright 2022 - 2023 Zapata Computing Inc.
 ################################################################################
 """
 Tests for the user-facing secrets API.
@@ -62,23 +62,6 @@ class TestIntegrationWithClient:
 
                 with pytest.raises(type(exc)):
                     secrets_action()
-
-        @staticmethod
-        @pytest.mark.parametrize(
-            "secrets_action",
-            [
-                lambda: sdk.secrets.get(name="some-secret"),
-                lambda: sdk.secrets.delete(name="some-secret"),
-                lambda: sdk.secrets.list(),
-                lambda: sdk.secrets.set(
-                    name="some-secret",
-                    value="You're doing great! :)",
-                ),
-            ],
-        )
-        def test_raises_warning_no_workspace(secrets_client_mock, secrets_action):
-            with pytest.warns(FutureWarning):
-                secrets_action()
 
         class TestForwardsConfigErrors:
             @staticmethod


### PR DESCRIPTION
[ORQSDK-985]

# The problem

We're no longer intending to make `workspace_id` a required parameter for secrets access. 
We shouldn't be warning users that we're about to do that.

# This PR's solution

Removes the deprecationwarning.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).


[ORQSDK-985]: https://zapatacomputing.atlassian.net/browse/ORQSDK-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ