### PR TITLE
Feat: Deprecate the usage of running workflows on CE without specifying workspace ID 

### DIFF
--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 🧟 *Deprecations*
 
+* Deprecation of `WorkflowDef.run()` method when running on CE without specifying workspace.
+
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_ce_runtime.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_ce_runtime.py
@@ -162,6 +162,13 @@ class CERuntime(RuntimeInterface):
         Returns:
             the workflow run ID.
         """
+        if project is None or project.workspace_id is None:
+            warnings.warn(
+                "Please specify workspace ID directly for submitting CE workflows."
+                " Support for default workspace will be removed in the next release",
+                category=PendingDeprecationWarning,
+            )
+
         max_invocation_resources = _get_max_resources(workflow_def)
 
         if workflow_def.resources is not None:

--- a/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
+++ b/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
@@ -93,9 +93,10 @@ class TestCreateWorkflowRun:
         mocked_client.create_workflow_run.return_value = workflow_run_id
 
         # When
-        wf_run_id = runtime.create_workflow_run(
-            my_workflow.model, project=None, dry_run=False
-        )
+        with pytest.warns(PendingDeprecationWarning):
+            wf_run_id = runtime.create_workflow_run(
+                my_workflow.model, project=None, dry_run=False
+            )
 
         # Then
         mocked_client.create_workflow_def.assert_called_once_with(
@@ -125,11 +126,12 @@ class TestCreateWorkflowRun:
             mocked_client.create_workflow_run.return_value = workflow_run_id
 
             # When
-            _ = runtime.create_workflow_run(
-                workflow_parametrised_with_resources(memory="10Gi").model,
-                None,
-                dry_run=False,
-            )
+            with pytest.warns(PendingDeprecationWarning):
+                _ = runtime.create_workflow_run(
+                    workflow_parametrised_with_resources(memory="10Gi").model,
+                    None,
+                    dry_run=False,
+                )
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
@@ -151,11 +153,12 @@ class TestCreateWorkflowRun:
             mocked_client.create_workflow_run.return_value = workflow_run_id
 
             # When
-            _ = runtime.create_workflow_run(
-                workflow_parametrised_with_resources(cpu="1000m").model,
-                None,
-                dry_run=False,
-            )
+            with pytest.warns(PendingDeprecationWarning):
+                _ = runtime.create_workflow_run(
+                    workflow_parametrised_with_resources(cpu="1000m").model,
+                    None,
+                    dry_run=False,
+                )
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
@@ -177,9 +180,12 @@ class TestCreateWorkflowRun:
             mocked_client.create_workflow_run.return_value = workflow_run_id
 
             # When
-            _ = runtime.create_workflow_run(
-                workflow_parametrised_with_resources(gpu="1").model, None, dry_run=False
-            )
+            with pytest.warns(PendingDeprecationWarning):
+                _ = runtime.create_workflow_run(
+                    workflow_parametrised_with_resources(gpu="1").model,
+                    None,
+                    dry_run=False,
+                )
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
@@ -201,9 +207,10 @@ class TestCreateWorkflowRun:
             mocked_client.create_workflow_run.return_value = workflow_run_id
 
             # When
-            _ = runtime.create_workflow_run(
-                workflow_with_different_resources().model, None, dry_run=False
-            )
+            with pytest.warns(PendingDeprecationWarning):
+                _ = runtime.create_workflow_run(
+                    workflow_with_different_resources().model, None, dry_run=False
+                )
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
@@ -225,13 +232,14 @@ class TestCreateWorkflowRun:
             mocked_client.create_workflow_run.return_value = workflow_run_id
 
             # When
-            _ = runtime.create_workflow_run(
-                my_workflow()
-                .with_resources(cpu="1", memory="1.5G", gpu="1", nodes=20)
-                .model,
-                None,
-                dry_run=False,
-            )
+            with pytest.warns(PendingDeprecationWarning):
+                _ = runtime.create_workflow_run(
+                    my_workflow()
+                    .with_resources(cpu="1", memory="1.5G", gpu="1", nodes=20)
+                    .model,
+                    None,
+                    dry_run=False,
+                )
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
@@ -267,11 +275,12 @@ class TestCreateWorkflowRun:
         mocked_client.create_workflow_run.return_value = workflow_run_id
 
         # When
-        _ = runtime.create_workflow_run(
-            wf().model,
-            None,
-            dry_run=False,
-        )
+        with pytest.warns(PendingDeprecationWarning):
+            _ = runtime.create_workflow_run(
+                wf().model,
+                None,
+                dry_run=False,
+            )
 
         # Then
         mocked_client.create_workflow_run.assert_called_once_with(
@@ -307,11 +316,12 @@ class TestCreateWorkflowRun:
         mocked_client.create_workflow_run.return_value = workflow_run_id
 
         # When
-        _ = runtime.create_workflow_run(
-            wf().model,
-            None,
-            dry_run=False,
-        )
+        with pytest.warns(PendingDeprecationWarning):
+            _ = runtime.create_workflow_run(
+                wf().model,
+                None,
+                dry_run=False,
+            )
 
         # Then
         mocked_client.create_workflow_run.assert_called_once_with(
@@ -332,7 +342,10 @@ class TestCreateWorkflowRun:
 
             # When
             with pytest.raises(exceptions.WorkflowSyntaxError):
-                _ = runtime.create_workflow_run(my_workflow.model, None, dry_run=False)
+                with pytest.warns(PendingDeprecationWarning):
+                    _ = runtime.create_workflow_run(
+                        my_workflow.model, None, dry_run=False
+                    )
 
         def test_unknown_http(
             self, mocked_client: MagicMock, runtime: _ce_runtime.CERuntime
@@ -344,7 +357,10 @@ class TestCreateWorkflowRun:
 
             # When
             with pytest.raises(_exceptions.UnknownHTTPError):
-                _ = runtime.create_workflow_run(my_workflow.model, None, dry_run=False)
+                with pytest.warns(PendingDeprecationWarning):
+                    _ = runtime.create_workflow_run(
+                        my_workflow.model, None, dry_run=False
+                    )
 
         @pytest.mark.parametrize(
             "failure_exc", [_exceptions.InvalidTokenError, _exceptions.ForbiddenError]
@@ -360,7 +376,10 @@ class TestCreateWorkflowRun:
 
             # When
             with pytest.raises(exceptions.UnauthorizedError):
-                _ = runtime.create_workflow_run(my_workflow.model, None, dry_run=False)
+                with pytest.warns(PendingDeprecationWarning):
+                    _ = runtime.create_workflow_run(
+                        my_workflow.model, None, dry_run=False
+                    )
 
         def test_invalid_project(
             self,
@@ -396,7 +415,10 @@ class TestCreateWorkflowRun:
 
             # When
             with pytest.raises(exceptions.WorkflowRunNotStarted):
-                _ = runtime.create_workflow_run(my_workflow.model, None, dry_run=False)
+                with pytest.warns(PendingDeprecationWarning):
+                    _ = runtime.create_workflow_run(
+                        my_workflow.model, None, dry_run=False
+                    )
 
         @pytest.mark.parametrize("submitted_version", (None, "0.1.0"))
         @pytest.mark.parametrize(
@@ -416,7 +438,10 @@ class TestCreateWorkflowRun:
 
             # When
             with pytest.raises(exceptions.WorkflowRunNotStarted) as exc_info:
-                _ = runtime.create_workflow_run(my_workflow.model, None, dry_run=False)
+                with pytest.warns(PendingDeprecationWarning):
+                    _ = runtime.create_workflow_run(
+                        my_workflow.model, None, dry_run=False
+                    )
 
             error_message = str(exc_info.value)
             assert "This is an unsupported version of orquestra-sdk.\n" in error_message
@@ -445,7 +470,10 @@ class TestCreateWorkflowRun:
 
             # When
             with pytest.raises(_exceptions.UnknownHTTPError):
-                _ = runtime.create_workflow_run(my_workflow.model, None, dry_run=False)
+                with pytest.warns(PendingDeprecationWarning):
+                    _ = runtime.create_workflow_run(
+                        my_workflow.model, None, dry_run=False
+                    )
 
         @pytest.mark.parametrize(
             "failure_exc", [_exceptions.InvalidTokenError, _exceptions.ForbiddenError]
@@ -461,7 +489,10 @@ class TestCreateWorkflowRun:
 
             # When
             with pytest.raises(exceptions.UnauthorizedError):
-                _ = runtime.create_workflow_run(my_workflow.model, None, dry_run=False)
+                with pytest.warns(PendingDeprecationWarning):
+                    _ = runtime.create_workflow_run(
+                        my_workflow.model, None, dry_run=False
+                    )
 
 
 class TestGetWorkflowRunStatus:
@@ -2090,7 +2121,8 @@ def test_ce_resources(
 
     # When
     with context as exec_info:
-        runtime.create_workflow_run(wf().model, None, dry_run=False)
+        with pytest.warns(PendingDeprecationWarning):
+            runtime.create_workflow_run(wf().model, None, dry_run=False)
 
     # Then
     if raises:

--- a/projects/orquestra-sdk/tests/sdk/test_consistent_return_shapes.py
+++ b/projects/orquestra-sdk/tests/sdk/test_consistent_return_shapes.py
@@ -348,7 +348,9 @@ class TestAPI:
         # GIVEN
         ip_run = sig().run(sdk.RuntimeConfig.in_process())
         ray_run = sig().run(sdk.RuntimeConfig.ray())
-        ce_run = sig().run(sdk.RuntimeConfig.load("CE"))
+        ce_run = sig().run(
+            sdk.RuntimeConfig.load("CE"), workspace_id="ws", project_id="proj"
+        )
         for run in [ip_run, ray_run]:
             run.wait_until_finished()
 
@@ -387,7 +389,10 @@ class TestAPI:
         # GIVEN
         ip_run = wf_return_multiple_packed_values().run(sdk.RuntimeConfig.in_process())
         ray_run = wf_return_multiple_packed_values().run(sdk.RuntimeConfig.ray())
-        ce_run = wf_return_multiple_packed_values().run(sdk.RuntimeConfig.load("CE"))
+
+        ce_run = wf_return_multiple_packed_values().run(
+            sdk.RuntimeConfig.load("CE"), workspace_id="ws", project_id="proj"
+        )
 
         for run in [ip_run, ray_run]:
             run.wait_until_finished()


### PR DESCRIPTION
# The problem
https://zapatacomputing.atlassian.net/browse/ORQSDK-1060
We want to sunset personal workspaces on CE

# This PR's solution
Deprecate the usage of running wokrflows on CE without specifying workspace ID 

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
