### PR TITLE
Int: Add new GH workflow to install dependencies without cache

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,58 @@
+# This workflow runs tests and reports code coverage.
+
+# We need a workflow name to be able to schedule it from Github UI
+name: TestCoverage
+
+on:
+  # Triggers the workflow on push to main
+  push:
+    branches:
+      - Morawiec/wf
+  # runs at midnight every work day
+  schedule:
+    - cron: '0 0 * * 1-5'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # The job ID has to match repo settings for PR required checks
+  Nightly:
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 25
+
+    name: Coverage - Python ${{ matrix.python }} - ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Fetch depth 0 required to compare against `main`
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: x64
+
+
+      # Installation method (venv/system/etc) affects Ray behavior. We're
+      # installing deps to a venv to align with the most common use case.
+      # Hence, we'll need to ensure the venv is always activated. More info:
+      # https://stackoverflow.com/questions/74668349/how-to-activate-a-virtualenv-in-a-github-action
+      - name: Install deps
+        shell: bash
+        run: |
+          python3 -m venv ./venv
+          source ./venv/bin/activate
+          make github_actions
+
+      - name: Run tests and gather coverage stats
+        shell: bash
+        run: |
+          source ./venv/bin/activate
+          make coverage

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,10 +4,6 @@
 name: NightlyDependencyCheck
 
 on:
-  # Triggers the workflow on push to main
-  push:
-    branches:
-      - Morawiec/wf
   # runs at midnight every work day
   schedule:
     - cron: '0 0 * * 1-5'
@@ -34,6 +30,8 @@ jobs:
           # Fetch depth 0 required to compare against `main`
           fetch-depth: 0
 
+      # Note no pip cache. We want to check the installation against the
+      # latest possible package versions.
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 # This workflow runs tests and reports code coverage.
 
 # We need a workflow name to be able to schedule it from Github UI
-name: TestCoverage
+name: NightlyDependencyCheck
 
 on:
   # Triggers the workflow on push to main
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   # The job ID has to match repo settings for PR required checks
-  Nightly:
+  NightlyDependencyCheck:
     runs-on: ubuntu-latest
 
     timeout-minutes: 25


### PR DESCRIPTION
# The problem
https://zapatacomputing.atlassian.net/browse/ORQSDK-1022
We want to remove upper bounds on some of the dependencies, but that might cause some issues when new packages are released. 
# This PR's solution
Install everything on newest dependencies each night on GH actions to ensure we are good to go

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [ ] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
