### PR TITLE
feat: add filtering to ce runtime list workflow runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 🔥 *Features*
 
+* Listing workflow runs on CE now supports filtering by state and max age.
+
 🧟 *Deprecations*
 
 * Un-deprecated not passing `workspace_id` when accessing secrets.

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -460,7 +460,6 @@ class CERuntime(RuntimeInterface):
 
         for page_size in page_sizes:
             try:
-                # https://github.com/zapatacomputing/workflow-driver/blob/c52013c0f4df066159fc32ad38d489b3eaff5850/openapi/src/resources/workflow-runs.yaml#L14 # noqa: E501
                 paginated_runs = func(
                     page_size=page_size,
                     page_token=page_token,

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -2,7 +2,6 @@
 # © Copyright 2022-2023 Zapata Computing Inc.
 ################################################################################
 """RuntimeInterface implementation that uses Compute Engine."""
-import warnings
 from datetime import timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Protocol, Sequence, Union
@@ -41,6 +40,8 @@ class PaginatedListFunc(Protocol):
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
         workspace: Optional[WorkspaceId] = None,
+        max_age: Optional[timedelta] = None,
+        state: Optional[Union[State, List[State]]] = None,
     ) -> _client.Paginated:
         ...
 
@@ -441,12 +442,6 @@ class CERuntime(RuntimeInterface):
             A list of workflow runs, expressed either as WorkflowRun or
                 WorkflowRunSummary objects.
         """
-        if max_age or state:
-            warnings.warn(
-                "Filtering CE workflow runs by max age and/or state is not currently "
-                "supported. These filters will not be applied."
-            )
-
         # Calculate how many pages of what sizes we need.
         # The max_page_size should be the same as the maximum defined in
         # https://github.com/zapatacomputing/workflow-driver/blob/fc3964d37e05d9421029fe28fa844699e2f99a52/openapi/src/parameters/query/pageSize.yaml#L10 # noqa: E501
@@ -465,12 +460,13 @@ class CERuntime(RuntimeInterface):
 
         for page_size in page_sizes:
             try:
-                # TODO(ORQSDK-684): driver client cannot do filtering via API yet
-                # https://zapatacomputing.atlassian.net/browse/ORQSDK-684?atlOrigin=eyJpIjoiYmNiZjUyMjZiNzg5NDI2YWJmNGU5NzAxZDI1MmJlNzEiLCJwIjoiaiJ9 # noqa: E501
+                # https://github.com/zapatacomputing/workflow-driver/blob/c52013c0f4df066159fc32ad38d489b3eaff5850/openapi/src/resources/workflow-runs.yaml#L14 # noqa: E501
                 paginated_runs = func(
                     page_size=page_size,
                     page_token=page_token,
                     workspace=workspace,
+                    max_age=max_age,
+                    state=state,
                 )
             except (_exceptions.InvalidTokenError, _exceptions.ForbiddenError) as e:
                 raise exceptions.UnauthorizedError(

--- a/src/orquestra/sdk/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_base/_driver/_client.py
@@ -10,6 +10,7 @@ Implemented API spec:
 import io
 import re
 import zlib
+from datetime import timedelta
 from tarfile import TarFile
 from typing import Generic, List, Mapping, Optional, Tuple, TypeVar, Union
 from urllib.parse import urljoin
@@ -23,6 +24,7 @@ from orquestra.sdk._base._spaces._api import make_workspace_zri
 from orquestra.sdk.schema.ir import WorkflowDef
 from orquestra.sdk.schema.responses import ComputeEngineWorkflowResult, WorkflowResult
 from orquestra.sdk.schema.workflow_run import (
+    State,
     WorkflowRun,
     WorkflowRunMinimal,
     WorkflowRunSummary,
@@ -506,6 +508,8 @@ class DriverClient:
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
         workspace: Optional[WorkspaceId] = None,
+        max_age: Optional[timedelta] = None,
+        state: Optional[Union[State, List[State]]] = None,
     ) -> Paginated[WorkflowRunMinimal]:
         """List workflow runs with a specified workflow def ID from the workflow driver.
 
@@ -517,6 +521,8 @@ class DriverClient:
                 If omitted the first page will be returned.
             workspace: Only list workflow runs in the specified workspace. If omitted,
                 workflow runs from all workspaces will be returned.
+            max_age: Only list workflows younger than the specified age.
+            state: Only list workflows in the specified state(s).
 
         Raises:
             orquestra.sdk._base._driver._exceptions.InvalidTokenError: when the
@@ -532,6 +538,8 @@ class DriverClient:
                 page_size,
                 page_token,
                 workspace,
+                max_age,
+                state,
             )
         except (
             _exceptions.InvalidTokenError,
@@ -565,6 +573,8 @@ class DriverClient:
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
         workspace: Optional[WorkspaceId] = None,
+        max_age: Optional[timedelta] = None,
+        state: Optional[Union[State, List[State]]] = None,
     ) -> Paginated[WorkflowRunSummary]:
         """List workflow runs summaries with a specified workflow def ID.
 
@@ -576,6 +586,8 @@ class DriverClient:
                 If omitted the first page will be returned.
             workspace: Only list workflow runs in the specified workspace. If omitted,
                 workflow runs from all workspaces will be returned.
+            max_age: Only list workflows younger than the specified age.
+            state: Only list workflows in the specified state(s).
 
         Raises:
             orquestra.sdk._base._driver._exceptions.InvalidTokenError: when the
@@ -591,6 +603,8 @@ class DriverClient:
                 page_size,
                 page_token,
                 workspace,
+                max_age,
+                state,
             )
         except (
             _exceptions.InvalidTokenError,
@@ -623,6 +637,8 @@ class DriverClient:
         page_size: Optional[int] = None,
         page_token: Optional[str] = None,
         workspace: Optional[WorkspaceId] = None,
+        max_age: Optional[timedelta] = None,
+        state: Optional[Union[State, List[State]]] = None,
     ):
         """Get a list of wf runs from the workflow driver.
 
@@ -639,6 +655,8 @@ class DriverClient:
                 If omitted the first page will be returned.
             workspace: Only list workflow runs in the specified workspace. If omitted,
                 workflow runs from all workspaces will be returned.
+            max_age: Only list workflows younger than the specified age.
+            state: Only list workflows in the specified state(s).
 
 
         Raises:
@@ -658,6 +676,18 @@ class DriverClient:
                 pageSize=page_size,
                 pageToken=page_token,
                 workspaceId=workspace,
+                maxAge=(int(max_age.total_seconds()) if max_age else None),
+                state=(
+                    ",".join(
+                        (
+                            [state.value]
+                            if not isinstance(state, list)
+                            else [st.value for st in state]
+                        )
+                    )
+                    if state
+                    else None
+                ),
             ).dict(),
         )
 

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -310,16 +310,6 @@ class ListWorkflowRunsRequest(pydantic.BaseModel):
     """
     Implements:
     https://github.com/zapatacomputing/workflow-driver/blob/c52013c0f4df066159fc32ad38d489b3eaff5850/openapi/src/resources/workflow-runs.yaml#L14.
-
-    Returns all workflow runs along with their definition IDs, statuses and owners.
-    Following optional query parameters can be passed to narrow the list down:
-
-    * `workflowDefinitionId`: ID of the workflow definition that the run was created
-        from
-    * `workspaceId`: ID of the workspace that the run was created in
-    * `maxAge`: Maximum age of the workflow run in seconds (computed by using the time
-        it's created)
-    * `state`: Comma-separated list of possible states that the workflow run might be in
     """  # noqa: D205, D212
 
     workflowDefinitionID: Optional[WorkflowDefID]

--- a/src/orquestra/sdk/_base/_driver/_models.py
+++ b/src/orquestra/sdk/_base/_driver/_models.py
@@ -309,7 +309,17 @@ class CreateWorkflowRunResponse(pydantic.BaseModel):
 class ListWorkflowRunsRequest(pydantic.BaseModel):
     """
     Implements:
-    https://github.com/zapatacomputing/workflow-driver/blob/34eba4253b56266772795a8a59d6ec7edf88c65a/openapi/src/resources/workflow-runs.yaml#L9.
+    https://github.com/zapatacomputing/workflow-driver/blob/c52013c0f4df066159fc32ad38d489b3eaff5850/openapi/src/resources/workflow-runs.yaml#L14.
+
+    Returns all workflow runs along with their definition IDs, statuses and owners.
+    Following optional query parameters can be passed to narrow the list down:
+
+    * `workflowDefinitionId`: ID of the workflow definition that the run was created
+        from
+    * `workspaceId`: ID of the workspace that the run was created in
+    * `maxAge`: Maximum age of the workflow run in seconds (computed by using the time
+        it's created)
+    * `state`: Comma-separated list of possible states that the workflow run might be in
     """  # noqa: D205, D212
 
     workflowDefinitionID: Optional[WorkflowDefID]
@@ -317,6 +327,8 @@ class ListWorkflowRunsRequest(pydantic.BaseModel):
     pageToken: Optional[str]
     workspaceId: Optional[WorkspaceId]
     projectId: Optional[ProjectId]
+    maxAge: Optional[int]
+    state: Optional[str]
 
 
 ListWorkflowRunsResponse = List[MinimalWorkflowRunResponse]

--- a/tests/sdk/driver/test_ce_runtime.py
+++ b/tests/sdk/driver/test_ce_runtime.py
@@ -990,58 +990,101 @@ class TestListWorkflowRuns:
             page_size=None,
             page_token=None,
             workspace=None,
+            max_age=None,
+            state=None,
         )
         assert runs == wf_runs
 
     @pytest.mark.parametrize(
         "limit, expected_requests",
         [
-            (89, [call(page_size=89, page_token=None, workspace=None)]),
+            (
+                89,
+                [
+                    call(
+                        page_size=89,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
             (
                 144,
                 [
-                    call(page_size=100, page_token=None, workspace=None),
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    ),
                     call(
                         page_size=44,
                         page_token="<token sentinel 0>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                 ],
             ),
             (
                 233,
                 [
-                    call(page_size=100, page_token=None, workspace=None),
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    ),
                     call(
                         page_size=100,
                         page_token="<token sentinel 0>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                     call(
                         page_size=33,
                         page_token="<token sentinel 1>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                 ],
             ),
             (
                 377,
                 [
-                    call(page_size=100, page_token=None, workspace=None),
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    ),
                     call(
                         page_size=100,
                         page_token="<token sentinel 0>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                     call(
                         page_size=100,
                         page_token="<token sentinel 1>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                     call(
                         page_size=77,
                         page_token="<token sentinel 2>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                 ],
             ),
@@ -1072,10 +1115,54 @@ class TestListWorkflowRuns:
     @pytest.mark.parametrize(
         "limit, expected_requests",
         [
-            (89, [call(page_size=89, page_token=None, workspace=None)]),
-            (144, [call(page_size=100, page_token=None, workspace=None)]),
-            (233, [call(page_size=100, page_token=None, workspace=None)]),
-            (377, [call(page_size=100, page_token=None, workspace=None)]),
+            (
+                89,
+                [
+                    call(
+                        page_size=89,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
+            (
+                144,
+                [
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
+            (
+                233,
+                [
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
+            (
+                377,
+                [
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
         ],
     )
     def test_limit_applied_when_there_are_fewer_workflows(
@@ -1100,7 +1187,6 @@ class TestListWorkflowRuns:
         # Then
         mocked_client.list_workflow_runs.assert_has_calls(expected_requests)
 
-    @pytest.mark.xfail(reason="Filtering not available in CE runtime yet")
     def test_filter_args_passed_to_client(
         self,
         mocked_client: MagicMock,
@@ -1115,7 +1201,11 @@ class TestListWorkflowRuns:
 
         # Then
         mocked_client.list_workflow_runs.assert_called_once_with(
-            max_age=max_age, limit=limit, state=state
+            page_size=None,
+            page_token=None,
+            workspace=None,
+            max_age=max_age,
+            state=state,
         )
 
     def test_unknown_http(
@@ -1165,61 +1255,100 @@ class TestListWorkflowRunSummaries:
 
         # Then
         mocked_client.list_workflow_run_summaries.assert_called_once_with(
-            page_size=None,
-            page_token=None,
-            workspace=None,
+            page_size=None, page_token=None, workspace=None, max_age=None, state=None
         )
         assert runs == wf_runs
 
     @pytest.mark.parametrize(
         "limit, expected_requests",
         [
-            (89, [call(page_size=89, page_token=None, workspace=None)]),
+            (
+                89,
+                [
+                    call(
+                        page_size=89,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
             (
                 144,
                 [
-                    call(page_size=100, page_token=None, workspace=None),
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    ),
                     call(
                         page_size=44,
                         page_token="<token sentinel 0>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                 ],
             ),
             (
                 233,
                 [
-                    call(page_size=100, page_token=None, workspace=None),
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    ),
                     call(
                         page_size=100,
                         page_token="<token sentinel 0>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                     call(
                         page_size=33,
                         page_token="<token sentinel 1>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                 ],
             ),
             (
                 377,
                 [
-                    call(page_size=100, page_token=None, workspace=None),
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    ),
                     call(
                         page_size=100,
                         page_token="<token sentinel 0>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                     call(
                         page_size=100,
                         page_token="<token sentinel 1>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                     call(
                         page_size=77,
                         page_token="<token sentinel 2>",
                         workspace=None,
+                        max_age=None,
+                        state=None,
                     ),
                 ],
             ),
@@ -1250,10 +1379,54 @@ class TestListWorkflowRunSummaries:
     @pytest.mark.parametrize(
         "limit, expected_requests",
         [
-            (89, [call(page_size=89, page_token=None, workspace=None)]),
-            (144, [call(page_size=100, page_token=None, workspace=None)]),
-            (233, [call(page_size=100, page_token=None, workspace=None)]),
-            (377, [call(page_size=100, page_token=None, workspace=None)]),
+            (
+                89,
+                [
+                    call(
+                        page_size=89,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
+            (
+                144,
+                [
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
+            (
+                233,
+                [
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
+            (
+                377,
+                [
+                    call(
+                        page_size=100,
+                        page_token=None,
+                        workspace=None,
+                        max_age=None,
+                        state=None,
+                    )
+                ],
+            ),
         ],
     )
     def test_limit_applied_when_there_are_fewer_workflows(
@@ -1278,7 +1451,6 @@ class TestListWorkflowRunSummaries:
         # Then
         mocked_client.list_workflow_run_summaries.assert_has_calls(expected_requests)
 
-    @pytest.mark.xfail(reason="Filtering not available in CE runtime yet")
     def test_filter_args_passed_to_client(
         self,
         mocked_client: MagicMock,

--- a/tests/sdk/driver/test_ce_runtime.py
+++ b/tests/sdk/driver/test_ce_runtime.py
@@ -1467,7 +1467,11 @@ class TestListWorkflowRunSummaries:
 
         # Then
         mocked_client.list_workflow_run_summaries.assert_called_once_with(
-            max_age=max_age, limit=limit, state=state
+            page_size=None,
+            page_token=None,
+            workspace=None,
+            max_age=max_age,
+            state=state,
         )
 
     def test_unknown_http(

--- a/tests/sdk/driver/test_client.py
+++ b/tests/sdk/driver/test_client.py
@@ -4,8 +4,9 @@
 """
 Tests for orquestra.sdk._base._driver._client.
 """
+from datetime import timedelta
 from typing import Any, Dict, List, Optional
-from unittest.mock import create_autospec
+from unittest.mock import Mock, create_autospec
 
 import numpy as np
 import pytest
@@ -933,6 +934,13 @@ class TestClient:
                     (
                         {"page_size": 100, "page_token": "abc"},
                         {"pageSize": 100, "pageToken": "abc"},
+                    ),
+                    ({"workspace": "abc"}, {"workspaceId": "abc"}),
+                    ({"max_age": timedelta(seconds=42)}, {"maxAge": 42}),
+                    ({"state": Mock(value="abc")}, {"state": "abc"}),
+                    (
+                        {"state": [Mock(value="abc"), Mock(value="cde")]},
+                        {"state": "abc,cde"},
                     ),
                 ],
             )


### PR DESCRIPTION
# The problem

The public API for listing workflows has some filtering options (max_age, limit, state). CERuntime.list_workflow_runs() does not make use of the options.

# This PR's solution

Modifies the workflow listing code to include these parameters in the API request.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).

[ORQSDK-684]

[ORQSDK-684]: https://zapatacomputing.atlassian.net/browse/ORQSDK-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ