### PR TITLE
Feat: Increase Ray venv setup timeout from 10 mins to 1 hour

### DIFF
--- a/projects/orquestra-workflow-runtime/CHANGELOG.md
+++ b/projects/orquestra-workflow-runtime/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 🔥 *Features*
 
+* Increase Ray venv setup timeout from 10 mins to 1 hour
+
 🧟 *Deprecations*
 
 👩‍🔬 *Experimental*

--- a/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_build_workflow.py
+++ b/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_build_workflow.py
@@ -31,6 +31,7 @@ from . import _client, _id_gen
 from ._dirs import redirected_logs_dir
 from ._env import RAY_DOWNLOAD_GIT_IMPORTS_ENV, RAY_SET_CUSTOM_IMAGE_RESOURCES_ENV
 from ._logs import _markers
+from ._ray_settings import VENV_SETUP_TIMEOUT_SECONDS
 from ._wf_metadata import InvUserMetadata, pydatic_to_json_dict
 
 DEFAULT_IMAGE_TEMPLATE = "hub.nexus.orquestra.io/zapatacomputing/orquestra-sdk-base:{}"
@@ -557,12 +558,14 @@ def make_ray_dag(
 
         pip = _import_pip_env(invocation, workflow_def, imports_pip_strings)
         env_vars = invocation.env_vars
-        # if we have pip env setting, or env_vars then we create runtime object
-        # otherwise we just leave it as None
-        runtime_env = (
-            _client.RuntimeEnv(pip=pip if len(pip) > 0 else None, env_vars=env_vars)
-            if len(pip) > 0 or env_vars
-            else None
+
+        runtime_env_config = _client.RuntimeEnvConfig(
+            setup_timeout_seconds=VENV_SETUP_TIMEOUT_SECONDS
+        )
+        runtime_env = _client.RuntimeEnv(
+            pip=pip if len(pip) > 0 else None,
+            env_vars=env_vars if env_vars else None,
+            config=runtime_env_config,
         )
 
         ray_options = {

--- a/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_client.py
+++ b/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_client.py
@@ -44,6 +44,7 @@ else:
     WorkflowStorage = WorkflowStorage
     Storage = RayStorage
     RuntimeEnv = ray.runtime_env.RuntimeEnv
+    RuntimeEnvConfig = ray.runtime_env.RuntimeEnvConfig
     FunctionNode = ray.dag.FunctionNode
     LogPrefixActorName = ray._private.ray_constants.LOG_PREFIX_ACTOR_NAME
     LogPrefixTaskName = ray._private.ray_constants.LOG_PREFIX_TASK_NAME

--- a/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_ray_settings.py
+++ b/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_ray_settings.py
@@ -1,0 +1,5 @@
+################################################################################
+# © Copyright 2024 Zapata Computing Inc.
+################################################################################
+
+VENV_SETUP_TIMEOUT_SECONDS = 60 * 60  # 1 hour for venv installation should be enough


### PR DESCRIPTION
# The problem
Some user workflows already started to fail due to the long pip backtracking (over 10 mins)
https://zapatacomputing.atlassian.net/browse/ORQSDK-1057

# This PR's solution
Increase the timeout to 1 hour


# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
