### PR TITLE
Feat: New API `WorkflowRun.get_artifact()` and `WorkflowRun.get_artifact_serialized()` to get single task output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 🔥 *Features*
+* New API `WorkflowRun.get_artifact()` and `WorkflowRun.get_artifact_serialized()` to get single task output
 
 🧟 *Deprecations*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,9 @@ per-file-ignores = [
 max-line-length = 88
 count = true
 arg-type-hints-in-docstring = false
+
+[tool.pyright]
+exclude = [
+"./src/orquestra/sdk/_base/_traversal.py"
+]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,8 @@ install_requires =
     tabulate
     rich~=13.5
     # For automatic login
-    aiohttp~=3.8
+    # 3.9 aiohttp introduced warnings in Python 3.11 and 3.12
+    aiohttp==3.8.*
     # Decoding JWTs
     PyJWT~=2.6
     # Capture stdout/stderr

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -454,21 +454,24 @@ class WorkflowRun:
             for inv_id, inv_output in inv_outputs.items()
         }
 
-    def get_artifact_serialized(self, task_invocation_id: ir.TaskInvocationId):
+    def get_artifact_serialized(
+        self, task_invocation_id: ir.TaskInvocationId
+    ) -> WorkflowResult:
         """Unstable: this API is not implemented for all runtimes yet.
 
         Returns serialized value calculated by given task if the task is finished.
         Raises exception if given task did not finish yet.
         """
-        self._runtime.get_output(self.run_id, task_invocation_id)
+        return self._runtime.get_output(self.run_id, task_invocation_id)
 
-    def get_artifact(self, task_invocation_id: ir.TaskInvocationId):
+    def get_artifact(self, task_invocation_id: ir.TaskInvocationId) -> t.Any:
         """Unstable: this API is not implemented for all runtimes yet.
 
         Returns value calculated by given task if the task is finished.
         Raises exception if given task did not finish yet.
         """
-        return serde.deserialize(self.get_artifact_serialized(task_invocation_id))
+        serialized_artifact = self.get_artifact_serialized(task_invocation_id)
+        return serde.deserialize(serialized_artifact)
 
     def get_logs(self) -> WorkflowLogs:
         """Unstable: this API will change.

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -444,8 +444,6 @@ class WorkflowRun:
                 task has 1 output, it's the dict entry's value. If the tasks has n
                 outputs, the dict entry's value is a n-tuple.
         """
-        # NOTE: this is a possible place for improvement. If future runtime APIs support
-        # getting a subset of artifacts, we should use them here.
         inv_outputs = self.get_artifacts_serialized()
 
         # The output shape differs across runtimes when the workflow functions returns a
@@ -455,6 +453,20 @@ class WorkflowRun:
             inv_id: serde.deserialize(inv_output)
             for inv_id, inv_output in inv_outputs.items()
         }
+
+    def get_artifact_serialized(self, task_invocation_id: ir.TaskInvocationId):
+        """
+        Returns serialized value calculated by given task if the task is finished.
+        Raises exception if given task did not finish yet.
+        """
+        self._runtime.get_output(self.run_id, task_invocation_id)
+
+    def get_artifact(self, task_invocation_id: ir.TaskInvocationId):
+        """
+        Returns value calculated by given task if the task is finished.
+        Raises exception if given task did not finish yet.
+        """
+        return serde.deserialize(self.get_artifact_serialized(task_invocation_id))
 
     def get_logs(self) -> WorkflowLogs:
         """Unstable: this API will change.

--- a/src/orquestra/sdk/_base/_api/_wf_run.py
+++ b/src/orquestra/sdk/_base/_api/_wf_run.py
@@ -455,14 +455,16 @@ class WorkflowRun:
         }
 
     def get_artifact_serialized(self, task_invocation_id: ir.TaskInvocationId):
-        """
+        """Unstable: this API is not implemented for all runtimes yet.
+
         Returns serialized value calculated by given task if the task is finished.
         Raises exception if given task did not finish yet.
         """
         self._runtime.get_output(self.run_id, task_invocation_id)
 
     def get_artifact(self, task_invocation_id: ir.TaskInvocationId):
-        """
+        """Unstable: this API is not implemented for all runtimes yet.
+
         Returns value calculated by given task if the task is finished.
         Raises exception if given task did not finish yet.
         """

--- a/src/orquestra/sdk/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_base/_driver/_ce_runtime.py
@@ -427,6 +427,13 @@ class CERuntime(RuntimeInterface):
                 "- the authorization token was rejected by the remote cluster."
             ) from e
 
+    def get_output(
+        self, workflow_run_id: WorkflowRunId, task_invocation_id: TaskInvocationId
+    ) -> WorkflowResult:
+        raise exceptions.UnsupportedRuntimeFeature(
+            "CE runtime" "does not support get_output()" "function yet."
+        )
+
     @staticmethod
     def _list_wf_runs(
         func: PaginatedListFunc,

--- a/src/orquestra/sdk/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_base/_in_process_runtime.py
@@ -262,6 +262,13 @@ class InProcessRuntime(abc.RuntimeInterface):
             ),
         )
 
+    def get_output(
+        self, workflow_run_id: WorkflowRunId, task_invocation_id: ir.TaskInvocationId
+    ) -> WorkflowResult:
+        raise exceptions.UnsupportedRuntimeFeature(
+            "in_process runtime" "does not support get_output()" "function yet."
+        )
+
     def stop_workflow_run(
         self, workflow_run_id: WfRunId, *, force: t.Optional[bool] = None
     ):

--- a/src/orquestra/sdk/_base/abc.py
+++ b/src/orquestra/sdk/_base/abc.py
@@ -117,6 +117,29 @@ class RuntimeInterface(ABC, LogReader):
         raise NotImplementedError()
 
     @abstractmethod
+    def get_output(
+        self, workflow_run_id: WorkflowRunId, task_invocation_id: TaskInvocationId
+    ) -> WorkflowResult:
+        """Returns single output for a workflow run.
+
+        This method returns single artifact for given task.
+        When the task failed or was not yet completed, this method throws an exception
+
+        Careful: This method does NOT return status of a task.
+        Verify it beforehand to make sure if task failed/succeeded/is running.
+        You might get an exception
+
+        Args:
+            workflow_run_id: ID identifying the workflow run.
+            task_invocation_id: ID identifying single task run
+
+        Returns:
+            Whatever the task function returned, independent of the
+            ``@task(n_outputs=...)`` value.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
     def stop_workflow_run(
         self, workflow_run_id: WorkflowRunId, *, force: t.Optional[bool] = None
     ) -> None:

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -78,7 +78,9 @@ else:
             ray.shutdown()
 
         def get(
-            self, obj_refs: t.List[ray.ObjectRef], timeout: t.Optional[float] = None
+            self,
+            obj_refs: t.Union[ray.ObjectRef, t.List[ray.ObjectRef]],
+            timeout: t.Optional[float] = None,
         ):
             return ray.get(obj_refs, timeout=timeout)
 

--- a/src/orquestra/sdk/_ray/_client.py
+++ b/src/orquestra/sdk/_ray/_client.py
@@ -4,7 +4,11 @@
 """Facade module for Ray API."""
 import typing as t
 
-from orquestra.sdk.exceptions import WorkflowRunNotFoundError
+from orquestra.sdk.exceptions import (
+    NotFoundError,
+    UserTaskFailedError,
+    WorkflowRunNotFoundError,
+)
 
 try:
     import ray
@@ -82,7 +86,10 @@ else:
             obj_refs: t.Union[ray.ObjectRef, t.List[ray.ObjectRef]],
             timeout: t.Optional[float] = None,
         ):
-            return ray.get(obj_refs, timeout=timeout)
+            try:
+                return ray.get(obj_refs, timeout=timeout)
+            except (UserTaskFailedError, exceptions.GetTimeoutError, ValueError):
+                raise NotFoundError
 
         def remote(self, fn):
             return ray.remote(fn)

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -668,6 +668,12 @@ class RayRuntime(RuntimeInterface):
         Returns:
             Whatever the task function returned, independent of the
             ``@task(n_outputs=...)`` value.
+
+        Raises:
+            orquestra.sdk.exceptions.WorkflowRunNotFoundError: if no run with
+                ``workflow_run_id`` was found.
+            orquestra.sdk.exceptions.exceptions.NotFoundError: if requested task
+                either failed, did not complete yet or outputs are not available
         """
         try:
             _ = self.get_workflow_run_status(workflow_run_id)

--- a/src/orquestra/sdk/_ray/_dag.py
+++ b/src/orquestra/sdk/_ray/_dag.py
@@ -309,7 +309,7 @@ class RayParams:
 # Defensive timeout for Ray operations that are expected to be instant.
 # Sometimes, Ray behaves unintuitively.
 JUST_IN_CASE_TIMEOUT = 10.0
-
+QUICK_TIMEOUT = 1.0
 
 class RayRuntime(RuntimeInterface):
     def __init__(
@@ -647,6 +647,51 @@ class RayRuntime(RuntimeInterface):
                 serialized_succeeded_values,
             )
         )
+
+    def get_output(
+        self, workflow_run_id: WorkflowRunId, task_invocation_id: TaskInvocationId
+    ) -> WorkflowResult:
+        """Returns single output for a workflow run.
+
+        This method returns single artifact for given task.
+        When the task failed or was not yet completed, this method throws an exception
+
+        Careful: This method does NOT return status of a task.
+        Verify it beforehand to make sure if task failed/succeeded/is running.
+        You might get an exception
+
+        Args:
+            workflow_run_id: ID identifying the workflow run.
+            task_invocation_id: ID identifying single task run
+
+        Returns:
+            Whatever the task function returned, independent of the
+            ``@task(n_outputs=...)`` value.
+        """
+        succeeded_obj_ref: _client.ObjectRef = self._client.get_task_output_async(
+                workflow_id=workflow_run_id,
+                # We rely on the fact that _make_ray_dag() assigns invocation
+                # ID as the Ray task name.
+                task_id=task_invocation_id,
+            )
+
+        # We don't know if the values are ready or not, quickly timeout and
+        # throw if they are not
+        try:
+            succeeded_value: t.Any = self._client.get(
+                succeeded_obj_ref, timeout=QUICK_TIMEOUT
+            )
+        except Exception as e:
+            iks demo
+            return
+
+        # We need to check if the task output was a TaskResult or any other value.
+        # A TaskResult means this is a >=0.47.0 workflow and there is a serialized
+        # value (WorkflowResult) in TaskResult.packed
+        # Anything else is a <0.47.0 workflow and the value should be serialized
+
+        return succeeded_value.packed if isinstance(succeeded_value, TaskResult) else serde.result_from_artifact(succeeded_value, ir.ArtifactFormat.AUTO)
+
 
     def stop_workflow_run(
         self, workflow_run_id: WorkflowRunId, *, force: t.Optional[bool] = None

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -24,6 +24,7 @@ from orquestra.sdk._base._config import LOCAL_RUNTIME_CONFIGURATION
 from orquestra.sdk._base._env import RAY_TEMP_PATH_ENV
 from orquestra.sdk._base._testing import _example_wfs, _ipc
 from orquestra.sdk._base.abc import RuntimeInterface
+from orquestra.sdk._base.serde import deserialize
 from orquestra.sdk._ray import _build_workflow, _client, _dag, _ray_logs
 from orquestra.sdk.schema import ir
 from orquestra.sdk.schema.responses import JSONResult
@@ -719,11 +720,22 @@ class TestRayRuntimeMethods:
                 '{"__tuple__": true, "__values__": ["Zapata", "Computing"]}'
             )
 
+            artifacts = [
+                runtime.get_output(wf_run_id, inv_id) for inv_id in invocation_ids
+            ]
+
+            assert len(artifacts) == 4
             assert all(
                 [
-                    runtime.get_output(wf_run_id, inv_id)
-                    == JSONResult(value=expected_result)
-                    for inv_id in invocation_ids
+                    artifact == JSONResult(value=expected_result)
+                    for artifact in artifacts
+                ]
+            )
+
+            assert all(
+                [
+                    deserialize(artifact) == ("Zapata", "Computing")
+                    for artifact in artifacts
                 ]
             )
 


### PR DESCRIPTION
# The problem
We lacked the ability to get single artifact based on invocation ID. This caused us to always fetch all the artifacts, which is problematic for workflows with lots of artifacts where each individual artifacts is memory-heavy 

# This PR's solution
Add new API to get single artifact - now only implemented on Ray Runtime

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
