### PR TITLE
Fix: revert dependency to ray[default]

### DIFF
--- a/projects/orquestra-workflow-runtime/pyproject.toml
+++ b/projects/orquestra-workflow-runtime/pyproject.toml
@@ -50,6 +50,7 @@ ray = [
     "async-timeout",       # Ray depends on this, but its missing from ray requirements. Can be removed when https://github.com/ray-project/ray/issues/41267 is fixed.
 ]
 
+# this extra is left for backward-compatibility reasons.
 dashboard = [
     "orquestra-workflow-runtime[ray]",
 ]

--- a/projects/orquestra-workflow-runtime/pyproject.toml
+++ b/projects/orquestra-workflow-runtime/pyproject.toml
@@ -45,14 +45,13 @@ dependencies = [
 
 [project.optional-dependencies]
 ray = [
-    "ray==2.30.0",
+    "ray[default]==2.30.0",
     "virtualenv>=20.0.24, !=20.21.1",  # Ray depends on this, but it's missing from the base requirements.
     "async-timeout",       # Ray depends on this, but its missing from ray requirements. Can be removed when https://github.com/ray-project/ray/issues/41267 is fixed.
 ]
 
 dashboard = [
     "orquestra-workflow-runtime[ray]",
-    "ray[default]",    
 ]
 
 all = ["orquestra-workflow-runtime[dashboard]"]


### PR DESCRIPTION
# The problem
When running ray workflows without installing [default] extra, ray behaves weirdly - some workflow fail without any particular reason, other are stuck.
This all was tracked down to change we did to reduce number of dependnecies

# This PR's solution
Revert the change - always install ray[default] in our system as we use ray only to run workflows.

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
