### PR TITLE
Imp: Remove usage of project_dir arguments in SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * When the user doesn't pass `config` directly to `sdk.WorkflowRun.by_id(run_id="...")` and `orq` commands, the SDK will query all known runtimes about this workflow run. This change improves accessing workflow runs submitted by other users.
 
 🥷 *Internal*
+* Remove unused `_db` code
 
 📃 *Docs*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Listing workflow runs on CE now supports filtering by state and max age.
 
 🧟 *Deprecations*
+* Deprecation of `project_dir` argument for all public API functions.
 
 👩‍🔬 *Experimental*
 

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -6,7 +6,6 @@ import json
 import logging
 import typing as t
 import warnings
-from pathlib import Path
 
 from packaging.version import parse as parse_version
 
@@ -174,19 +173,13 @@ class RuntimeConfig:
 
     # endregion factories
     def _get_runtime(
-        self, project_dir: t.Optional[t.Union[str, Path]] = None
+        self,
     ) -> RuntimeInterface:
         """Build the run.
-
-        Args:
-            project_dir: the path to the project directory. If omitted, the current
-                working directory is used.
 
         Returns:
             Runtime: The runtime specified by the configuration.
         """
-        _project_dir: Path = Path(project_dir or Path.cwd())
-
         runtime_options = {}
         for key in _config.RUNTIME_OPTION_NAMES:
             try:
@@ -200,9 +193,7 @@ class RuntimeConfig:
             runtime_options=runtime_options,
         )
 
-        return build_runtime_from_config(
-            project_dir=_project_dir, config=runtime_configuration
-        )
+        return build_runtime_from_config(config=runtime_configuration)
 
     # region LOADING FROM FILE
     @classmethod

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -677,7 +677,7 @@ def list_workflow_run_summaries(
         NotImplementedError: when a filter is specified for a runtime that does not
             support it.
     """
-    project = _handle_common_listing_project_errors(project, workspace)
+    _handle_common_listing_project_errors(project, workspace)
     workspace = resolve_studio_workspace_ref(workspace_id=workspace)
 
     # Resolve config
@@ -687,7 +687,7 @@ def list_workflow_run_summaries(
         raise
 
     # resolve runtime
-    runtime = resolved_config._get_runtime(Path.cwd())
+    runtime = resolved_config._get_runtime()
 
     # Grab the workflow summaries from the runtime.
     with warnings.catch_warnings():

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -73,9 +73,7 @@ class WorkflowRun:
             config: Determines where to look for the workflow run record. If omitted,
                 we will retrieve the config name from a local cache of workflow runs
                 submitted from this machine.
-            project_dir: The location of the project directory. This directory must
-                contain the workflows database to which this run was saved. If omitted,
-                the current working directory is assumed to be the project directory.
+            project_dir: DEPRECATED
 
         Raises:
             orquestra.sdk.exceptions.RuntimeQuerySummaryError: when ``config``
@@ -91,7 +89,11 @@ class WorkflowRun:
             orquestra.sdk.exceptions.ConfigNameNotFoundError: when there's no
                 corresponding config entry in the config file.
         """
-        _project_dir = Path(project_dir or Path.cwd())
+        if project_dir:
+            warnings.warn(
+                "project_dir argument is deprecated and will be removed"
+                "in upcoming versions of orquestra-sdk"
+            )
 
         # Resolve config
         resolved_config: RuntimeConfig
@@ -100,7 +102,6 @@ class WorkflowRun:
             try:
                 resolved_config = _find_config_for_workflow(
                     wf_run_id=run_id,
-                    project_dir=_project_dir,
                 )
             except (
                 RuntimeQuerySummaryError,
@@ -115,7 +116,7 @@ class WorkflowRun:
         # - Ray stores wf def for us under a metadata entry.
         # - CE will have endpoints for getting [wf def] by [wf run ID]. See:
         #   https://zapatacomputing.atlassian.net/browse/ORQP-1317
-        runtime = resolved_config._get_runtime(_project_dir)
+        runtime = resolved_config._get_runtime()
         try:
             wf_run_model = runtime.get_workflow_run_status(run_id)
         except (UnauthorizedError, WorkflowRunNotFoundError):
@@ -151,12 +152,17 @@ class WorkflowRun:
             project_id: ID of the project for workflow - supported only on CE
             dry_run: Run the workflow without actually executing any task code.
                 Useful for testing infrastructure, dependency imports, etc.
-            project_dir: the path to the project directory. If omitted, the current
-                working directory is used.
+            project_dir: DEPRECATED
         """
+        if project_dir:
+            warnings.warn(
+                "project_dir argument is deprecated and will be removed"
+                "in upcoming versions of orquestra-sdk"
+            )
+
         _config = resolve_config(config)
 
-        runtime = _config._get_runtime(project_dir)
+        runtime = _config._get_runtime()
 
         assert runtime is not None
 
@@ -588,9 +594,7 @@ def _handle_common_listing_project_errors(
     return None
 
 
-def _find_config_for_workflow(
-    wf_run_id: WorkflowRunId, project_dir: Path
-) -> RuntimeConfig:
+def _find_config_for_workflow(wf_run_id: WorkflowRunId) -> RuntimeConfig:
     not_found_configs: t.List[RuntimeConfig] = []
     unauthorized_configs: t.List[RuntimeConfig] = []
     not_running_configs: t.List[RuntimeConfig] = []
@@ -599,7 +603,7 @@ def _find_config_for_workflow(
     for config_name in config_names:
         config_obj = RuntimeConfig.load(config_name)
         try:
-            runtime = config_obj._get_runtime(project_dir)
+            runtime = config_obj._get_runtime()
         except RayNotRunningError:
             # Ray connection is set up in `RayRuntime.__init__()`. We'll get the
             # exception when runtime object is created.
@@ -726,11 +730,7 @@ def list_workflow_runs(
         limit: Restrict the number of runs to return, prioritising the most recent.
         max_age: Only return runs younger than the specified maximum age.
         state: Only return runs of runs with the specified status.
-        project_dir: The location of the project directory.
-            This directory must contain the workflows database to which this run was
-            saved.
-            If omitted, the current working directory is assumed to be the project
-            directory.
+        project_dir: DEPRECATED
         workspace: Only return runs from the specified workspace when using CE.
         project: will be used to list workflows from specific workspace and project
             when using CE.
@@ -745,10 +745,14 @@ def list_workflow_runs(
     """
     # TODO: update docstring when platform workspace/project filtering is merged [ORQP-1479](https://zapatacomputing.atlassian.net/browse/ORQP-1479?atlOrigin=eyJpIjoiZWExMWI4MDUzYTI0NDQ0ZDg2ZTBlNzgyNjE3Njc4MDgiLCJwIjoiaiJ9) # noqa: E501
 
-    project = _handle_common_listing_project_errors(project, workspace)
-    workspace = resolve_studio_workspace_ref(workspace_id=workspace)
+    if project_dir:
+        warnings.warn(
+            "project_dir argument is deprecated and will be removed"
+            "in upcoming versions of orquestra-sdk"
+        )
 
-    _project_dir = Path(project_dir or Path.cwd())
+    _handle_common_listing_project_errors(project, workspace)
+    workspace = resolve_studio_workspace_ref(workspace_id=workspace)
 
     # Resolve config
     try:
@@ -758,7 +762,7 @@ def list_workflow_runs(
     # If user wasn't specific with workspace and project, we might want to resolve it
 
     # resolve runtime
-    runtime = resolved_config._get_runtime(_project_dir)
+    runtime = resolved_config._get_runtime()
 
     # Grab the "workflow runs" from the runtime.
     # Note: WorkflowRun means something else in runtime land. To avoid overloading, this

--- a/src/orquestra/sdk/_base/_factory.py
+++ b/src/orquestra/sdk/_base/_factory.py
@@ -1,7 +1,6 @@
 ################################################################################
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
-from pathlib import Path
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base.abc import RuntimeInterface
@@ -9,7 +8,7 @@ from orquestra.sdk.schema.configs import RuntimeConfiguration, RuntimeName
 
 
 def build_runtime_from_config(
-    project_dir: Path, config: RuntimeConfiguration, verbose: bool = False
+    config: RuntimeConfiguration, verbose: bool = False
 ) -> RuntimeInterface:
     """Centralized place to get runtime object based on config.
 
@@ -24,7 +23,6 @@ def build_runtime_from_config(
         import orquestra.sdk._ray._dag
 
         return orquestra.sdk._ray._dag.RayRuntime(
-            project_dir=project_dir,
             config=config,
         )
     elif config.runtime_name == RuntimeName.IN_PROCESS:

--- a/src/orquestra/sdk/_base/_workflow.py
+++ b/src/orquestra/sdk/_base/_workflow.py
@@ -163,8 +163,7 @@ class WorkflowDef(Generic[_R]):
             config: SDK needs to know where to execute the workflow. The config
                 contains the required details. This can be a RuntimeConfig object, or
                 the name of a saved configuration.
-            project_dir: the path to the project directory. If omitted, the current
-                working directory is used.
+            project_dir: DEPRECATED
             workspace_id: ID of the workspace for workflow - supported only on CE
             project_id: ID of the project for workflow - supported only on CE
             dry_run: Run the workflow without actually executing any task code.
@@ -177,6 +176,12 @@ class WorkflowDef(Generic[_R]):
             orquestra.sdk.exceptions.ProjectInvalidError: when only 1 out of project and
                 workspace is passed.
         """
+        if project_dir:
+            warnings.warn(
+                "project_dir argument is deprecated and will be removed"
+                "in upcoming versions of orquestra-sdk"
+            )
+
         try:
             wf_def_model = self.model
         except exceptions.DirtyGitRepo:
@@ -188,7 +193,6 @@ class WorkflowDef(Generic[_R]):
                 config=config,
                 workspace_id=workspace_id,
                 project_id=project_id,
-                project_dir=project_dir,
                 dry_run=dry_run,
             )
         except exceptions.ProjectInvalidError:

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -12,7 +12,6 @@ import re
 import typing as t
 import warnings
 from datetime import timedelta
-from pathlib import Path
 
 from orquestra.sdk.schema.responses import WorkflowResult
 
@@ -316,7 +315,6 @@ class RayRuntime(RuntimeInterface):
     def __init__(
         self,
         config: RuntimeConfiguration,
-        project_dir: Path,
         client: t.Optional[_client.RayClient] = None,
     ):
         self._client = client or _client.RayClient()
@@ -331,7 +329,6 @@ class RayRuntime(RuntimeInterface):
         self.startup(ray_params)
 
         self._config = config
-        self._project_dir = project_dir
 
         self._log_reader: LogReader = _ray_logs.DirectLogReader(
             _services.ray_temp_path()
@@ -418,7 +415,6 @@ class RayRuntime(RuntimeInterface):
             self._client,
             workflow_def=workflow_def,
             workflow_run_id=wf_run_id,
-            project_dir=self._project_dir,
             dry_run=dry_run,
         )
         wf_user_metadata = WfUserMetadata(workflow_def=workflow_def)

--- a/tests/runtime/ray/regression/test_workflow_outputs.py
+++ b/tests/runtime/ray/regression/test_workflow_outputs.py
@@ -36,12 +36,10 @@ class TestOutputs:
     @pytest.fixture(scope="class")
     def runtime(
         self,
-        tmp_path_factory: pytest.TempPathFactory,
     ):
-        project_dir = tmp_path_factory.mktemp("ray-regression")
         config = LOCAL_RUNTIME_CONFIGURATION
         client = _client.RayClient()
-        rt = _dag.RayRuntime(config, project_dir, client)
+        rt = _dag.RayRuntime(config, client)
         yield rt
 
     @pytest.mark.parametrize(

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -280,7 +280,6 @@ class TestRayRuntime:
                 rt = _dag.RayRuntime(
                     client=Mock(),
                     config=runtime_config,
-                    project_dir=tmp_path,
                 )
 
                 logs_dict = {"inv_id1": ["Hello, there!", "General Kenobi!"]}
@@ -314,7 +313,6 @@ class TestRayRuntime:
                 rt = _dag.RayRuntime(
                     client=Mock(),
                     config=runtime_config,
-                    project_dir=tmp_path,
                 )
 
                 logs_list = ["hello", "there!"]
@@ -346,7 +344,6 @@ class TestRayRuntime:
             runtime = _dag.RayRuntime(
                 client=client,
                 config=runtime_config,
-                project_dir=tmp_path,
             )
             with pytest.warns(expected_warning=exceptions.UnsupportedRuntimeFeature):
                 runtime.create_workflow_run(
@@ -364,7 +361,6 @@ class TestRayRuntime:
             runtime = _dag.RayRuntime(
                 client=client,
                 config=runtime_config,
-                project_dir=tmp_path,
             )
             mock_status = Mock()
             monkeypatch.setattr(
@@ -384,7 +380,6 @@ class TestRayRuntime:
             runtime = _dag.RayRuntime(
                 client=client,
                 config=runtime_config,
-                project_dir=tmp_path,
             )
             monkeypatch.setattr(
                 runtime,
@@ -404,7 +399,6 @@ class TestRayRuntime:
             runtime = _dag.RayRuntime(
                 client=client,
                 config=runtime_config,
-                project_dir=tmp_path,
             )
             # Given
             mock_status = Mock()
@@ -432,7 +426,6 @@ class TestRayRuntime:
             runtime = _dag.RayRuntime(
                 client=client,
                 config=runtime_config,
-                project_dir=tmp_path,
             )
             # Given
             mock_status = Mock()
@@ -460,7 +453,6 @@ class TestRayRuntime:
             runtime = _dag.RayRuntime(
                 client=client,
                 config=runtime_config,
-                project_dir=tmp_path,
             )
             mock_status = Mock()
             type(mock_status.status).start_time = PropertyMock(
@@ -487,7 +479,6 @@ class TestRayRuntime:
             runtime = _dag.RayRuntime(
                 client=client,
                 config=runtime_config,
-                project_dir=tmp_path,
             )
             mock_status = Mock()
             type(mock_status.status).start_time = PropertyMock(

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -39,17 +39,15 @@ pytestmark = pytest.mark.filterwarnings(
 @pytest.fixture(scope="module")
 def runtime(
     shared_ray_conn,
-    tmp_path_factory: pytest.TempPathFactory,
 ):
     # We need to set this env variable to let our logging code know the
     # tmp location has changed.
     old_env = os.getenv(RAY_TEMP_PATH_ENV)
     os.environ[RAY_TEMP_PATH_ENV] = str(shared_ray_conn._temp_dir)
 
-    project_dir = tmp_path_factory.mktemp("ray-integration")
     config = LOCAL_RUNTIME_CONFIGURATION
     client = _client.RayClient()
-    rt = _dag.RayRuntime(config, project_dir, client)
+    rt = _dag.RayRuntime(config, client)
 
     yield rt
 

--- a/tests/sdk/api/test_wf_run.py
+++ b/tests/sdk/api/test_wf_run.py
@@ -243,7 +243,7 @@ class TestWorkflowRun:
 
                 # Set up runtime
                 runtime = Mock()
-                setattr(config, "_get_runtime", lambda _: runtime)
+                setattr(config, "_get_runtime", lambda: runtime)
                 wf_def = "<wf def sentinel>"
                 runtime.get_workflow_run_status().workflow_def = wf_def
 
@@ -280,7 +280,7 @@ class TestWorkflowRun:
 
                 # Set up runtime
                 runtime = Mock()
-                setattr(config_obj, "_get_runtime", lambda _: runtime)
+                setattr(config_obj, "_get_runtime", lambda: runtime)
                 wf_def = "<wf def sentinel>"
                 runtime.get_workflow_run_status().workflow_def = wf_def
 
@@ -336,9 +336,7 @@ class TestWorkflowRun:
 
                         # Set up runtime
                         runtime = create_autospec(RuntimeInterface)
-                        monkeypatch.setattr(
-                            config_obj, "_get_runtime", lambda _: runtime
-                        )
+                        monkeypatch.setattr(config_obj, "_get_runtime", lambda: runtime)
                         wf_def = sentinel.wf_def
                         runtime.get_workflow_run_status(run_id).workflow_def = wf_def
 
@@ -380,8 +378,8 @@ class TestWorkflowRun:
                         # Set up runtimes
                         runtime1 = create_autospec(RuntimeInterface)
                         runtime2 = create_autospec(RuntimeInterface)
-                        monkeypatch.setattr(config1, "_get_runtime", lambda _: runtime1)
-                        monkeypatch.setattr(config2, "_get_runtime", lambda _: runtime2)
+                        monkeypatch.setattr(config1, "_get_runtime", lambda: runtime1)
+                        monkeypatch.setattr(config2, "_get_runtime", lambda: runtime2)
 
                         wf_def = sentinel.wf_def
 
@@ -434,7 +432,7 @@ class TestWorkflowRun:
                             "_get_runtime",
                             Mock(side_effect=RayNotRunningError),
                         )
-                        monkeypatch.setattr(config2, "_get_runtime", lambda _: runtime2)
+                        monkeypatch.setattr(config2, "_get_runtime", lambda: runtime2)
 
                         wf_def = sentinel.wf_def
 
@@ -490,8 +488,8 @@ class TestWorkflowRun:
 
                         runtime2 = create_autospec(RuntimeInterface)
                         runtime3 = create_autospec(RuntimeInterface)
-                        monkeypatch.setattr(config2, "_get_runtime", lambda _: runtime2)
-                        monkeypatch.setattr(config3, "_get_runtime", lambda _: runtime3)
+                        monkeypatch.setattr(config2, "_get_runtime", lambda: runtime2)
+                        monkeypatch.setattr(config3, "_get_runtime", lambda: runtime3)
 
                         wf_def = sentinel.wf_def
 
@@ -576,9 +574,7 @@ class TestWorkflowRun:
 
                         # Set up runtimes
                         runtime = create_autospec(RuntimeInterface)
-                        monkeypatch.setattr(
-                            config_obj, "_get_runtime", lambda _: runtime
-                        )
+                        monkeypatch.setattr(config_obj, "_get_runtime", lambda: runtime)
 
                         runtime.get_workflow_run_status.side_effect = (
                             WorkflowRunNotFoundError
@@ -624,8 +620,8 @@ class TestWorkflowRun:
                         runtime1 = create_autospec(RuntimeInterface)
                         runtime2 = create_autospec(RuntimeInterface)
 
-                        monkeypatch.setattr(config1, "_get_runtime", lambda _: runtime1)
-                        monkeypatch.setattr(config2, "_get_runtime", lambda _: runtime2)
+                        monkeypatch.setattr(config1, "_get_runtime", lambda: runtime1)
+                        monkeypatch.setattr(config2, "_get_runtime", lambda: runtime2)
 
                         runtime1.get_workflow_run_status.side_effect = (
                             WorkflowRunNotFoundError

--- a/tests/sdk/driver/conftest.py
+++ b/tests/sdk/driver/conftest.py
@@ -2,7 +2,6 @@
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
 
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
@@ -20,7 +19,7 @@ def runtime():
         runtime_options={"uri": "http://localhost", "token": "blah"},
     )
 
-    return build_runtime_from_config(project_dir=Path.cwd(), config=config)
+    return build_runtime_from_config(config=config)
 
 
 @pytest.fixture
@@ -33,9 +32,7 @@ def runtime_verbose(tmp_path):
         runtime_options={"uri": "http://localhost", "token": "blah"},
     )
     # Return a runtime object
-    return build_runtime_from_config(
-        project_dir=Path.cwd(), config=config, verbose=True
-    )
+    return build_runtime_from_config(config=config, verbose=True)
 
 
 @pytest.fixture

--- a/tests/sdk/test_factory.py
+++ b/tests/sdk/test_factory.py
@@ -2,7 +2,6 @@
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
 
-from pathlib import Path
 
 import pytest
 
@@ -43,9 +42,7 @@ class TestBuildRuntimeFromConfig:
             runtime_name=config_type,
             runtime_options=runtime_options,
         )
-        runtime = build_runtime_from_config(
-            project_dir=Path.cwd(), config=runtime_config
-        )
+        runtime = build_runtime_from_config(config=runtime_config)
         assert isinstance(runtime, expected_runtime)
 
     @pytest.mark.parametrize(
@@ -62,7 +59,7 @@ class TestBuildRuntimeFromConfig:
         )
 
         with pytest.raises(RuntimeConfigError):
-            build_runtime_from_config(project_dir=Path.cwd(), config=runtime_config)
+            build_runtime_from_config(config=runtime_config)
 
     def test_qe_removed(self):
         runtime_config = RuntimeConfiguration(
@@ -71,4 +68,4 @@ class TestBuildRuntimeFromConfig:
         )
 
         with pytest.raises(QERemoved):
-            build_runtime_from_config(project_dir=Path.cwd(), config=runtime_config)
+            build_runtime_from_config(config=runtime_config)


### PR DESCRIPTION
# The problem
https://zapatacomputing.atlassian.net/browse/ORQSDK-971
Project_dir argument was a leftover from VS studio times. Now it is obsolete and makes the unnecessary complex.

# This PR's solution

Remove project_dir internally. Deprecate it on user-API functions

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
