### PR TITLE
Feat: Change statuses reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 🚨 *Breaking Changes*
 
+* Workflow status will be set to `FAILED` as soon as first task fails. Tasks that already started will finish their execution
+
 🔥 *Features*
 
 🧟 *Deprecations*

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -103,7 +103,7 @@ task_state_cases = [
     # Failed:
     # Tasks are still running, report as RUNNING
     + [
-        (_client.WorkflowStatus.FAILED, start, end, task_states, State.RUNNING)
+        (_client.WorkflowStatus.FAILED, start, end, task_states, State.FAILED)
         for start in [None, TEST_TIME]
         for end in [None, TEST_TIME]
         for task_states in [
@@ -141,7 +141,6 @@ def test_workflow_state_from_ray_meta(
             ray_wf_status,
             start_time,
             end_time,
-            ray_task_metas=[mock_ray_meta, mock_ray_meta],
         )
         == expected_orq_status
     )

--- a/tests/runtime/ray/test_dag.py
+++ b/tests/runtime/ray/test_dag.py
@@ -134,7 +134,6 @@ def test_workflow_state_from_ray_meta(
 ):
     mock_task_state: Mock = create_autospec(_dag._task_state_from_ray_meta)
     mock_task_state.side_effect = task_states
-    mock_ray_meta: dict = {"stats": {}}
     monkeypatch.setattr(_dag, "_task_state_from_ray_meta", mock_task_state)
     assert (
         _dag._workflow_state_from_ray_meta(


### PR DESCRIPTION
# The problem
We were overwriting Ray FAILED status with RUNNING in some cases which lead to WDR issues.
https://zapatacomputing.atlassian.net/browse/ORQSDK-1024

# This PR's solution
Change how we report status of a workflow where 1 task already failed, but there are still tasks running. It uses to be RUNNING now we go back to FAILED

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
