### PR TITLE
chore: build CPU images on arm64 as well as amd64

### DIFF
--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -81,4 +81,4 @@ jobs:
           # DUE TO JSON LIMITATIONS, NEWLINES MUST BE EXPLICITLY ADDED AS \n
           docker_build_args: SDK_REQUIREMENT=${{ inputs.sdk_requirement }}
           # leave blank for linux/amd64 (recommended)
-          target_platforms: ''
+          target_platforms: 'linux/amd64,linux/arm64'

--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -13,6 +13,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+
 * `orquestra-sdk-base` CPU image is now built on `arm64`
 
 🥷 *Internal*

--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -13,6 +13,7 @@
 🐛 *Bug Fixes*
 
 💅 *Improvements*
+* `orquestra-sdk-base` CPU image is now built on `arm64`
 
 🥷 *Internal*
 


### PR DESCRIPTION
# The problem

We had a request to build these images on `arm64`

# This PR's solution

Update the CICD build to have `arm64` as a target.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
