### PR TITLE
fix: update signature for graphviz save.

### DIFF
--- a/tests/sdk/test_workflow.py
+++ b/tests/sdk/test_workflow.py
@@ -259,7 +259,7 @@ class TestGraph:
 
         # When
         graph = _simple_workflow().graph
-        graph.save(directory=dot_path)
+        graph.save(filename=dot_path)
 
         # Then
         assert dot_path.exists()

--- a/tests/sdk/test_workflow.py
+++ b/tests/sdk/test_workflow.py
@@ -249,9 +249,6 @@ class TestGraph:
     """
 
     @staticmethod
-    # graphviz is changing the signiture of `save()`.
-    # The change shouldn't affect our code.
-    @pytest.mark.filterwarnings("ignore::PendingDeprecationWarning")
     def test_is_exportable_to_dot(tmp_path):
         """
         Checks if the graph we build can be exported to a dot language.
@@ -262,7 +259,7 @@ class TestGraph:
 
         # When
         graph = _simple_workflow().graph
-        graph.save(dot_path)
+        graph.save(directory=dot_path)
 
         # Then
         assert dot_path.exists()


### PR DESCRIPTION
# The problem

```
PendingDeprecationWarning: The signature of save will be reduced to 1 positional arg [‘filename’]: pass directory=PosixPath(‘/tmp/pytest-of-runner/pytest-0/test_is_exportable_to_dot0/graph.gv’) as keyword arg(s)
venv/lib/python3.11/site-packages/graphviz/_tools.py:168: PendingDeprecationWarning
```

# This PR's solution

Updates the one place we actually use `.save()`

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [X] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
