### PR TITLE
int: declutter PR check view

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,7 +27,10 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.9", "3.10", "3.11"]
+        # Choice of Python versions to run against:
+        # * 3.9: the oldest supported version
+        # * 3.11: the latest officially supported version. Used in CE images.
+        python: ["3.9", "3.11"]
         # Extend the matrix with a job that prints coverage.
         # Because { os: "ubuntu-latest", python: "3.11" } is already in the matrix,
         # print_coverage: true is added to that job.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.11
           architecture: x64
           cache: 'pip'
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -26,7 +26,10 @@ jobs:
     # Run jobs for a couple of Python versions.
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11"]
+        # Choice of Python versions to run against:
+        # * 3.9: the oldest supported version
+        # * 3.11: the latest officially supported version. Used in CE images.
+        python: ["3.9", "3.11"]
 
     name: Style - Python ${{ matrix.python }}
     timeout-minutes: 25

--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: 3.11
           architecture: x64
           cache: 'pip'
 


### PR DESCRIPTION
# The problem

Our CI runs so many jobs that the PR checks list is getting difficult to browse. Meanwhile, not every combination of job-OS-Python brings benefit of running on every push, for every PR.

# This PR's solution

* Remove Python 3.10 from the PR set up matrix. We'll run against Python 3.11 and 3.9.
* Bump performance tests workflow to Python 3.11.

I'll remove the 3.10 job requirement from the repo settings when this PR is accepted.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
