### PR TITLE
fix: running tests against aiohttp

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,11 +55,16 @@ jobs:
 
       - name: Install deps
         shell: bash
-        run: make github_actions
+        run: |
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          make github_actions
 
       - name: Run tests and gather coverage stats
         shell: bash
-        run: make coverage
+        run: |
+          source ./venv/bin/activate
+          make coverage
 
       - name: Comment with code coverage
         # Conditionally run this step to prevent multiple comments

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-          cache: 'pip'
+          # cache: 'pip'
 
       - name: Install deps
         shell: bash

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,13 +45,12 @@ jobs:
         with:
           # Fetch depth 0 required to compare against `main`
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      # Used to create OS-agnostic python virtual env used for other steps.
-      - uses: syphar/restore-virtualenv@v1
-        id: cache-virtualenv
+          cache: 'pip'
 
       - name: Install deps
         shell: bash

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.9", "3.10", "3.11"]
+        # python: ["3.9", "3.10", "3.11"]
+        python: ["3.11"]
         # Extend the matrix with a job that prints coverage.
         # Because { os: "ubuntu-latest", python: "3.11" } is already in the matrix,
         # print_coverage: true is added to that job.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,10 +33,11 @@ jobs:
 
       # Load a specific version of Python
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           architecture: x64
+          cache: 'pip'
 
       - name: Install deps
         shell: bash

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -25,13 +25,17 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      # Used to create OS-agnostic python virtual env used for other steps.
-      - uses: syphar/restore-virtualenv@v1
-        id: cache-virtualenv
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: x64
+          cache: 'pip'
+
+      - name: Install deps
+        shell: bash
+        run: make github_actions
 
       - name: Run performance test
         shell: bash
-        run: |
-          make github_actions
-          make performance
+        run: make performance

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -40,16 +40,11 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
+          cache: 'pip'
 
       - name: Install deps
         shell: bash
         run: make github_actions
-
-      # Ensure we don't run checks against stale, cached modules.
-      - name: Clean
-        shell: bash
-        run: |
-          make clean
 
       # Pyright-specific step. Temporarily separated from the regular "style" check.
       # To be merged with 'make style' when we fix all pyright errors. Until then,

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -27,8 +27,16 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: x64
+          cache: 'pip'
+
+      - name: Install deps
+        shell: bash
+        run: make github_actions
+
       - name: Run type checking test
         shell: bash
-        run: |
-          make github_actions
-          make user-typing
+        run: make user-typing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 🐛 *Bug Fixes*
 
 * Workaround for Ray cluster not starting because of a missing dependency, `async_timeout`.
+* Fix warnings when used with `aiohttp>3.9`.
 
 💅 *Improvements*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     tabulate
     rich~=13.5
     # For automatic login
-    aiohttp~=3.8
+    aiohttp>=3.9.0
     # Decoding JWTs
     PyJWT~=2.6
     # Capture stdout/stderr

--- a/src/orquestra/sdk/_base/cli/_login/_login_server.py
+++ b/src/orquestra/sdk/_base/cli/_login/_login_server.py
@@ -7,6 +7,9 @@ from typing import Optional
 from aiohttp import web
 
 
+CLUSTER_URL_KEY = web.AppKey("cluster_url", str)
+
+
 class LoginServer:
     def __init__(self):
         self._token: Optional[str] = None
@@ -18,7 +21,7 @@ class LoginServer:
 
     async def start(self, cluster_url: str, listen_host: str = "127.0.0.1") -> int:
         app = web.Application()
-        app["cluster_url"] = cluster_url
+        app[CLUSTER_URL_KEY] = cluster_url
         app.add_routes([web.get("/state", self._state_handler)])
         self._runner = web.AppRunner(app)
         await self._runner.setup()
@@ -34,7 +37,7 @@ class LoginServer:
         res = web.StreamResponse(
             status=status_code,
             headers={
-                "Access-Control-Allow-Origin": request.app["cluster_url"],
+                "Access-Control-Allow-Origin": request.app[CLUSTER_URL_KEY],
                 "Content-Length": "0",
             },
         )

--- a/tests/cli/test_login_server.py
+++ b/tests/cli/test_login_server.py
@@ -8,7 +8,7 @@ import sys
 import pytest
 from aiohttp import ClientResponse, ClientSession, web
 
-from orquestra.sdk._base.cli._login._login_server import LoginServer
+from orquestra.sdk._base.cli._login._login_server import CLUSTER_URL_KEY, LoginServer
 
 
 class TestLoginServer:
@@ -48,7 +48,7 @@ class TestHandlers:
         server = LoginServer()
 
         app = web.Application()
-        app["cluster_url"] = cluster_url
+        app[CLUSTER_URL_KEY] = cluster_url
         app.router.add_get("/state", server._state_handler)
 
         resp = asyncio.run(make_request(app, "/state"))
@@ -63,7 +63,7 @@ class TestHandlers:
         server = LoginServer()
 
         app = web.Application()
-        app["cluster_url"] = cluster_url
+        app[CLUSTER_URL_KEY] = cluster_url
         app.router.add_get("/state", server._state_handler)
 
         with pytest.raises(web.GracefulExit):

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -962,9 +962,12 @@ class TestDirectLogReader:
             assert len(logs.env_setup) > 0
 
             for tell_tale in ["Cloning virtualenv", "'pip', 'install'"]:
+                matched_lines = [
+                    line for line in logs.env_setup.out if tell_tale in line
+                ]
                 assert (
-                    len([line for line in logs.env_setup.out if tell_tale in line]) > 0
-                )
+                    len(matched_lines) > 0
+                ), f"No match. Full output:\n{logs.env_setup.out}"
 
     @staticmethod
     @pytest.mark.parametrize(


### PR DESCRIPTION
# The problem

Running tests are failing because of an `aiohttp` warning raised in `tests/cli/test_login_server.py`. It seems there's a new version of `aiohttp` that raises warnings:

```
E           aiohttp.web_exceptions.NotAppKeyWarning: It is recommended to use web.AppKey instances for keys.
E           https://docs.aiohttp.org/en/stable/web_advanced.html#application-s-config
```

# This PR's solution



# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
