### PR TITLE
fix: Disallow responses 0.24 due to ResourceWarning with sockets

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -116,7 +116,7 @@ dev =
     pytest-cov>=2.12
     pytest-dependency
     pytest_httpserver
-    responses~=0.20
+    responses~=0.20,!=0.24
     ruff
     scikit-learn
     types-psutil


### PR DESCRIPTION
# The problem

New venvs install the latest version of `responses` which leaves a socket open causing a `ResourceWarning` which causes tests to fail.

# This PR's solution

- Disallow `responses==0.24` in dependencies

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
