### PR TITLE
docs: Align docs & docstrings with auto config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 📃 *Docs*
 
+* Update _Runtime Configuration_ guide and config-related docstrings to align them with the ``auto`` config.
+
 ## v0.58.0
 
 🚨 *Breaking Changes*

--- a/docs/guides/runtime-configuration.rst
+++ b/docs/guides/runtime-configuration.rst
@@ -6,19 +6,29 @@ A *runtime* is execution environment for workflows; it knows about your workflow
 
 Runtimes fall into two general categories:
 
-#. *Remote*. Orquestra Compute Engine. Managed clusters.
-#. *Local*. These runtimes support a subset of Orquestra functionality for local use.
+#. *Remote*.
+   Orquestra Compute Engine.
+   Managed clusters.
+#. *Local*.
+   These runtimes support a subset of Orquestra functionality for local use.
 
 Runtime Selection
 -----------------
 
-Using many of the Workflow SDK's APIs requires that you first specify which runtime to use. Runtimes are identified by **config name**:
+Using many of the Workflow SDK's APIs requires that you first specify which runtime to use.
+Runtimes are identified by **config name**:
 
-* ``auto`` -- infers the runtime to use based on contextual information. See the section below for more information.
+* ``auto`` -- infers the runtime to use based on contextual information.
+  See the section below for more information.
 * ``in_process`` -- refers to a local runtime that executes tasks sequentially in the same Python process. Useful for debugging.
-* ``ray`` -- refers to a local Ray runtime that executes workflows in the background. Allows running tasks in parallel. Requires starting the runtime daemon with ``orq up``.
-* ``local`` -- alias for ``ray``. Created at a time when there was just a single local runtime kind.
-* **other config name** -- refers to a remote runtime. Most of the remote runtime URIs have the form ``https://<subdomain>.<domain>.<tld>``, we use the ``<subdomain>`` as the identifying config name. Connection details for remote runtimes are stored in ``~/.orquestra/config.json``.
+* ``ray`` -- refers to a local Ray runtime that executes workflows in the background.
+  Allows running tasks in parallel.
+  Requires starting the runtime daemon with ``orq up``.
+* ``local`` -- alias for ``ray``.
+  Created at a time when there was just a single local runtime kind.
+* **other config name** -- refers to a remote runtime.
+  Most of the remote runtime URIs have the form ``https://<subdomain>.<domain>.<tld>``, we use the ``<subdomain>`` as the identifying config name.
+  Connection details for remote runtimes are stored in ``~/.orquestra/config.json``.
 
 
 ``auto`` Config Resolution

--- a/docs/guides/runtime-configuration.rst
+++ b/docs/guides/runtime-configuration.rst
@@ -2,7 +2,7 @@ Runtime Configuration
 =====================
 
 Most productive things you can do with Orquestra Workflow SDK require interacting with runtimes.
-A *runtime* is execution environment for workflows; it knows about your workflow runs, can host web UIs, stores Orquestra secrets.
+A *runtime* is execution environment for workflows; it knows about your workflow runs, can host web UIs, and stores Orquestra secrets.
 
 Runtimes fall into two general categories:
 
@@ -12,13 +12,13 @@ Runtimes fall into two general categories:
 Runtime Selection
 -----------------
 
-Many of Workflow SDK APIs need specifying the runtime to use. Runtimes are identified by **config name**.
+Using many of the Workflow SDK's APIs requires that you first specify which runtime to use. Runtimes are identified by **config name**:
 
-* ``auto`` -- guesses the runtime to use based on contextual information. See the section below for more information.
+* ``auto`` -- infers the runtime to use based on contextual information. See the section below for more information.
 * ``in_process`` -- refers to a local runtime that executes tasks sequentially in the same Python process. Useful for debugging.
 * ``ray`` -- refers to a local Ray runtime that executes workflows in the background. Allows running tasks in parallel. Requires starting the runtime daemon with ``orq up``.
 * ``local`` -- alias for ``ray``. Created at a time when there was just a single local runtime kind.
-* ``<subdomain>`` -- refers to a remote runtime. The config name is inferred from the URI, as most of the remote runtime URIs have the form ``https://<subdomain>.<domain>.<tld>``. Connection details for remote runtimes are stored in ``~/.orquestra/config.json``.
+* **other config name** -- refers to a remote runtime. Most of the remote runtime URIs have the form ``https://<subdomain>.<domain>.<tld>``, we use the ``<subdomain>`` as the identifying config name. Connection details for remote runtimes are stored in ``~/.orquestra/config.json``.
 
 
 ``auto`` Config Resolution
@@ -35,4 +35,4 @@ Many of Workflow SDK APIs need specifying the runtime to use. Runtimes are ident
    * - Code inside a task being executed by Compute Engine (the remote runtime).
      - The same Orquestra cluster as Compute Engine.
    * - Code in a script running on your local machine.
-     - Contents of the ``ORQ_CURRENT_CONFIG`` environment variable.
+     - Contents of the ``ORQ_CURRENT_CONFIG`` environment variable, or error if this variable is unset.

--- a/docs/guides/runtime-configuration.rst
+++ b/docs/guides/runtime-configuration.rst
@@ -1,61 +1,38 @@
 Runtime Configuration
 =====================
 
-.. decide where to expose this in the docs
+Most productive things you can do with Orquestra Workflow SDK require interacting with runtimes.
+A *runtime* is execution environment for workflows; it knows about your workflow runs, can host web UIs, stores Orquestra secrets.
 
-Orquestra can support different execution environments for workflows, called runtimes.
-Currently there are two supported runtimes: local execution via Ray, and remote execution via Compute Engine.
+Runtimes fall into two general categories:
 
-In some cases, additional configuration options are required in order to use a runtime.
-For example, a URL is required to connect to Compute Engine.
-Choosing a runtime and supplying options is called a *Runtime Configuration*.
+#. *Remote*. Orquestra Compute Engine. Managed clusters.
+#. *Local*. These runtimes support a subset of Orquestra functionality for local use.
 
-There is always one *Runtime Configuration* defined, called ``local``.
-This configuration option is reserved and cannot be updated or saved to.
-Manually editing the configuration file will not change this reserved option.
+Runtime Selection
+-----------------
 
-This is used by default in the CLI and executes a workflow locally with the default runtime options.
+Many of Workflow SDK APIs need specifying the runtime to use. Runtimes are identified by **config name**.
 
-..
-    TODO: Add how CLI uses configurations
-
-Configuration File
-------------------
-
-These *Runtime Configurations* are stored in a configuration file located at ``~/.orquestra/config.json``.
-The configuration file is a JSON file that is defined by:
-
-.. list-table::
-   :widths: 25 75
-   :header-rows: 1
-
-   * - Option
-     - Description
-   * - ``version``
-     - The version of the runtime configuration schema currently in use.
-   * - ``configs``
-     - Key-value pairs where the key is the configuration name and the value is the ``RuntimeConfiguration``.
-       See RuntimeConfiguration_.
+* ``auto`` -- guesses the runtime to use based on contextual information. See the section below for more information.
+* ``in_process`` -- refers to a local runtime that executes tasks sequentially in the same Python process. Useful for debugging.
+* ``ray`` -- refers to a local Ray runtime that executes workflows in the background. Allows running tasks in parallel. Requires starting the runtime daemon with ``orq up``.
+* ``local`` -- alias for ``ray``. Created at a time when there was just a single local runtime kind.
+* ``<subdomain>`` -- refers to a remote runtime. The config name is inferred from the URI, as most of the remote runtime URIs have the form ``https://<subdomain>.<domain>.<tld>``. Connection details for remote runtimes are stored in ``~/.orquestra/config.json``.
 
 
-.. _RuntimeConfiguration:
-
-``RuntimeConfiguration``
-------------------------
-
-Inside the configuration file, each *Runtime Configuration* is defined by:
+``auto`` Config Resolution
+--------------------------
 
 .. list-table::
-   :widths: 25 75
+   :widths: 50 50
    :header-rows: 1
 
-   * - Configuration option
-     - Description
-   * - ``config_name``
-     - The human readable configuration name.
-       This is what you should use in the :doc:`CLI <../quickref/cli-reference>` or SDK to reference a configuration.
-   * - ``runtime_name``
-     - The internal reference to the Orquestra runtime.
-       Currently supported options: ``RAY_LOCAL``, ``CE_REMOTE``.
-   * - ``runtime_options``
-     - A key-value pair of options passed to the specific runtime.
+   * - Scenario
+     - Resolved Runtime
+   * - You're in Orquestra Studio (the web IDE you can access by visiting Orquestra cluster URI in your web browser) -- either your code in a Jupyter cell or a terminal prompt.
+     - The same Orquestra cluster as the Studio instance.
+   * - Code inside a task being executed by Compute Engine (the remote runtime).
+     - The same Orquestra cluster as Compute Engine.
+   * - Code in a script running on your local machine.
+     - Contents of the ``ORQ_CURRENT_CONFIG`` environment variable.

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -208,7 +208,7 @@ class RuntimeConfig:
     @classmethod
     def list_configs(
         cls,
-    ) -> list:
+    ) -> t.List[ConfigName]:
         """List config names.
 
         Returns:
@@ -222,7 +222,7 @@ class RuntimeConfig:
     @classmethod
     def load(
         cls,
-        config_name: str,
+        config_name: ConfigName,
     ):
         """Load an existing runtime configuration.
 

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -209,7 +209,7 @@ class RuntimeConfig:
     def list_configs(
         cls,
     ) -> list:
-        """List previously saved configurations.
+        """List config names.
 
         Returns:
             list: list of configurations within the save file.
@@ -224,10 +224,14 @@ class RuntimeConfig:
         cls,
         config_name: str,
     ):
-        """Load an existing configuration from a file.
+        """Load an existing runtime configuration.
+
+        For more information about the supported names, visit the
+        `Runtime Configuration guide
+        <https://docs.orquestra.io/docs/core/sdk/guides/runtime-configuration.html>`_.
 
         Args:
-            config_name: The name of the configuration to be loaded.
+            config_name: The runtime name to load.
 
         Raises:
             orquestra.sdk.exceptions.ConfigFileNotFoundError: When the config file is

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -23,13 +23,17 @@ def get(
 ) -> str:
     """Retrieves secret value from the remote vault.
 
+    For more information about the supported config/runtime names, visit the
+    `Runtime Configuration guide
+    <https://docs.orquestra.io/docs/core/sdk/guides/runtime-configuration.html>`_.
+
     Args:
         name: secret identifier.
         workspace_id: ID of the workspace. Using platform-defined default if omitted -
             - currently it is personal workspace
-        config_name: config entry to use to communicate with Orquestra Platform.
-            Required when used from a local machine. Ignored when
-            ORQUESTRA_PASSPORT_FILE env variable is set.
+        config_name: name of the runtime use to communicate with Orquestra Platform.
+            Required when used from a local machine. Ignored when already running on a
+            remote Orquestra cluster.
 
     Raises:
         orquestra.sdk.exceptions.ConfigNameNotFoundError: when no matching config was
@@ -76,12 +80,16 @@ def list(
 ) -> t.Sequence[str]:
     """Lists all secret names.
 
+    For more information about the supported config/runtime names, visit the
+    `Runtime Configuration guide
+    <https://docs.orquestra.io/docs/core/sdk/guides/runtime-configuration.html>`_.
+
     Args:
         workspace_id: ID of the workspace. Using platform-defined default if omitted -
             - currently it is personal workspace.
-        config_name: config entry to use to communicate with Orquestra Platform.
-            Required when used from a local machine.
-            Ignored when the ORQUESTRA_PASSPORT_FILE env variable is set.
+        config_name: name of the runtime use to communicate with Orquestra Platform.
+            Required when used from a local machine. Ignored when already running on a
+            remote Orquestra cluster.
 
     Raises:
         orquestra.sdk.exceptions.ConfigNameNotFoundError: when no matching config was
@@ -112,14 +120,18 @@ def set(
 ):
     """Sets secret value at the remote vault. Overwrites already existing secrets.
 
+    For more information about the supported config/runtime names, visit the
+    `Runtime Configuration guide
+    <https://docs.orquestra.io/docs/core/sdk/guides/runtime-configuration.html>`_.
+
     Args:
         name: secret identifier.
         value: new secret name.
         workspace_id: workspace in which secret will be created. Using platform-defined
             default if omitted - currently it is personal workspace.
-        config_name: config entry to use to communicate with Orquestra Platform.
-            Required when used from a local machine.
-            Ignored when the ORQUESTRA_PASSPORT_FILE env variable is set.
+        config_name: name of the runtime use to communicate with Orquestra Platform.
+            Required when used from a local machine. Ignored when already running on a
+            remote Orquestra cluster.
 
     Raises:
         orquestra.sdk.exceptions.ConfigNameNotFoundError: when no matching config was
@@ -156,13 +168,17 @@ def delete(
 ):
     """Deletes secret from the remote vault.
 
+    For more information about the supported config/runtime names, visit the
+    `Runtime Configuration guide
+    <https://docs.orquestra.io/docs/core/sdk/guides/runtime-configuration.html>`_.
+
     Args:
         name: secret identifier.
         workspace_id: ID of the workspace. Using platform-defined default if omitted -
             - currently it is personal workspace.
-        config_name: config entry to use to communicate with Orquestra Platform.
-            Required when used from a local machine.
-            Ignored when the ORQUESTRA_PASSPORT_FILE env variable is set.
+        config_name: name of the runtime use to communicate with Orquestra Platform.
+            Required when used from a local machine. Ignored when already running on a
+            remote Orquestra cluster.
 
     Raises:
         orquestra.sdk.exceptions.ConfigNameNotFoundError: when no matching config was

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -6,6 +6,7 @@ import typing as t
 
 from .. import exceptions as sdk_exc
 from .._base import _dsl, _exec_ctx
+from ..schema.configs import ConfigName
 from ..schema.workflow_run import WorkspaceId
 from . import _auth, _exceptions, _models
 
@@ -18,8 +19,8 @@ def _translate_to_zri(workspace_id: WorkspaceId, secret_name: str) -> str:
 def get(
     name: str,
     *,
-    workspace_id: t.Optional[str] = None,
-    config_name: t.Optional[str] = None,
+    workspace_id: t.Optional[WorkspaceId] = None,
+    config_name: t.Optional[ConfigName] = None,
 ) -> str:
     """Retrieves secret value from the remote vault.
 
@@ -75,8 +76,8 @@ def get(
 
 def list(
     *,
-    workspace_id: t.Optional[str] = None,
-    config_name: t.Optional[str] = None,
+    workspace_id: t.Optional[WorkspaceId] = None,
+    config_name: t.Optional[ConfigName] = None,
 ) -> t.Sequence[str]:
     """Lists all secret names.
 
@@ -115,8 +116,8 @@ def set(
     name: str,
     value: str,
     *,
-    workspace_id: t.Optional[str] = None,
-    config_name: t.Optional[str] = None,
+    workspace_id: t.Optional[WorkspaceId] = None,
+    config_name: t.Optional[ConfigName] = None,
 ):
     """Sets secret value at the remote vault. Overwrites already existing secrets.
 
@@ -163,8 +164,8 @@ def set(
 def delete(
     name: str,
     *,
-    workspace_id: t.Optional[str] = None,
-    config_name: t.Optional[str] = None,
+    workspace_id: t.Optional[WorkspaceId] = None,
+    config_name: t.Optional[ConfigName] = None,
 ):
     """Deletes secret from the remote vault.
 

--- a/src/orquestra/sdk/secrets/_api.py
+++ b/src/orquestra/sdk/secrets/_api.py
@@ -32,7 +32,7 @@ def get(
         name: secret identifier.
         workspace_id: ID of the workspace. Using platform-defined default if omitted -
             - currently it is personal workspace
-        config_name: name of the runtime use to communicate with Orquestra Platform.
+        config_name: name of the runtime used to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when already running on a
             remote Orquestra cluster.
 
@@ -88,7 +88,7 @@ def list(
     Args:
         workspace_id: ID of the workspace. Using platform-defined default if omitted -
             - currently it is personal workspace.
-        config_name: name of the runtime use to communicate with Orquestra Platform.
+        config_name: name of the runtime used to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when already running on a
             remote Orquestra cluster.
 
@@ -130,7 +130,7 @@ def set(
         value: new secret name.
         workspace_id: workspace in which secret will be created. Using platform-defined
             default if omitted - currently it is personal workspace.
-        config_name: name of the runtime use to communicate with Orquestra Platform.
+        config_name: name of the runtime used to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when already running on a
             remote Orquestra cluster.
 
@@ -177,7 +177,7 @@ def delete(
         name: secret identifier.
         workspace_id: ID of the workspace. Using platform-defined default if omitted -
             - currently it is personal workspace.
-        config_name: name of the runtime use to communicate with Orquestra Platform.
+        config_name: name of the runtime used to communicate with Orquestra Platform.
             Required when used from a local machine. Ignored when already running on a
             remote Orquestra cluster.
 


### PR DESCRIPTION
# The problem

* We introduced the ``auto`` config, but its use wasn't documented.
* Our *Runtime Configuration* guide was out of date.

# This PR's solution

* Rewrites the guide to mention the current behavior of runtimes and configs.
* Removes the guide's content related to implementation details of config file contents. Motivation:
    * Users shouldn't need to fiddle with config files on their own.
    * The config file content made it difficult for me to write down a coherent narrative.
* Updates some missing type aliases I found.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
