### PR TITLE
Feat: Add env_vars parameter and with_env_variables to task decorator to pass environmental variables for task execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 🔥 *Features*
 
 * Add new API `current_exec_ctx` which returns current `workspace_id` `project_id` and `config_name`. To be used inside a task.
+* Add 'env_vars' parameter to task and 'with_env_variables' function to pass environmental variables for task execution
 
 🧟 *Deprecations*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 🔥 *Features*
 
 * Add new API `current_exec_ctx` which returns current `workspace_id` `project_id` and `config_name`. To be used inside a task.
-* Add 'env_vars' parameter to task and 'with_env_variables' function to pass environmental variables for task execution
+* Add `env_vars` parameter to task and `with_env_variables()` function to pass environmental variables for task execution
 
 🧟 *Deprecations*
 

--- a/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/src/orquestra/sdk/_client/_base/_dsl.py
@@ -841,7 +841,10 @@ class ArtifactFuture(Generic[_TaskReturn]):
             Union[str, "orquestra.sdk._client._base._dsl.Sentinel"]  # pyright: ignore
         ] = Sentinel.NO_UPDATE,
         env_vars: Optional[
-            Union[Dict[str, str], "orquestra.sdk._client._base._dsl.Sentinel"]
+            Union[
+                Dict[str, str],
+                "orquestra.sdk._client._base._dsl.Sentinel",  # pyright: ignore
+            ]
         ] = Sentinel.NO_UPDATE,
     ) -> "ArtifactFuture":
         """
@@ -989,7 +992,8 @@ class ArtifactFuture(Generic[_TaskReturn]):
         self,
         env_vars: Optional[
             Union[
-                Dict[str, str], "orquestra.sdk._client._base._dsl.Sentinel"
+                Dict[str, str],
+                "orquestra.sdk._client._base._dsl.Sentinel",  # pyright: ignore
             ]  # pyright: ignore
         ] = Sentinel.NO_UPDATE,
     ) -> "ArtifactFuture":

--- a/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/src/orquestra/sdk/_client/_base/_dsl.py
@@ -1003,6 +1003,10 @@ class ArtifactFuture(Generic[_TaskReturn]):
 
         Doesn't modify existing invocations, returns a new one.
 
+        Env vars passed to that function are directly passed to Ray runtime_env object.
+        This function overwrites env_vars set by the `env_vars` parameter in the task,
+        it does not append them.
+
         Example usage::
 
             text = capitalize("hello").with_env_variables(

--- a/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/src/orquestra/sdk/_client/_base/_dsl.py
@@ -515,6 +515,7 @@ class TaskDef(wrapt.ObjectProxy, Generic[_TaskReturn]):
         custom_name: Optional[str] = None,
         fn_ref: Optional[FunctionRef] = None,
         max_retries: Optional[int] = None,
+        env_vars: Optional[Dict[str, str]] = None,
     ):
         if isinstance(fn, BuiltinFunctionType):
             raise NotImplementedError("Built-in functions are not supported as Tasks")
@@ -532,6 +533,7 @@ class TaskDef(wrapt.ObjectProxy, Generic[_TaskReturn]):
         self._source_import = source_import
         self._use_default_source_import = source_import is None
         self._max_retries = max_retries
+        self._env_vars = env_vars
 
         # task itself is not part of any workflow yet. Don't pass wf defaults
         self._resolve_task_source_data()
@@ -636,6 +638,7 @@ class TaskDef(wrapt.ObjectProxy, Generic[_TaskReturn]):
                 resources=self._resources,
                 custom_name=parse_custom_name(self._custom_name, signature),
                 custom_image=self._custom_image,
+                env_vars=self._env_vars,
             )
         )
 
@@ -701,6 +704,7 @@ class TaskInvocation(Generic[_TaskReturn]):
         resources: Resources = Resources(),
         custom_name: Optional[str] = None,
         custom_image: Optional[str] = None,
+        env_vars: Optional[Dict[str, str]] = None,
     ):
         self.task = task
         self.args = args
@@ -709,6 +713,7 @@ class TaskInvocation(Generic[_TaskReturn]):
         self.type = type
         self.custom_name = custom_name
         self.custom_image = custom_image
+        self.env_vars = env_vars
 
     def _asdict(self) -> Dict[str, Any]:
         return {
@@ -719,6 +724,7 @@ class TaskInvocation(Generic[_TaskReturn]):
             "resources": self.resources,
             "custom_name": self.custom_name,
             "custom_image": self.custom_image,
+            "env_vars": self.env_vars,
         }
 
 
@@ -745,10 +751,11 @@ class ArtifactFuture(Generic[_TaskReturn]):
 
     def __init__(
         self,
-        invocation: TaskInvocation[_TaskReturn],  # pyright: ignore
+        invocation: TaskInvocation[_TaskReturn],
         output_index: Optional[int] = None,
         custom_name: Optional[str] = DEFAULT_CUSTOM_NAME,
         serialization_format: ArtifactFormat = DEFAULT_SERIALIZATION_FORMAT,
+        env_vars: Optional[Dict[str, str]] = None,
     ):
         self.invocation = invocation
         # if the invocation returns multiple values, this the index in the output
@@ -757,6 +764,7 @@ class ArtifactFuture(Generic[_TaskReturn]):
         # metadata below
         self.custom_name = custom_name
         self.serialization_format = serialization_format
+        self.env_vars = env_vars
 
     def __repr__(self):
         return (
@@ -832,6 +840,9 @@ class ArtifactFuture(Generic[_TaskReturn]):
         custom_image: Optional[
             Union[str, "orquestra.sdk._client._base._dsl.Sentinel"]  # pyright: ignore
         ] = Sentinel.NO_UPDATE,
+        env_vars: Optional[
+            Union[Dict[str, str], "orquestra.sdk._client._base._dsl.Sentinel"]
+        ] = Sentinel.NO_UPDATE,
     ) -> "ArtifactFuture":
         """
         Assigns optional metadata related to task invocation used to generate this
@@ -851,6 +862,7 @@ class ArtifactFuture(Generic[_TaskReturn]):
             disk: amount of disk assigned to the task invocation
             gpu: amount of gpu assigned to the task invocation
             custom_image: docker image used to run the task invocation
+            env_vars: dict of environmental variables to be used in task
         """  # noqa: D205, D212
         self._check_if_destructured(
             fn_name=self.invocation.task._fn_name,
@@ -878,6 +890,11 @@ class ArtifactFuture(Generic[_TaskReturn]):
         else:
             new_custom_image = invocation.custom_image
 
+        if env_vars is not Sentinel.NO_UPDATE:
+            new_env_vars = env_vars
+        else:
+            new_env_vars = invocation.env_vars
+
         new_invocation = TaskInvocation(
             task=invocation.task,
             args=invocation.args,
@@ -885,6 +902,7 @@ class ArtifactFuture(Generic[_TaskReturn]):
             resources=new_resources,
             custom_name=invocation.custom_name,
             custom_image=new_custom_image,
+            env_vars=new_env_vars,
         )
 
         return ArtifactFuture(
@@ -966,6 +984,36 @@ class ArtifactFuture(Generic[_TaskReturn]):
         )
 
         return self.with_invocation_meta(custom_image=custom_image)
+
+    def with_env_variables(
+        self,
+        env_vars: Optional[
+            Union[
+                Dict[str, str], "orquestra.sdk._client._base._dsl.Sentinel"
+            ]  # pyright: ignore
+        ] = Sentinel.NO_UPDATE,
+    ) -> "ArtifactFuture":
+        """
+        Assigns optional metadata related to task invocation used to generate this
+        artifact.
+
+        Doesn't modify existing invocations, returns a new one.
+
+        Example usage::
+
+            text = capitalize("hello").with_env_variables(
+                {"MY_VAR_NAME": "MY_VAR_VALUE"}
+            )
+
+        Args:
+            env_vars: dict of all env variables to be set before task starts executing
+        """  # noqa: D205, D212
+        self._check_if_destructured(
+            fn_name=self.invocation.task._fn_name,
+            assign_type="env_vars",
+        )
+
+        return self.with_invocation_meta(env_vars=env_vars)
 
     def _check_if_destructured(self, fn_name: str, assign_type: str):
         """Check if an ArtifactFuture has been destructured.
@@ -1094,6 +1142,7 @@ def task(
     custom_image: Optional[str] = None,
     custom_name: Optional[str] = None,
     max_retries: Optional[int] = None,
+    env_vars: Optional[Dict[str, str]] = None,
 ) -> Callable[[Callable[..., _TaskReturn]], TaskDef[_TaskReturn]]:
     ...
 
@@ -1109,6 +1158,7 @@ def task(
     custom_image: Optional[str] = None,
     custom_name: Optional[str] = None,
     max_retries: Optional[int] = None,
+    env_vars: Optional[Dict[str, str]] = None,
 ) -> TaskDef[_TaskReturn]:
     ...
 
@@ -1123,6 +1173,7 @@ def task(
     custom_image: Optional[str] = None,
     custom_name: Optional[str] = None,
     max_retries: Optional[int] = None,
+    env_vars: Optional[Dict[str, str]] = None,
 ) -> Union[
     TaskDef[_TaskReturn], Callable[[Callable[..., _TaskReturn]], TaskDef[_TaskReturn]]
 ]:
@@ -1162,7 +1213,8 @@ def task(
             WARNING: retried workers might cause issues in MLflow logging, as retried
             workers share the same invocation ID, MLflow identifier will be shared
             between them.
-
+        env_vars: environmental variables that will be set on a worker before
+            the task is scheduled
     Raises:
         ValueError: when a task has fewer than 1 outputs.
     """
@@ -1200,6 +1252,7 @@ def task(
             custom_image=custom_image,
             custom_name=custom_name,
             max_retries=max_retries,
+            env_vars=env_vars,
         )
 
         return task_def

--- a/src/orquestra/sdk/_client/_base/_testing/_connections.py
+++ b/src/orquestra/sdk/_client/_base/_testing/_connections.py
@@ -70,6 +70,10 @@ def make_ray_conn(storage_path: t.Optional[str] = None) -> t.Iterator[_dag.RayPa
     """
     cluster_url_env = os.getenv("RAY_CLUSTER_URL")
 
+    # variable used for testing of overwriting env variables in worker nodes.
+    # it needs to be set before ray cluster is started
+    os.environ["MY_NEW_SECRET_ENV"] = "SET_BEFORE_RAY_STARTS"
+
     with ray_suitable_temp_dir() as tmp_path:
         if cluster_url_env is not None:
             # Connecting to a background cluster?

--- a/src/orquestra/sdk/_client/_base/_testing/_example_wfs.py
+++ b/src/orquestra/sdk/_client/_base/_testing/_example_wfs.py
@@ -403,3 +403,24 @@ def cause_env_setup_error():
     cause_env_setup_error_task task will cause pip to throw an error.
     """
     return [cause_env_setup_error_task()]
+
+
+class GetEnvWhileReduce:
+    def __init__(self):
+        import os
+
+        self.val = os.getenv("MY_UNIQUE_ENV")
+
+    def __reduce__(self):
+        return (GetEnvWhileReduce, tuple())
+
+
+@sdk.task(env_vars={"MY_UNIQUE_ENV": "MY_UNIQUE_VALUE"})
+def get_env_task(obj):
+    return obj.val
+
+
+@sdk.workflow
+def get_env_before_task_executes_task():
+    obj = GetEnvWhileReduce()
+    return [get_env_task(obj)]

--- a/src/orquestra/sdk/_client/_base/_traversal.py
+++ b/src/orquestra/sdk/_client/_base/_traversal.py
@@ -754,6 +754,7 @@ def _make_invocation_model(
         output_ids=graph.output_ids_for_invocation(invocation),
         resources=_make_resources_model(invocation.resources),
         custom_image=invocation.custom_image,
+        env_vars=invocation.env_vars,
     )
 
 

--- a/src/orquestra/sdk/_client/_base/_traversal.py
+++ b/src/orquestra/sdk/_client/_base/_traversal.py
@@ -340,7 +340,7 @@ def _iter_nodes(
 
 
 @singledispatch
-def _make_import_id(imp: _dsl.Import, import_hash: str):
+def _make_import_id(imp: _dsl.Import, import_hash: str) -> str:
     raise TypeError(f"Unknown import: {type(imp)}")
 
 

--- a/src/orquestra/sdk/_runtime/_ray/_build_workflow.py
+++ b/src/orquestra/sdk/_runtime/_ray/_build_workflow.py
@@ -550,6 +550,14 @@ def make_ray_dag(
         )
 
         pip = _import_pip_env(invocation, workflow_def, imports_pip_strings)
+        env_vars = invocation.env_vars
+        # if we have pip env setting, or env_vars then we create runtime object
+        # otherwise we just leave it as None
+        runtime_env = (
+            _client.RuntimeEnv(pip=pip if len(pip) > 0 else None, env_vars=env_vars)
+            if len(pip) > 0 or env_vars
+            else None
+        )
 
         ray_options = {
             # We're using task invocation ID as the Ray "task ID" instead of task run ID
@@ -558,7 +566,7 @@ def make_ray_dag(
             "name": invocation.id,
             "metadata": pydatic_to_json_dict(inv_metadata),
             # If there are any python packages to install for step - set runtime env
-            "runtime_env": (_client.RuntimeEnv(pip=pip) if len(pip) > 0 else None),
+            "runtime_env": runtime_env,
             "catch_exceptions": False,
             # We only want to execute workflow tasks once by default.
             # This is so there is only one task run ID per task, for scenarios where

--- a/src/orquestra/sdk/_shared/schema/ir.py
+++ b/src/orquestra/sdk/_shared/schema/ir.py
@@ -364,6 +364,9 @@ class TaskInvocation(BaseModel):
     # if not set, will fall back to TaskDef custom_image
     custom_image: t.Optional[str] = None
 
+    # Specific env_variables set for this given invocation
+    env_vars: t.Optional[t.Dict[str, str]] = None
+
 
 WorkflowDefName = str
 

--- a/tests/cli/test_repos.py
+++ b/tests/cli/test_repos.py
@@ -1525,6 +1525,7 @@ class TestWorkflowDefRepoIntegration:
                 "workflow_with_different_resources",
                 "wf_with_explicit_n_outputs",
                 "cause_env_setup_error",
+                "get_env_before_task_executes_task",
             ]
 
         @staticmethod

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -1431,8 +1431,8 @@ class TestEnvVars:
             inv3 = task().with_env_variables({"MY_UNIQUE_ENV": "NEW_SECRET"})
             return inv1, inv2, inv3
 
-        wf = wf().model
-        wf_run_id = runtime.create_workflow_run(wf, None, False)
+        wf_model = wf().model
+        wf_run_id = runtime.create_workflow_run(wf_model, None, False)
         _wait_to_finish_wf(wf_run_id, runtime)
         results = runtime.get_workflow_run_outputs_non_blocking(wf_run_id)
         artifacts = [res.value for res in results]

--- a/tests/runtime/ray/test_integration.py
+++ b/tests/runtime/ray/test_integration.py
@@ -1451,3 +1451,41 @@ class TestEnvVars:
         artifacts = [res.value for res in results]
         assert len(artifacts) == 1
         assert artifacts == ['"MY_UNIQUE_VALUE"']
+
+    def test_env_vars_iteration_with_already_exiting(
+        self, runtime: _dag.RayRuntime, monkeypatch
+    ):
+        @sdk.task(env_vars={"DIFFERENT_ENV": "NOT_OVERWRITTEN"})
+        def task_other_env():
+            import os
+
+            return os.getenv("MY_NEW_SECRET_ENV")
+
+        @sdk.task(env_vars={"MY_NEW_SECRET_ENV": "OVERWRITTEN"})
+        def task_same_env():
+            import os
+
+            return os.getenv("MY_NEW_SECRET_ENV")
+
+        @sdk.workflow
+        def wf():
+            inv1 = task_same_env()  # this one overwrites intentionally the same env_var
+            inv2 = task_other_env()  # this one uses different env var
+            inv3 = task_other_env().with_env_variables(
+                {"MY_NEW_SECRET_ENV": "OVERWRITTEN_IN_WF"}  # overwrites env var
+            )
+            inv4 = task_same_env().with_env_variables(
+                {"DIFFERENT_ENV_VAR": "DIFFERENT_VALUE"}  # does not overwrite env var
+            )
+            return inv1, inv2, inv3, inv4
+
+        os.environ["MY_NEW_SECRET_ENV"] = "ABC"
+        wf_model = wf().model
+        wf_run_id = runtime.create_workflow_run(wf_model, None, False)
+        _wait_to_finish_wf(wf_run_id, runtime)
+        results = runtime.get_workflow_run_outputs_non_blocking(wf_run_id)
+        artifacts = [res.value for res in results]
+        assert len(artifacts) == 4
+        assert '"OVERWRITTEN_IN_WF"' in artifacts  # expected in inv3
+        assert '"OVERWRITTEN"' in artifacts  # expected in inv1
+        assert artifacts.count('"SET_BEFORE_RAY_STARTS"') == 2  # expected in inv2 and 4

--- a/tests/sdk/test_artifact_future_methods.py
+++ b/tests/sdk/test_artifact_future_methods.py
@@ -49,6 +49,7 @@ CUSTOM_METADATA = {
     "disk": "99Gi",
     "gpu": "1",
     "custom_image": "zapatacomputing/orquestra-not-default",
+    "env_vars": {"A": "B"},
 }
 
 
@@ -161,7 +162,14 @@ def wf_with_custom_image_call():
 def wf_with_invocation_meta_call():
     future = _task_without_resources()
     assert isinstance(future, ArtifactFuture)
-    new_future = future.with_invocation_meta(**CUSTOM_METADATA)
+    new_future = future.with_invocation_meta(
+        cpu="2000m",
+        memory="100Gi",
+        disk="99Gi",
+        gpu="1",
+        custom_image="zapatacomputing/orquestra-not-default",
+        env_vars={"A": "B"},
+    )
     return [future, new_future]
 
 

--- a/tests/sdk/test_dsl.py
+++ b/tests/sdk/test_dsl.py
@@ -171,7 +171,7 @@ def test_task_invocation_as_dict():
         "kwargs": future.invocation.kwargs,
         "resources": future.invocation.resources,
         "custom_name": future.invocation.custom_name,
-        "env_var": future.invocation.env_vars,
+        "env_vars": future.invocation.env_vars,
         "custom_image": future.invocation.custom_image,
         "type": future.invocation.type,
     }

--- a/tests/sdk/test_dsl.py
+++ b/tests/sdk/test_dsl.py
@@ -171,7 +171,7 @@ def test_task_invocation_as_dict():
         "kwargs": future.invocation.kwargs,
         "resources": future.invocation.resources,
         "custom_name": future.invocation.custom_name,
-        "env_var": future.invocation.env_var,
+        "env_var": future.invocation.env_vars,
         "custom_image": future.invocation.custom_image,
         "type": future.invocation.type,
     }

--- a/tests/sdk/test_dsl.py
+++ b/tests/sdk/test_dsl.py
@@ -171,6 +171,7 @@ def test_task_invocation_as_dict():
         "kwargs": future.invocation.kwargs,
         "resources": future.invocation.resources,
         "custom_name": future.invocation.custom_name,
+        "env_var": future.invocation.env_var,
         "custom_image": future.invocation.custom_image,
         "type": future.invocation.type,
     }
@@ -554,6 +555,37 @@ def test_max_retries():
         ...
 
     assert task._max_retries == 5
+
+
+class TestEnvVars:
+    def test_simple_scenario(self):
+        @_dsl.task(env_vars={"X": "Y"})
+        def task():
+            ...
+
+        assert task._env_vars == {"X": "Y"}
+        artifact_future = task()
+        assert artifact_future.invocation.env_vars == {"X": "Y"}
+
+    def test_with_env_vars(self):
+        @_dsl.task(env_vars={"X": "Y"})
+        def task():
+            ...
+
+        new_artifact_future = task().with_env_variables({"W": "Z"})
+        original_artifact_future = task()
+        assert original_artifact_future.invocation.env_vars == {"X": "Y"}
+        assert new_artifact_future.invocation.env_vars == {"W": "Z"}
+
+    def test_chained_invocation_meta(self):
+        @_dsl.task
+        def task():
+            ...
+
+        new_artifact_future = (
+            task().with_custom_image("x").with_env_variables({"W": "Z"})
+        )
+        assert new_artifact_future.invocation.env_vars == {"W": "Z"}
 
 
 def test_default_import_type(monkeypatch):


### PR DESCRIPTION
# The problem
Users wanted to add env variables to tasks before it starts executing (cannot be done in tasks because it might be needed during import or unpickle: https://zapatacomputing.atlassian.net/browse/ORQSDK-1045)

# This PR's solution

Add new parameter to task - `env_vars` and new function `with_env_variables` 

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
