### PR TITLE
Fix: `workflow().with_resources(...)` properly copies default source and dependency imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 * `sdk.workflow(fn, resources=...)` will no longer show type errors from linters.
 * CLI log dumping now correctly saves stdout and stderr logs
+* `workflow().with_resources(...)` properly copies default source and dependency imports
 
 💅 *Improvements*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,9 @@ dependencies = [
     # Capture stdout/stderr
     "wurlitzer>=3.0",
     # For dremio client
-    "pyarrow>=10.0",
+    # pyarrow 16.0 crashed ray workers for unknown reason. Crashes were not
+    # reproducable on mac - so carefull with taking that restriction away.
+    "pyarrow>=10.0,<16.0",
     "pandas>=1.4",
 ]
 

--- a/src/orquestra/sdk/_client/_base/_workflow.py
+++ b/src/orquestra/sdk/_client/_base/_workflow.py
@@ -243,6 +243,8 @@ class WorkflowDef(Generic[_R]):
             data_aggregation=self._data_aggregation,
             workflow_args=self._workflow_args,
             workflow_kwargs=self._workflow_kwargs,
+            default_source_import=self.default_source_import,
+            default_dependency_imports=self.default_dependency_imports,
         )
 
 

--- a/tests/sdk/test_consistent_return_shapes.py
+++ b/tests/sdk/test_consistent_return_shapes.py
@@ -461,7 +461,9 @@ class TestCLI:
         m = re.match(
             r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
-        assert m is not None
+        assert (
+            m is not None
+        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert "Workflow Submitted!" in run_ce.stdout.decode()
 
@@ -520,7 +522,9 @@ class TestCLI:
         m = re.match(
             r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
-        assert m is not None
+        assert (
+            m is not None
+        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert "Workflow Submitted!" in run_ce.stdout.decode()
 
@@ -591,7 +595,9 @@ class TestCLIDownloadDir:
         m = re.match(
             r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
-        assert m is not None
+        assert (
+            m is not None
+        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert mock_ce_run_single in run_ce.stdout.decode()
 
@@ -669,7 +675,9 @@ class TestCLIDownloadDir:
         m = re.match(
             r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
-        assert m is not None
+        assert (
+            m is not None
+        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert mock_ce_run_multiple in run_ce.stdout.decode()
 

--- a/tests/sdk/test_consistent_return_shapes.py
+++ b/tests/sdk/test_consistent_return_shapes.py
@@ -461,9 +461,10 @@ class TestCLI:
         m = re.match(
             r"Workflow Submitted! Run ID: (?P<run_id>.*)", run_ray.stdout.decode()
         )
+
         assert (
             m is not None
-        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
+        ), f"STDOUT: {run_ray.stdout.decode()},\n\nSTDERR: {run_ray.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert "Workflow Submitted!" in run_ce.stdout.decode()
 
@@ -524,7 +525,7 @@ class TestCLI:
         )
         assert (
             m is not None
-        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
+        ), f"STDOUT: {run_ray.stdout.decode()},\n\nSTDERR: {run_ray.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert "Workflow Submitted!" in run_ce.stdout.decode()
 
@@ -597,7 +598,7 @@ class TestCLIDownloadDir:
         )
         assert (
             m is not None
-        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
+        ), f"STDOUT: {run_ray.stdout.decode()},\n\nSTDERR: {run_ray.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert mock_ce_run_single in run_ce.stdout.decode()
 
@@ -677,7 +678,7 @@ class TestCLIDownloadDir:
         )
         assert (
             m is not None
-        ), f"STDOUT: {run_ce.stdout.decode()},\n\nSTDERR: {run_ce.stderr.decode()}"
+        ), f"STDOUT: {run_ray.stdout.decode()},\n\nSTDERR: {run_ray.stderr.decode()}"
         run_id_ray = m.group("run_id").strip()
         assert mock_ce_run_multiple in run_ce.stdout.decode()
 

--- a/tests/sdk/test_workflow.py
+++ b/tests/sdk/test_workflow.py
@@ -401,7 +401,7 @@ def test_default_dependency_imports(dependency_imports, expected_imports):
     assert my_workflow._default_dependency_imports == expected_imports
 
 
-def test_with_resources_copy_imports():
+def test_with_resources_copies_imports():
     @sdk.workflow(
         default_dependency_imports=[sdk.PythonImports("abc")],
         default_source_import=sdk.GitImport(repo_url="abc", git_ref="xyz"),

--- a/tests/sdk/test_workflow.py
+++ b/tests/sdk/test_workflow.py
@@ -403,7 +403,7 @@ def test_default_dependency_imports(dependency_imports, expected_imports):
 
 def test_with_resources_copy_imports():
     @sdk.workflow(
-        default_dependency_imports=sdk.PythonImports("abc"),
+        default_dependency_imports=[sdk.PythonImports("abc")],
         default_source_import=sdk.GitImport(repo_url="abc", git_ref="xyz"),
     )
     def my_workflow():

--- a/tests/sdk/test_workflow.py
+++ b/tests/sdk/test_workflow.py
@@ -399,3 +399,24 @@ def test_default_dependency_imports(dependency_imports, expected_imports):
         pass
 
     assert my_workflow._default_dependency_imports == expected_imports
+
+
+def test_with_resources_copy_imports():
+    @sdk.workflow(
+        default_dependency_imports=sdk.PythonImports("abc"),
+        default_source_import=sdk.GitImport(repo_url="abc", git_ref="xyz"),
+    )
+    def my_workflow():
+        pass
+
+    initial_workflow = my_workflow()
+    modified_workflow = initial_workflow.with_resources(cpu="xyz")
+
+    assert (
+        initial_workflow.default_dependency_imports
+        == modified_workflow.default_dependency_imports
+    )
+    assert (
+        initial_workflow.default_source_import
+        == modified_workflow.default_source_import
+    )


### PR DESCRIPTION
# The problem

`with_resources` function omitted copying of the imports causing problems when this parameter was used

# This PR's solution

properly copy all parameters

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
