### PR TITLE
Feat: Add `WorkflowDef.with_head_node_resources()` function

### DIFF
--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 🔥 *Features*
 
+* Add `WorkflowDef.with_head_node_resources()` function to programmatically set head node resources for a workflow definition
+
 🧟 *Deprecations*
 
 👩‍🔬 *Experimental*

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
@@ -273,12 +273,18 @@ class WorkflowDef(Generic[_R]):
         # None is a valid option, so we are using the Sentinel object pattern:
         # https://python-patterns.guide/python/sentinel-object/
 
-        resources = self._data_aggregation.resources
+        resources = (
+            self._data_aggregation.resources
+            if self._data_aggregation
+            else _dsl.Resources()
+        )
+
         new_resources = _dsl.Resources(
             cpu=resources.cpu if cpu is _dsl.Sentinel.NO_UPDATE else cpu,
             memory=resources.memory if memory is _dsl.Sentinel.NO_UPDATE else memory,
             disk=resources.disk if disk is _dsl.Sentinel.NO_UPDATE else disk,
         )
+
         new_data_aggregation = _dsl.DataAggregation(resources=new_resources)
         return WorkflowDef(
             name=self._name,

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
@@ -247,6 +247,51 @@ class WorkflowDef(Generic[_R]):
             default_dependency_imports=self.default_dependency_imports,
         )
 
+    def with_head_node_resources(
+        self,
+        *,
+        cpu: Optional[Union[str, _dsl.Sentinel]] = _dsl.Sentinel.NO_UPDATE,
+        memory: Optional[Union[str, _dsl.Sentinel]] = _dsl.Sentinel.NO_UPDATE,
+        disk: Optional[Union[str, _dsl.Sentinel]] = _dsl.Sentinel.NO_UPDATE,
+    ) -> "WorkflowDef":
+        """Assigns optional metadata related to this workflow definition object.
+
+        Doesn't modify the existing workflow definition, returns a new one.
+
+        Example usage::
+
+            wf_run = my_workflow().with_head_node_resources(
+                cpu="10", memory="10Gi"
+            ).run("my_cluster")
+
+        Args:
+            cpu: amount of cpu requested for the head node
+            memory: amount of memory requested for the head node
+            disk: amount of disk requested for the head node
+        """
+        # Only use the new properties if they have not been changed.
+        # None is a valid option, so we are using the Sentinel object pattern:
+        # https://python-patterns.guide/python/sentinel-object/
+
+        resources = self._data_aggregation.resources
+        new_resources = _dsl.Resources(
+            cpu=resources.cpu if cpu is _dsl.Sentinel.NO_UPDATE else cpu,
+            memory=resources.memory if memory is _dsl.Sentinel.NO_UPDATE else memory,
+            disk=resources.disk if disk is _dsl.Sentinel.NO_UPDATE else disk,
+        )
+        new_data_aggregation = _dsl.DataAggregation(resources=new_resources)
+        return WorkflowDef(
+            name=self._name,
+            workflow_fn=self._fn,
+            fn_ref=self._fn_ref,
+            resources=self._resources,
+            data_aggregation=new_data_aggregation,
+            workflow_args=self._workflow_args,
+            workflow_kwargs=self._workflow_kwargs,
+            default_source_import=self.default_source_import,
+            default_dependency_imports=self.default_dependency_imports,
+        )
+
 
 class WorkflowTemplate(Generic[_P, _R]):
     """Result of applying the `@workflow` decorator to a function."""

--- a/projects/orquestra-sdk/tests/sdk/test_workflow.py
+++ b/projects/orquestra-sdk/tests/sdk/test_workflow.py
@@ -165,6 +165,7 @@ class TestHeadNodeResources:
 
         modified_model = wf().with_head_node_resources(**override_resouces).model
 
+        assert modified_model.data_aggregation is not None
         assert modified_model.data_aggregation.resources == expected_resources
 
 


### PR DESCRIPTION
# The problem
Users wanted to set head node resources programatically based on workflow size
https://zapatacomputing.atlassian.net/browse/ORQSDK-1038

# This PR's solution
Add new function that returns new workflow definition with head node resources

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
