### PR TITLE
fix: correct DremioClient documentation

### DIFF
--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 📃 *Docs*
 
+* Correct docstring of DremioClient to remove erronious reference to `ORQ_DREMIO_HOST`.
+
 ## v0.64.0
 
 🔥 *Features*

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/dremio/_api.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/dremio/_api.py
@@ -11,7 +11,7 @@ class DremioClient:
 
     Requires specifying connection details as environment variables:
 
-        * ``ORQ_DREMIO_HOST``: the full dremio URI, with protocol and port. Example
+        * ``ORQ_DREMIO_URI``: the full dremio URI, with protocol and port. Example
           value: ``grpc+tls://ws2-12de2f.test-cluster.dremio-client.orquestra.io``
         * ``ORQ_DREMIO_USER``: your Dremio account email.
         * ``ORQ_DREMIO_PASS``: your Dremio account password.


### PR DESCRIPTION
# The problem

The docstring for DremioClient mentions the `ORQ_DREMIO_HOST` env var, and not `ORQ_DREMIO_URI`.

# This PR's solution

Replace the one with the other.

# Checklist

_Check that this PR satisfies the following items:_

- [X] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [X] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [X] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
