### PR TITLE
fix: workaround missing Ray dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 🐛 *Bug Fixes*
 
+* Workaround for Ray cluster not starting because of a missing dependency, `async_timeout`.
+
 💅 *Improvements*
 
 * When the user doesn't pass `config` directly to `sdk.WorkflowRun.by_id(run_id="...")` and `orq` commands, the SDK will query all known runtimes about this workflow run. This change improves accessing workflow runs submitted by other users.

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,9 +76,8 @@ where = src
 [options.extras_require]
 ray =
     ray[default]==2.6.3
-    # Ray workflows also requires pyarrow but it's missing from their requirements.
-    pyarrow
-
+    async-timeout # Ray depends on this, but its missing from ray requirements.
+    pyarrow # Ray workflows depend on this, but it's missing from ray requirements.
 all =
     orquestra-sdk[ray]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,7 +76,7 @@ where = src
 [options.extras_require]
 ray =
     ray[default]==2.6.3
-    async-timeout # Ray depends on this, but its missing from ray requirements.
+    async-timeout # Ray depends on this, but its missing from ray requirements. Can be removed when https://github.com/ray-project/ray/issues/41267 is fixed.
     pyarrow # Ray workflows depend on this, but it's missing from ray requirements.
 all =
     orquestra-sdk[ray]


### PR DESCRIPTION
# The problem

Discovered by @jamesclark-Zapata and @SebastianMorawiec during an unrelated debugging session yesterday. `orq up` didn't actually start Ray. Under the hood, `ray start --head` returns status code 0, despite failing to initialize the Ray cluster.

Related Ray issue: https://github.com/ray-project/ray/issues/41267. Looks like Ray code depends on `async-timeout` directly, but it was only a transitive dependency. The middle dependency recently stopped requiring `async-timeout`.

## Reproducing Scenario

* Grab a fresh venv, with Python 3.11.6.
* `pip install -e .[ray]`
* `orq up`
* `orq status`
    * Should show: "Ray running"
    * Shows: "Ray not running"
* `ray status`
    * Should show: some stats about the local Ray cluster
    * Shows: `ModuleNotFoundError: No module named 'async_timeout'`

# This PR's solution

Adds `async-timeout` to our `ray` extra.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
