### PR TITLE
feat: compact tracebacks in orq CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+* Tracebacks in `orq` are made more compact to help with copy and pasting when an issue happens.
 
 🥷 *Internal*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+
 * Tracebacks in `orq` are made more compact to help with copy and pasting when an issue happens.
 
 🥷 *Internal*

--- a/src/orquestra/sdk/_base/cli/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_errors.py
@@ -2,9 +2,7 @@
 # © Copyright 2023 Zapata Computing Inc.
 ################################################################################
 import sys
-import traceback
 from functools import singledispatch
-import itertools
 from pathlib import Path
 from types import TracebackType
 from typing import Optional
@@ -21,14 +19,10 @@ from orquestra.sdk.schema.responses import ResponseStatusCode
 
 
 def _compact_tb(tb: TracebackType):
-    return (
-        "{}:{}:{}".format(
-            tb.tb_frame.f_code.co_name,
-            Path(tb.tb_frame.f_code.co_filename).name,
-            tb.tb_lineno,
-        )
-        if tb is not None
-        else ""
+    return "{}:{}:{}".format(
+        tb.tb_frame.f_code.co_name,
+        Path(tb.tb_frame.f_code.co_filename).name,
+        tb.tb_lineno,
     )
 
 
@@ -37,7 +31,13 @@ def _compact_exc(e: BaseException, prefix: str = ""):
     exc_message = f"{e}"
     spacing = ": " if len(exc_message) > 0 else ""
     file_details = f"({_compact_tb(tb)})" if tb is not None else ""
-    return f"{prefix}[red][b]{type(e).__name__}{spacing}[/b]{exc_message} {file_details}[/red]"
+    return "{}[red][b]{}{}[/b]{} {}[/red]".format(
+        prefix,
+        type(e).__name__,
+        spacing,
+        exc_message,
+        file_details,
+    )
 
 
 def _print_traceback(

--- a/src/orquestra/sdk/_base/cli/_ui/_errors.py
+++ b/src/orquestra/sdk/_base/cli/_ui/_errors.py
@@ -4,8 +4,13 @@
 import sys
 import traceback
 from functools import singledispatch
+import itertools
+from pathlib import Path
+from types import TracebackType
+from typing import Optional
 
 import click
+import rich
 from rich.box import SIMPLE_HEAVY
 from rich.console import Console
 from rich.table import Column, Table
@@ -15,12 +20,50 @@ from orquestra.sdk._base._config import IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_
 from orquestra.sdk.schema.responses import ResponseStatusCode
 
 
-def _print_traceback(e: Exception):
-    # Newer Python versions like 3.10 allow passing just the exception object to
-    # traceback.format_exception(). Python 3.8 requires an explicit 3-argument form.
+def _compact_tb(tb: TracebackType):
+    return (
+        "{}:{}:{}".format(
+            tb.tb_frame.f_code.co_name,
+            Path(tb.tb_frame.f_code.co_filename).name,
+            tb.tb_lineno,
+        )
+        if tb is not None
+        else ""
+    )
 
-    tb_lines = traceback.format_exception(type(e), e, e.__traceback__)
-    click.secho("".join(tb_lines), fg="red", file=sys.stderr)
+
+def _compact_exc(e: BaseException, prefix: str = ""):
+    tb = e.__traceback__
+    exc_message = f"{e}"
+    spacing = ": " if len(exc_message) > 0 else ""
+    file_details = f"({_compact_tb(tb)})" if tb is not None else ""
+    return f"{prefix}[red][b]{type(e).__name__}{spacing}[/b]{exc_message} {file_details}[/red]"
+
+
+def _print_traceback(
+    e: BaseException, level: int = 0, console: Optional[rich.console.Console] = None
+):
+    _console = (
+        rich.console.Console(file=sys.stderr, highlight=False)
+        if console is None
+        else console
+    )
+    indent = "  " * level
+    _console.print(f"{indent}{_compact_exc(e)}")
+    if level == 0:
+        tb = e.__traceback__
+        while tb is not None:
+            _console.print(f"  [red]{_compact_tb(tb)}[/red]")
+            tb = tb.tb_next
+    next_exc = e.__cause__
+    context_exc = e.__context__
+    suppress_context = e.__suppress_context__
+    if next_exc is not None:
+        _console.print(f"{indent}[red b]Caused by:[/red b]")
+        _print_traceback(next_exc, level + 1, _console)
+    elif context_exc is not None and not suppress_context:
+        _console.print(f"{indent}[red b]While handling:[/red b]")
+        _print_traceback(context_exc, level + 1, _console)
 
 
 @singledispatch

--- a/tests/cli/ui/exception_makers.py
+++ b/tests/cli/ui/exception_makers.py
@@ -1,0 +1,51 @@
+################################################################################
+# © Copyright 2024 Zapata Computing Inc.
+################################################################################
+def except_from():
+    try:
+        try:
+            raise KeyError("key")
+        except KeyError as e:
+            raise ValueError("Invalid file") from e
+    except ValueError as e:
+        raise RuntimeError("Unable to do thing") from e
+
+
+def except_from_within_except():
+    try:
+        try:
+            raise KeyError("key")
+        except KeyError as e:
+            raise ValueError("Invalid file")
+    except ValueError as e:
+        raise RuntimeError("Unable to do thing") from e
+
+
+def except_within_except():
+    try:
+        try:
+            raise KeyError("key")
+        except KeyError as e:
+            raise ValueError("Invalid file")
+    except ValueError as e:
+        raise RuntimeError("Unable to do thing")
+
+
+def except_no_message():
+    raise RuntimeError()
+
+
+def except_plain():
+    raise RuntimeError("Unable to do thing")
+
+
+def _a():
+    except_plain()
+
+
+def _b():
+    _a()
+
+
+def except_stack():
+    _b()

--- a/tests/cli/ui/exception_makers.py
+++ b/tests/cli/ui/exception_makers.py
@@ -15,7 +15,7 @@ def except_from_within_except():
     try:
         try:
             raise KeyError("key")
-        except KeyError as e:
+        except KeyError:
             raise ValueError("Invalid file")
     except ValueError as e:
         raise RuntimeError("Unable to do thing") from e
@@ -25,9 +25,9 @@ def except_within_except():
     try:
         try:
             raise KeyError("key")
-        except KeyError as e:
+        except KeyError:
             raise ValueError("Invalid file")
-    except ValueError as e:
+    except ValueError:
         raise RuntimeError("Unable to do thing")
 
 

--- a/tests/cli/ui/test_errors.py
+++ b/tests/cli/ui/test_errors.py
@@ -1,8 +1,8 @@
 ################################################################################
 # © Copyright 2023-2024 Zapata Computing Inc.
 ################################################################################
-from typing import Callable, List
 import re
+from typing import Callable, List
 
 import pytest
 
@@ -19,7 +19,7 @@ from . import exception_makers
         (
             exception_makers.except_plain,
             [
-                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",  # noqa: E501
                 r"  test_print_traceback:test_errors.py:[\d]+",
                 r"  except_plain:exception_makers.py:[\d]+",
             ],
@@ -35,7 +35,7 @@ from . import exception_makers
         (
             exception_makers.except_stack,
             [
-                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",  # noqa: E501
                 r"  test_print_traceback:test_errors.py:[\d]+",
                 r"  except_stack:exception_makers.py:[\d]+",
                 r"  _b:exception_makers.py:[\d]+",
@@ -46,7 +46,7 @@ from . import exception_makers
         (
             exception_makers.except_from,
             [
-                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",  # noqa: E501
                 r"  test_print_traceback:test_errors.py:[\d]+",
                 r"  except_from:exception_makers.py:[\d]+",
                 r"Caused by:",
@@ -58,25 +58,25 @@ from . import exception_makers
         (
             exception_makers.except_within_except,
             [
-                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",  # noqa: E501
                 r"  test_print_traceback:test_errors.py:[\d]+",
                 r"  except_within_except:exception_makers.py:[\d]+",
                 r"While handling:",
-                r"  ValueError: Invalid file \(except_within_except:exception_makers.py:[\d]+\)",
+                r"  ValueError: Invalid file \(except_within_except:exception_makers.py:[\d]+\)",  # noqa: E501
                 r"  While handling:",
-                r"    KeyError: 'key' \(except_within_except:exception_makers.py:[\d]+\)",
+                r"    KeyError: 'key' \(except_within_except:exception_makers.py:[\d]+\)",  # noqa: E501
             ],
         ),
         (
             exception_makers.except_from_within_except,
             [
-                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",  # noqa: E501
                 r"  test_print_traceback:test_errors.py:[\d]+",
                 r"  except_from_within_except:exception_makers.py:[\d]+",
                 r"Caused by:",
-                r"  ValueError: Invalid file \(except_from_within_except:exception_makers.py:[\d]+\)",
+                r"  ValueError: Invalid file \(except_from_within_except:exception_makers.py:[\d]+\)",  # noqa: E501
                 r"  While handling:",
-                r"    KeyError: 'key' \(except_from_within_except:exception_makers.py:[\d]+\)",
+                r"    KeyError: 'key' \(except_from_within_except:exception_makers.py:[\d]+\)",  # noqa: E501
             ],
         ),
     ),

--- a/tests/cli/ui/test_errors.py
+++ b/tests/cli/ui/test_errors.py
@@ -1,11 +1,108 @@
 ################################################################################
-# © Copyright 2023 Zapata Computing Inc.
+# © Copyright 2023-2024 Zapata Computing Inc.
 ################################################################################
+from typing import Callable, List
+import re
+
 import pytest
 
 from orquestra.sdk import exceptions
 from orquestra.sdk._base.cli._ui import _errors
 from orquestra.sdk.schema.workflow_run import State
+
+from . import exception_makers
+
+
+@pytest.mark.parametrize(
+    "exception_func, expected_lines",
+    (
+        (
+            exception_makers.except_plain,
+            [
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"  test_print_traceback:test_errors.py:[\d]+",
+                r"  except_plain:exception_makers.py:[\d]+",
+            ],
+        ),
+        (
+            exception_makers.except_no_message,
+            [
+                r"RuntimeError \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"  test_print_traceback:test_errors.py:[\d]+",
+                r"  except_no_message:exception_makers.py:[\d]+",
+            ],
+        ),
+        (
+            exception_makers.except_stack,
+            [
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"  test_print_traceback:test_errors.py:[\d]+",
+                r"  except_stack:exception_makers.py:[\d]+",
+                r"  _b:exception_makers.py:[\d]+",
+                r"  _a:exception_makers.py:[\d]+",
+                r"  except_plain:exception_makers.py:[\d]+",
+            ],
+        ),
+        (
+            exception_makers.except_from,
+            [
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"  test_print_traceback:test_errors.py:[\d]+",
+                r"  except_from:exception_makers.py:[\d]+",
+                r"Caused by:",
+                r"  ValueError: Invalid file \(except_from:exception_makers.py:[\d]+\)",
+                r"  Caused by:",
+                r"    KeyError: 'key' \(except_from:exception_makers.py:[\d]+\)",
+            ],
+        ),
+        (
+            exception_makers.except_within_except,
+            [
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"  test_print_traceback:test_errors.py:[\d]+",
+                r"  except_within_except:exception_makers.py:[\d]+",
+                r"While handling:",
+                r"  ValueError: Invalid file \(except_within_except:exception_makers.py:[\d]+\)",
+                r"  While handling:",
+                r"    KeyError: 'key' \(except_within_except:exception_makers.py:[\d]+\)",
+            ],
+        ),
+        (
+            exception_makers.except_from_within_except,
+            [
+                r"RuntimeError: Unable to do thing \(test_print_traceback:test_errors.py:[\d]+\)",
+                r"  test_print_traceback:test_errors.py:[\d]+",
+                r"  except_from_within_except:exception_makers.py:[\d]+",
+                r"Caused by:",
+                r"  ValueError: Invalid file \(except_from_within_except:exception_makers.py:[\d]+\)",
+                r"  While handling:",
+                r"    KeyError: 'key' \(except_from_within_except:exception_makers.py:[\d]+\)",
+            ],
+        ),
+    ),
+)
+def test_print_traceback(
+    capsys: pytest.CaptureFixture[str],
+    exception_func: Callable[[], None],
+    expected_lines: List[str],
+):
+    """
+    This tests the traceback printing with some contrived examples.
+    Other tests in this file use proper `orquestra-sdk` exceptions
+    """
+    try:
+        exception_func()
+    except Exception as e:
+        _errors._print_traceback(e)
+
+    captured = capsys.readouterr()
+    actual_lines = captured.err.splitlines()
+
+    assert len(expected_lines) == len(actual_lines)
+
+    for expected_line, actual_line in zip(expected_lines, actual_lines):
+        match = re.match(expected_line, actual_line)
+        assert match is not None, (expected_line, actual_line)
 
 
 class TestPrettyPrintException:
@@ -55,7 +152,9 @@ class TestPrettyPrintException:
             ),
         ],
     )
-    def test_prints_to_std_streams(capsys, exc, stdout_marker: str):
+    def test_prints_to_std_streams(
+        capsys: pytest.CaptureFixture[str], exc: Exception, stdout_marker: str
+    ):
         # Given
         try:
             # Simulate raising the exception object. This is supposed to realistically
@@ -77,7 +176,9 @@ class TestPrettyPrintException:
 
         # Verifies that user sees the stack trace. This is useful for bug reports and
         # debugging.
-        assert "Traceback (most recent call last):\n  File" in captured.err
+        # We know the file and function, so let's search for that.
+        # We expect one instance on the Exception line, and one in the traceback
+        assert captured.err.count("test_prints_to_std_streams:test_errors.py") == 2
 
     @staticmethod
     @pytest.mark.parametrize(


### PR DESCRIPTION
# The problem

When an issue happens in the CLI, we get a text dump from Python's traceback.

# This PR's solution

Replaces our exception printing with a more compact version

<img width="472" alt="Screenshot 2024-03-07 at 09 47 05" src="https://github.com/zapatacomputing/orquestra-workflow-sdk/assets/70290797/eb195425-b276-4428-97ab-74cb0bf6af68">


# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
