### PR TITLE
ci: fix stale cache

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,21 +45,29 @@ jobs:
         with:
           # Fetch depth 0 required to compare against `main`
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
-      # Used to create OS-agnostic python virtual env used for other steps.
-      - uses: syphar/restore-virtualenv@v1
-        id: cache-virtualenv
+          cache: 'pip'
 
+      # Installation method (venv/system/etc) affects Ray behavior. We're
+      # installing deps to a venv to align with the most common use case.
+      # Hence, we'll need to ensure the venv is always activated. More info:
+      # https://stackoverflow.com/questions/74668349/how-to-activate-a-virtualenv-in-a-github-action
       - name: Install deps
         shell: bash
-        run: make github_actions
+        run: |
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          make github_actions
 
       - name: Run tests and gather coverage stats
         shell: bash
-        run: make coverage
+        run: |
+          source ./venv/bin/activate
+          make coverage
 
       - name: Comment with code coverage
         # Conditionally run this step to prevent multiple comments

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,18 +33,23 @@ jobs:
 
       # Load a specific version of Python
       - name: Setup python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.9
           architecture: x64
+          cache: 'pip'
 
       - name: Install deps
         shell: bash
-        run: make github_actions
+        run: |
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          make github_actions
 
       - name: Run docs build
         shell: bash
         run: |
+          source ./venv/bin/activate
           make docs
 
       - name: Store as artifact

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -25,13 +25,26 @@ jobs:
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-      # Used to create OS-agnostic python virtual env used for other steps.
-      - uses: syphar/restore-virtualenv@v1
-        id: cache-virtualenv
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: x64
+          cache: 'pip'
+
+      # Installation method (venv/system/etc) affects Ray behavior. We're
+      # installing deps to a venv to align with the most common use case.
+      # Hence, we'll need to ensure the venv is always activated. More info:
+      # https://stackoverflow.com/questions/74668349/how-to-activate-a-virtualenv-in-a-github-action
+      - name: Install deps
+        shell: bash
+        run: |
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          make github_actions
 
       - name: Run performance test
         shell: bash
         run: |
-          make github_actions
+          source ./venv/bin/activate
           make performance

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -40,16 +40,18 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           architecture: x64
+          cache: 'pip'
 
+      # Installation method (venv/system/etc) affects Ray behavior. We're
+      # installing deps to a venv to align with the most common use case.
+      # Hence, we'll need to ensure the venv is always activated. More info:
+      # https://stackoverflow.com/questions/74668349/how-to-activate-a-virtualenv-in-a-github-action
       - name: Install deps
         shell: bash
-        run: make github_actions
-
-      # Ensure we don't run checks against stale, cached modules.
-      - name: Clean
-        shell: bash
         run: |
-          make clean
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          make github_actions
 
       # Pyright-specific step. Temporarily separated from the regular "style" check.
       # To be merged with 'make style' when we fix all pyright errors. Until then,
@@ -57,11 +59,13 @@ jobs:
       - name: Run pyright
         shell: bash
         run: |
+          source ./venv/bin/activate
           make pyright || true
 
       - name: Check style
         shell: bash
         run: |
+          source ./venv/bin/activate
           make style
 
   ruff:

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -27,8 +27,25 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v3
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: x64
+          cache: 'pip'
+
+      # Installation method (venv/system/etc) affects Ray behavior. We're
+      # installing deps to a venv to align with the most common use case.
+      # Hence, we'll need to ensure the venv is always activated. More info:
+      # https://stackoverflow.com/questions/74668349/how-to-activate-a-virtualenv-in-a-github-action
+      - name: Install deps
+        shell: bash
+        run: |
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          make github_actions
+
       - name: Run type checking test
         shell: bash
         run: |
-          make github_actions
+          source ./venv/bin/activate
           make user-typing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,3 +98,10 @@ per-file-ignores = [
 max-line-length = 88
 count = true
 arg-type-hints-in-docstring = false
+
+[tool.pyright]
+# pyright 1.1.340 and newer hangs up when analyzing this file.
+exclude = [
+    "./src/orquestra/sdk/_base/_traversal.py"
+]
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     tabulate
     rich~=13.5
     # For automatic login
-    aiohttp~=3.8
+    aiohttp~=3.8.0
     # Decoding JWTs
     PyJWT~=2.6
     # Capture stdout/stderr

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,7 +110,7 @@ dev =
     numpy
     pydoclint # Linter for python docstrings. Provides a flake8 plugin.
     pymarkdownlnt # Linter for markdown files.
-    pyright
+    pyright!=1.1.340,!=1.1.341 # these pyright versions hang up on _traveral.py
     pytest~=6.2
     pytest-cov>=2.12
     pytest-dependency

--- a/setup.cfg
+++ b/setup.cfg
@@ -110,7 +110,7 @@ dev =
     numpy
     pydoclint # Linter for python docstrings. Provides a flake8 plugin.
     pymarkdownlnt # Linter for markdown files.
-    pyright!=1.1.340,!=1.1.341 # these pyright versions hang up on _traveral.py
+    pyright
     pytest~=6.2
     pytest-cov>=2.12
     pytest-dependency

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -962,9 +962,12 @@ class TestDirectLogReader:
             assert len(logs.env_setup) > 0
 
             for tell_tale in ["Cloning virtualenv", "'pip', 'install'"]:
+                matched_lines = [
+                    line for line in logs.env_setup.out if tell_tale in line
+                ]
                 assert (
-                    len([line for line in logs.env_setup.out if tell_tale in line]) > 0
-                )
+                    len(matched_lines) > 0
+                ), f"No match. Full output:\n{logs.env_setup.out}"
 
     @staticmethod
     @pytest.mark.parametrize(


### PR DESCRIPTION
# The problem

1. During my work I needed a newer version of `aiohttp`. After bumping `install_requires`, the CI test runs failed because of [conflicting dependencies](https://github.com/zapatacomputing/orquestra-workflow-sdk/actions/runs/7246047008/job/19737217522). `pip._vendor.pkg_resources.ContextualVersionConflict: (aiohttp 3.8.6 [...] Requirement.parse('aiohttp>=3.9.0'), {'orquestra-sdk'})`. The only explanation was a stale virtual env cache that caused conflicts when installing a new version of `aiohttp`.
2. The `syphar/restore-virtualenv@v1` action has been deprecated. Nowadays, this functionality is part of `actions/setup-python`.
3. The new `actions/setup-python` doesn't automatically activate the virtual env; instead it works via system packages by default. The installation mode affects how Ray processes the Ray-managed virtual envs. With "system packages" as "outer", Ray "creates" new virtual envs, which changes the Ray env setup logs. This made our assertions fail in the integration tests.

Investigated with @SebastianMorawiec.

# This PR's solution


* Switches `syphar/restore-virtualenv@v1` to `actions/setup-python`.
* Installs deps to a virtual env on the CI, for all the workflows. 
* Improves the error message for the env setup integration tests.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
