### PR TITLE
Int: Remove optional str from runtime name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 🥷 *Internal*
 
+* Change `RuntimeConfig._name` typing from `Optional[str]` to `str`
+
 📃 *Docs*
 
 * Update _Runtime Configuration_ guide and config-related docstrings to align them with the ``auto`` config.

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -57,7 +57,7 @@ class RuntimeConfig:
                 "`RuntimeConfig.ce()` for Compute Engine. \n"
             )
 
-        self._name: str = name
+        self._name = name
         try:
             self._runtime_name: RuntimeName = RuntimeName(runtime_name)
         except ValueError as e:

--- a/src/orquestra/sdk/_base/_api/_config.py
+++ b/src/orquestra/sdk/_base/_api/_config.py
@@ -46,7 +46,7 @@ class RuntimeConfig:
     def __init__(
         self,
         runtime_name: str,
-        name: t.Optional[str] = None,
+        name: str,
         bypass_factory_methods=False,
     ):
         if not bypass_factory_methods:
@@ -58,7 +58,7 @@ class RuntimeConfig:
                 "`RuntimeConfig.ce()` for Compute Engine. \n"
             )
 
-        self._name = name
+        self._name: str = name
         try:
             self._runtime_name: RuntimeName = RuntimeName(runtime_name)
         except ValueError as e:
@@ -96,7 +96,7 @@ class RuntimeConfig:
         )
 
     @property
-    def name(self) -> t.Optional[str]:
+    def name(self) -> str:
         return self._name
 
     def _get_runtime_options(self) -> dict:
@@ -195,7 +195,7 @@ class RuntimeConfig:
                 continue
 
         runtime_configuration = RuntimeConfiguration(
-            config_name=str(self._name),
+            config_name=self._name,
             runtime_name=self._runtime_name,
             runtime_options=runtime_options,
         )
@@ -339,10 +339,6 @@ class RuntimeConfig:
                 "This runtime configuration does not require an authorization token. "
                 "Nothing has been saved."
             )
-
-        assert (
-            self._name is not None
-        ), "We have a save location but not a name for this configuration. "
 
         old_config = self._config_from_runtimeconfiguration(
             _config.read_config(self._name)

--- a/src/orquestra/sdk/_base/cli/_repos.py
+++ b/src/orquestra/sdk/_base/cli/_repos.py
@@ -83,9 +83,6 @@ class WorkflowRunRepo:
             "Workflow run without a config. It's only possible for in-process "
             "runtime. However, it should never be a result of using by_id()"
         )
-        assert (
-            run.config.name is not None
-        ), "Config without a name. This shouldn't happen in normal circumstances"
         return run.config.name
 
     def list_wf_run_summaries(

--- a/tests/sdk/api/test_config.py
+++ b/tests/sdk/api/test_config.py
@@ -50,7 +50,7 @@ class TestRuntimeConfiguration:
         @staticmethod
         def test_raises_value_error_if_called_directly():
             with pytest.raises(ValueError) as exc_info:
-                api_cfg.RuntimeConfig("test_runtime_name")
+                api_cfg.RuntimeConfig("test_runtime_name", "name")
             assert (
                 "Please use the appropriate factory method for your desired runtime."
                 in str(exc_info.value)
@@ -62,7 +62,9 @@ class TestRuntimeConfiguration:
         @staticmethod
         def test_raises_exception_for_invalid_config_name():
             with pytest.raises(ValueError) as exc_info:
-                api_cfg.RuntimeConfig("bad_runtime_name", bypass_factory_methods=True)
+                api_cfg.RuntimeConfig(
+                    "bad_runtime_name", "name", bypass_factory_methods=True
+                )
             for valid_name in RuntimeName:
                 assert valid_name.value in str(exc_info)
 
@@ -186,8 +188,10 @@ class TestRuntimeConfiguration:
         def test_with_essential_params_only(change_test_dir):
             with warnings.catch_warnings():
                 warnings.simplefilter("error")
-                config = api_cfg.RuntimeConfig("RAY_LOCAL", bypass_factory_methods=True)
-            assert "RuntimeConfiguration 'None' for runtime RAY_LOCAL" in str(config)
+                config = api_cfg.RuntimeConfig(
+                    "RAY_LOCAL", "NAME", bypass_factory_methods=True
+                )
+            assert "RuntimeConfiguration 'NAME' for runtime RAY_LOCAL" in str(config)
 
         @staticmethod
         def test_with_optional_params():

--- a/tests/sdk/api/test_wf_run.py
+++ b/tests/sdk/api/test_wf_run.py
@@ -238,6 +238,7 @@ class TestWorkflowRun:
                 # Set up config
                 config = _api.RuntimeConfig(
                     runtime_name=RuntimeName.IN_PROCESS,
+                    name="name",
                     bypass_factory_methods=True,
                 )
 


### PR DESCRIPTION
# The problem

https://zapatacomputing.atlassian.net/browse/ORQSDK-996
Name for config was optional for historical reasons. Now we always pass the name in our factory methods.

# This PR's solution

Initial idea was to deprecate usage of `name = None` BUT
I found out that our `RuntimeConfig` has convention of factory methods, and using `__init__` should not be considered as public API due to `bypass_factory_methods` setting (plus there is bunch of comments saying to not use it)
So as a solution ive already changed the `name` parameter from `optional[str]` to `str`

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
