### PR TITLE
fix: aiohttp warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 🐛 *Bug Fixes*
 
 * Workaround for Ray cluster not starting because of a missing dependency, `async_timeout`.
+* Fix warnings when used with `aiohttp>3.9`.
 
 💅 *Improvements*
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,7 +57,7 @@ install_requires =
     tabulate
     rich~=13.5
     # For automatic login
-    aiohttp~=3.8.0
+    aiohttp>=3.9.0
     # Decoding JWTs
     PyJWT~=2.6
     # Capture stdout/stderr

--- a/src/orquestra/sdk/_base/cli/_login/_login_server.py
+++ b/src/orquestra/sdk/_base/cli/_login/_login_server.py
@@ -7,6 +7,9 @@ from typing import Optional
 from aiohttp import web
 
 
+CLUSTER_URL_KEY = web.AppKey("cluster_url", str)
+
+
 class LoginServer:
     def __init__(self):
         self._token: Optional[str] = None
@@ -18,7 +21,7 @@ class LoginServer:
 
     async def start(self, cluster_url: str, listen_host: str = "127.0.0.1") -> int:
         app = web.Application()
-        app["cluster_url"] = cluster_url
+        app[CLUSTER_URL_KEY] = cluster_url
         app.add_routes([web.get("/state", self._state_handler)])
         self._runner = web.AppRunner(app)
         await self._runner.setup()
@@ -34,7 +37,7 @@ class LoginServer:
         res = web.StreamResponse(
             status=status_code,
             headers={
-                "Access-Control-Allow-Origin": request.app["cluster_url"],
+                "Access-Control-Allow-Origin": request.app[CLUSTER_URL_KEY],
                 "Content-Length": "0",
             },
         )

--- a/src/orquestra/sdk/_base/cli/_login/_login_server.py
+++ b/src/orquestra/sdk/_base/cli/_login/_login_server.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 from aiohttp import web
 
-
 CLUSTER_URL_KEY = web.AppKey("cluster_url", str)
 
 

--- a/tests/cli/test_login_server.py
+++ b/tests/cli/test_login_server.py
@@ -8,7 +8,7 @@ import sys
 import pytest
 from aiohttp import ClientResponse, ClientSession, web
 
-from orquestra.sdk._base.cli._login._login_server import LoginServer
+from orquestra.sdk._base.cli._login._login_server import CLUSTER_URL_KEY, LoginServer
 
 
 class TestLoginServer:
@@ -48,7 +48,7 @@ class TestHandlers:
         server = LoginServer()
 
         app = web.Application()
-        app["cluster_url"] = cluster_url
+        app[CLUSTER_URL_KEY] = cluster_url
         app.router.add_get("/state", server._state_handler)
 
         resp = asyncio.run(make_request(app, "/state"))
@@ -63,7 +63,7 @@ class TestHandlers:
         server = LoginServer()
 
         app = web.Application()
-        app["cluster_url"] = cluster_url
+        app[CLUSTER_URL_KEY] = cluster_url
         app.router.add_get("/state", server._state_handler)
 
         with pytest.raises(web.GracefulExit):


### PR DESCRIPTION
~Depends on #348.~

# The problem

* I need to update a dependency. I ran `pip install -U [...]`. It upgraded `aiohttp`.
* New-ish versions of `aiohttp` (>= 3.9.0) changed the recommended use of one functionality. They deprecated how we have been using it.,
* The deprecation emits warnings. We treat warnings as errors. Our test runs fail.

# This PR's solution

Makes use of the suggested `aiohttp` Python API.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
