### PR TITLE
int: fix relative/absolute imports across to-be-wheels

### DIFF
--- a/src/orquestra/sdk/_client/_base/_api/_config.py
+++ b/src/orquestra/sdk/_client/_base/_api/_config.py
@@ -9,7 +9,6 @@ import warnings
 
 from packaging.version import parse as parse_version
 
-from orquestra.sdk._client._base._factory import build_runtime_from_config
 from orquestra.sdk.exceptions import ConfigFileNotFoundError, ConfigNameNotFoundError
 from orquestra.sdk.shared.abc import RuntimeInterface
 from orquestra.sdk.shared.schema.configs import (
@@ -20,6 +19,7 @@ from orquestra.sdk.shared.schema.configs import (
 )
 
 from .. import _config
+from .._factory import build_runtime_from_config
 
 
 class RuntimeConfig:

--- a/src/orquestra/sdk/_client/_base/_driver/_ce_runtime.py
+++ b/src/orquestra/sdk/_client/_base/_driver/_ce_runtime.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Protocol, Sequence, Union
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._client._base import _retry
 from orquestra.sdk.exceptions import IgnoredFieldWarning
 from orquestra.sdk.shared import serde
 from orquestra.sdk.shared._logs import _regrouping
@@ -33,6 +32,7 @@ from orquestra.sdk.shared.schema.workflow_run import (
     WorkspaceId,
 )
 
+from ..._base import _retry
 from . import _client, _exceptions, _models
 
 

--- a/src/orquestra/sdk/_client/_base/_driver/_client.py
+++ b/src/orquestra/sdk/_client/_base/_driver/_client.py
@@ -20,7 +20,6 @@ import requests
 from requests import codes
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._client._base._spaces._api import make_workspace_zri
 from orquestra.sdk.shared._regex import VERSION_REGEX
 from orquestra.sdk.shared._spaces._structs import ProjectRef
 from orquestra.sdk.shared._storage import TypeAdapter
@@ -37,6 +36,7 @@ from orquestra.sdk.shared.schema.workflow_run import (
     WorkspaceId,
 )
 
+from .._spaces._api import make_workspace_zri
 from . import _exceptions, _models
 
 

--- a/src/orquestra/sdk/_client/_base/_in_process_runtime.py
+++ b/src/orquestra/sdk/_client/_base/_in_process_runtime.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from datetime import timedelta
 
 from orquestra.sdk import exceptions, secrets
+from orquestra.sdk.shared import _dates, abc, serde
 from orquestra.sdk.shared._graphs import iter_invocations_topologically
 from orquestra.sdk.shared._spaces._structs import ProjectRef
 from orquestra.sdk.shared.dispatch import locate_fn_ref
@@ -24,8 +25,6 @@ from orquestra.sdk.shared.schema.workflow_run import (
     WorkflowRunSummary,
     WorkspaceId,
 )
-
-from ...shared import _dates, abc, serde
 
 WfRunId = str
 ArtifactValue = t.Any

--- a/src/orquestra/sdk/_client/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_client/_base/_testing/_example_wfs.py
@@ -5,7 +5,8 @@ import time
 from typing import Optional, Sequence, Tuple
 
 import orquestra.sdk as sdk
-import orquestra.sdk._client._base._testing._ipc as ipc
+
+from . import _ipc as ipc
 
 
 @sdk.task

--- a/src/orquestra/sdk/_client/_base/_traversal.py
+++ b/src/orquestra/sdk/_client/_base/_traversal.py
@@ -18,13 +18,13 @@ from functools import singledispatch
 from pip_api._parse_requirements import Requirement
 
 from orquestra.sdk import exceptions
+from orquestra.sdk.shared import _exec_ctx, serde
 from orquestra.sdk.shared.packaging._versions import (
     get_current_python_version,
     get_current_sdk_version,
 )
 from orquestra.sdk.shared.schema import ir, responses
 
-from ...shared import _exec_ctx, serde
 from . import _dsl, _git_url_utils, _workflow
 
 N_BYTES_IN_HASH = 8

--- a/src/orquestra/sdk/_client/_base/cli/_arg_resolvers.py
+++ b/src/orquestra/sdk/_client/_base/cli/_arg_resolvers.py
@@ -12,8 +12,6 @@ import typing as t
 import warnings
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._client._base import _services
-from orquestra.sdk._client._base._config import IN_PROCESS_CONFIG_NAME
 from orquestra.sdk.shared._logs._interfaces import WorkflowLogs
 from orquestra.sdk.shared.schema.configs import ConfigName
 from orquestra.sdk.shared.schema.ir import TaskInvocationId
@@ -26,6 +24,8 @@ from orquestra.sdk.shared.schema.workflow_run import (
     WorkspaceId,
 )
 
+from ..._base import _services
+from ..._base._config import IN_PROCESS_CONFIG_NAME
 from . import _repos
 from ._ui import _presenters, _prompts
 

--- a/src/orquestra/sdk/_client/_base/cli/_cli_logs.py
+++ b/src/orquestra/sdk/_client/_base/cli/_cli_logs.py
@@ -9,7 +9,7 @@ Logging should be only configured by apps.
 
 import logging
 
-from orquestra.sdk._client._base import _env
+from ..._base import _env
 
 
 def configure_verboseness_if_needed():  # pragma: no cover

--- a/src/orquestra/sdk/_client/_base/cli/_config/_list.py
+++ b/src/orquestra/sdk/_client/_base/cli/_config/_list.py
@@ -3,9 +3,9 @@
 ################################################################################
 
 """Code for 'orq login --list'."""
-from orquestra.sdk._client._base._jwt import check_jwt_without_signature_verification
 from orquestra.sdk.exceptions import ExpiredTokenError, InvalidTokenError
 
+from ..._jwt import check_jwt_without_signature_verification
 from .. import _repos
 from .._ui import _presenters, _prompts
 

--- a/src/orquestra/sdk/_client/_base/cli/_entry.py
+++ b/src/orquestra/sdk/_client/_base/cli/_entry.py
@@ -11,10 +11,10 @@ from pathlib import Path
 import click
 import cloup
 
-from orquestra.sdk._client._base.cli._ui._click_default_group import DefaultGroup
 from orquestra.sdk.shared.schema.configs import RuntimeName
 
 from . import _cli_logs
+from ._ui._click_default_group import DefaultGroup
 
 # Adds '-h' alias for '--help'
 CLICK_CTX_SETTINGS = {"help_option_names": ["-h", "--help"]}

--- a/src/orquestra/sdk/_client/_base/cli/_repos.py
+++ b/src/orquestra/sdk/_client/_base/cli/_repos.py
@@ -19,12 +19,6 @@ from typing_extensions import assert_never
 
 from orquestra import sdk
 from orquestra.sdk import exceptions
-from orquestra.sdk._client._base import _config, loader
-from orquestra.sdk._client._base._driver._client import (
-    DriverClient,
-    ExternalUriProvider,
-)
-from orquestra.sdk._client._base._jwt import check_jwt_without_signature_verification
 from orquestra.sdk.shared import _dates
 from orquestra.sdk.shared._logs._interfaces import LogOutput, WorkflowLogs
 from orquestra.sdk.shared.abc import ArtifactValue
@@ -47,6 +41,9 @@ from orquestra.sdk.shared.schema.workflow_run import (
     WorkspaceId,
 )
 
+from ..._base import _config, loader
+from ..._base._driver._client import DriverClient, ExternalUriProvider
+from ..._base._jwt import check_jwt_without_signature_verification
 from ._ui import _models as ui_models
 
 

--- a/src/orquestra/sdk/_client/_base/cli/_ui/_errors.py
+++ b/src/orquestra/sdk/_client/_base/cli/_ui/_errors.py
@@ -14,11 +14,9 @@ from rich.console import Console
 from rich.table import Column, Table
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._client._base._config import (
-    IN_PROCESS_CONFIG_NAME,
-    RAY_CONFIG_NAME_ALIAS,
-)
 from orquestra.sdk.shared.schema.responses import ResponseStatusCode
+
+from ...._base._config import IN_PROCESS_CONFIG_NAME, RAY_CONFIG_NAME_ALIAS
 
 
 def _compact_tb(tb: TracebackType):

--- a/src/orquestra/sdk/_client/_base/cli/_ui/_presenters.py
+++ b/src/orquestra/sdk/_client/_base/cli/_ui/_presenters.py
@@ -24,7 +24,6 @@ from rich.spinner import Spinner
 from rich.table import Column, Table
 from tabulate import tabulate
 
-from orquestra.sdk._client._base import _env
 from orquestra.sdk.shared import _dates, serde
 from orquestra.sdk.shared._dates import Instant
 from orquestra.sdk.shared._logs._interfaces import LogOutput, WorkflowLogs
@@ -37,6 +36,7 @@ from orquestra.sdk.shared.schema.configs import (
 from orquestra.sdk.shared.schema.ir import ArtifactFormat
 from orquestra.sdk.shared.schema.workflow_run import TaskInvocationId, WorkflowRunId
 
+from ...._base import _env
 from . import _errors
 from . import _models as ui_models
 

--- a/src/orquestra/sdk/_client/_base/loader.py
+++ b/src/orquestra/sdk/_client/_base/loader.py
@@ -17,7 +17,7 @@ import types
 import typing as t
 from importlib import abc
 
-from ...shared import dispatch
+from orquestra.sdk.shared import dispatch
 
 
 class FakeImportedAttribute:

--- a/src/orquestra/sdk/_client/dremio/_api.py
+++ b/src/orquestra/sdk/_client/dremio/_api.py
@@ -1,8 +1,7 @@
 ################################################################################
 # © Copyright 2023-2024 Zapata Computing Inc.
 ################################################################################
-from orquestra.sdk._client._base import _env
-
+from .._base import _env
 from ._env_var_reader import EnvVarReader
 from ._flight_facade import FlightCallOptions, FlightClient, FlightDescriptor
 

--- a/src/orquestra/sdk/_client/mlflow/_connection_utils.py
+++ b/src/orquestra/sdk/_client/mlflow/_connection_utils.py
@@ -13,16 +13,14 @@ from typing import Optional, Tuple
 from requests import Response, Session
 
 from orquestra import sdk
-from orquestra.sdk._client._base import _env
-from orquestra.sdk._client._base._config import read_config
-from orquestra.sdk._client._base._env import CURRENT_USER_ENV
-from orquestra.sdk._client._base._jwt import get_email_from_jwt_token
-from orquestra.sdk._client._base._services import ORQUESTRA_BASE_PATH
-from orquestra.sdk._client._base._spaces._api import (
-    make_workspace_url,
-    make_workspace_zri,
-)
 from orquestra.sdk.exceptions import ConfigNameNotFoundError, RuntimeConfigError
+
+from .._base import _env
+from .._base._config import read_config
+from .._base._env import CURRENT_USER_ENV
+from .._base._jwt import get_email_from_jwt_token
+from .._base._services import ORQUESTRA_BASE_PATH
+from .._base._spaces._api import make_workspace_url, make_workspace_zri
 
 DEFAULT_TEMP_ARTIFACTS_DIR: Path = ORQUESTRA_BASE_PATH / "mlflow" / "artifacts"
 RESOURCE_CATALOG_URI: str = "http://orquestra-resource-catalog.resource-catalog"

--- a/src/orquestra/sdk/_client/secrets/_api.py
+++ b/src/orquestra/sdk/_client/secrets/_api.py
@@ -5,11 +5,11 @@
 import typing as t
 
 from orquestra.sdk import exceptions as sdk_exc
-from orquestra.sdk._client._base import _dsl
 from orquestra.sdk.shared.schema.configs import ConfigName
 from orquestra.sdk.shared.schema.workflow_run import WorkspaceId
 
 from ...shared import _exec_ctx
+from .._base import _dsl
 from . import _auth, _exceptions, _models
 
 

--- a/src/orquestra/sdk/_client/secrets/_api.py
+++ b/src/orquestra/sdk/_client/secrets/_api.py
@@ -5,10 +5,10 @@
 import typing as t
 
 from orquestra.sdk import exceptions as sdk_exc
+from orquestra.sdk.shared import _exec_ctx
 from orquestra.sdk.shared.schema.configs import ConfigName
 from orquestra.sdk.shared.schema.workflow_run import WorkspaceId
 
-from ...shared import _exec_ctx
 from .._base import _dsl
 from . import _auth, _exceptions, _models
 

--- a/src/orquestra/sdk/_client/secrets/_auth.py
+++ b/src/orquestra/sdk/_client/secrets/_auth.py
@@ -6,10 +6,10 @@ import typing as t
 from pathlib import Path
 
 from orquestra.sdk import exceptions
-from orquestra.sdk._client._base import _config
-from orquestra.sdk._client._base._env import PASSPORT_FILE_ENV
 from orquestra.sdk.shared.schema.configs import ConfigName
 
+from .._base import _config
+from .._base._env import PASSPORT_FILE_ENV
 from ._client import SecretsClient
 
 # We assume that we can access the Config Service under a well-known URI if the passport

--- a/src/orquestra/sdk/runtime/_ray/_dag.py
+++ b/src/orquestra/sdk/runtime/_ray/_dag.py
@@ -14,6 +14,7 @@ import warnings
 from datetime import timedelta
 
 from orquestra.sdk import exceptions
+from orquestra.sdk.shared import _dates, serde
 from orquestra.sdk.shared._logs._interfaces import LogReader
 from orquestra.sdk.shared._spaces._structs import ProjectRef
 from orquestra.sdk.shared.abc import RuntimeInterface
@@ -31,7 +32,6 @@ from orquestra.sdk.shared.schema.workflow_run import (
     WorkspaceId,
 )
 
-from ...shared import _dates, serde
 from . import _client, _id_gen, _ray_logs
 from ._build_workflow import TaskResult, make_ray_dag
 from ._dirs import ray_temp_path

--- a/src/orquestra/sdk/shared/_graphs.py
+++ b/src/orquestra/sdk/shared/_graphs.py
@@ -4,7 +4,7 @@
 import typing as t
 from copy import copy
 
-from orquestra.sdk.shared.schema import ir
+from .schema import ir
 
 Node = str
 

--- a/src/orquestra/sdk/shared/_logs/_interfaces.py
+++ b/src/orquestra/sdk/shared/_logs/_interfaces.py
@@ -6,8 +6,8 @@ import typing as t
 from dataclasses import dataclass
 from enum import Enum
 
-from orquestra.sdk.shared.schema.ir import TaskInvocationId
-from orquestra.sdk.shared.schema.workflow_run import WorkflowRunId
+from ..schema.ir import TaskInvocationId
+from ..schema.workflow_run import WorkflowRunId
 
 
 @dataclass(frozen=True)

--- a/src/orquestra/sdk/shared/_spaces/_structs.py
+++ b/src/orquestra/sdk/shared/_spaces/_structs.py
@@ -3,7 +3,7 @@
 ################################################################################
 from dataclasses import dataclass
 
-from orquestra.sdk.shared.schema.workflow_run import ProjectId, WorkspaceId
+from ..schema.workflow_run import ProjectId, WorkspaceId
 
 
 @dataclass(frozen=True)

--- a/src/orquestra/sdk/shared/abc.py
+++ b/src/orquestra/sdk/shared/abc.py
@@ -14,11 +14,12 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 
 from orquestra.sdk.exceptions import WorkspacesNotSupportedError
-from orquestra.sdk.shared._logs._interfaces import LogOutput, LogReader, WorkflowLogs
-from orquestra.sdk.shared._spaces._structs import Project, ProjectRef, Workspace
-from orquestra.sdk.shared.schema.ir import TaskInvocationId, WorkflowDef
-from orquestra.sdk.shared.schema.responses import WorkflowResult
-from orquestra.sdk.shared.schema.workflow_run import (
+
+from ._logs._interfaces import LogOutput, LogReader, WorkflowLogs
+from ._spaces._structs import Project, ProjectRef, Workspace
+from .schema.ir import TaskInvocationId, WorkflowDef
+from .schema.responses import WorkflowResult
+from .schema.workflow_run import (
     State,
     WorkflowRun,
     WorkflowRunId,

--- a/src/orquestra/sdk/shared/dispatch.py
+++ b/src/orquestra/sdk/shared/dispatch.py
@@ -8,8 +8,8 @@ import sys
 import typing as t
 from functools import singledispatch
 
-from orquestra.sdk.shared import serde
-from orquestra.sdk.shared.schema import ir
+from ..schema import ir
+from . import serde
 
 
 def _locate_callable(fn_ref_dict) -> t.Callable:

--- a/src/orquestra/sdk/shared/packaging/_versions.py
+++ b/src/orquestra/sdk/shared/packaging/_versions.py
@@ -14,7 +14,8 @@ except ModuleNotFoundError:  # pragma: no cover
 import packaging.version
 
 from orquestra.sdk.exceptions import BaseRuntimeError
-from orquestra.sdk.shared.schema import ir
+
+from ..schema import ir
 
 
 class PackagingError(BaseRuntimeError):

--- a/src/orquestra/sdk/shared/schema/configs.py
+++ b/src/orquestra/sdk/shared/schema/configs.py
@@ -4,7 +4,7 @@
 from enum import Enum
 from typing import Any, Dict, Literal
 
-from orquestra.sdk.shared._storage import BaseModel
+from .._storage import BaseModel
 
 CONFIG_FILE_CURRENT_VERSION = "0.0.2"
 

--- a/src/orquestra/sdk/shared/schema/ir.py
+++ b/src/orquestra/sdk/shared/schema/ir.py
@@ -14,7 +14,7 @@ import warnings
 import pydantic
 from typing_extensions import Annotated
 
-from orquestra.sdk.shared._storage import BaseModel, GpuResourceType, field_validator
+from .._storage import BaseModel, GpuResourceType, field_validator
 
 ImportId = str
 SecretNodeId = str

--- a/src/orquestra/sdk/shared/schema/responses.py
+++ b/src/orquestra/sdk/shared/schema/responses.py
@@ -13,8 +13,7 @@ import typing as t
 from pydantic import Field
 from typing_extensions import Annotated
 
-from orquestra.sdk.shared._storage import BaseModel
-
+from .._storage import BaseModel
 from .ir import ArtifactFormat
 
 

--- a/src/orquestra/sdk/shared/schema/workflow_run.py
+++ b/src/orquestra/sdk/shared/schema/workflow_run.py
@@ -11,9 +11,9 @@ import enum
 import typing as t
 import warnings
 
-from orquestra.sdk.shared._dates import Instant
-from orquestra.sdk.shared._storage import BaseModel
-from orquestra.sdk.shared.schema.ir import TaskInvocationId, WorkflowDef
+from .._dates import Instant
+from .._storage import BaseModel
+from .ir import TaskInvocationId, WorkflowDef
 
 WorkflowRunId = str
 TaskRunId = str

--- a/src/orquestra/sdk/shared/serde.py
+++ b/src/orquestra/sdk/shared/serde.py
@@ -11,8 +11,8 @@ from pathlib import Path
 
 import cloudpickle  # type: ignore
 
-from orquestra.sdk.shared._storage import TypeAdapter
-from orquestra.sdk.shared.schema import ir, responses
+from ._storage import TypeAdapter
+from .schema import ir, responses
 
 CHUNK_SIZE = 40_000
 ENCODING = "base64"


### PR DESCRIPTION
# The problem

Imports weren't following the conventions established in the [design doc](https://zapatacomputing.atlassian.net/wiki/spaces/ORQSRUN/pages/851280058/Client-Server+Decoupling+Jan+2024#Interim-Solution).

# This PR's solution

* Uses relative imports when importing only within the same "wheel".
* Uses absolute imports when importing only across different "wheels".

# Checklist

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
