### PR TITLE
Int: silence valid but impossible to fix pyright issue

### DIFF
--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
@@ -441,7 +441,12 @@ class WorkflowTemplate(Generic[_P, _R]):
                 "Parametrized WorkflowTemplates cannot be serialised yet"
             )
         else:
-            return self().model
+            # The reason we do type: ignore here is the following:
+            # self.__call__() accepts Paramspec _P as input types. But since we know
+            # that _P is empty (self.is_parametrized above doing as basically a type
+            # assertion) we can call __call__ that way, but  type checkers do not know
+            # that.
+            return self().model  # type: ignore
 
 
 # ----- decorator helpers -----

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
@@ -441,11 +441,18 @@ class WorkflowTemplate(Generic[_P, _R]):
                 "Parametrized WorkflowTemplates cannot be serialised yet"
             )
         else:
-            # The reason we do type: ignore here is the following:
-            # self.__call__() accepts Paramspec _P as input types. But since we know
-            # that _P is empty (self.is_parametrized above doing as basically a type
-            # assertion) we can call __call__ that way, but  type checkers do not know
-            # that.
+            # `WorkflowTemplate.__call__` accepts arguments if and only if the
+            # underlying function has parameters.
+            # The `self.is_parametrized` property tells us if the workflow function
+            # is parametrized.
+            # However, `self.__call__()` accepts a Paramspec `_P` as the input
+            # parameter type (`_P.args` and `_P.kwargs`).
+            # This causes a type error in Pyright because Pyright does not have the
+            # information that `is_parametrized` tells us if `_P` has any members.
+            # When `is_parametrized` is false, we know that `_P.args` and `_P.kwargs`
+            # are empty.
+            # This means, that when we are in this branch, we can be sure that
+            # `__call__` does not accept any args or kwargs.
             return self().model  # type: ignore
 
 


### PR DESCRIPTION
# The problem
New pyright dropped and detected valid issue - we are doing the right thing in the code, but there is no way for
type checkers to know that.

# This PR's solution
Just silence type checking for that line

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
