### PR TITLE
Fix: Fix `orq wf logs` command when no logs are available

### DIFF
--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -6,19 +6,23 @@
 
 🔥 *Features*
 
-* `workflow` decorator now accepts optional `head_node_image` parameter to select what image should be used in head node.
-
 🧟 *Deprecations*
 
 👩‍🔬 *Experimental*
 
 🐛 *Bug Fixes*
 
+* fix `orq wf logs` CLI command when WF didn't emit any logs
+
 💅 *Improvements*
 
 🥷 *Internal*
 
-📃 *Docs*
+## v1.1.0
+
+🔥 *Features*
+
+* `workflow` decorator now accepts optional `head_node_image` parameter to select what image should be used in head node.
 
 ## v1.0.0
 
@@ -28,18 +32,6 @@
 
 * New function: `sdk.infer_git_ref` to infer git refs for Git Imports.
 * SDK dependency will be explicitly added as a PythonImport to every task submitted. Version will be inferred from local version during submission.
-
-🧟 *Deprecations*
-
-👩‍🔬 *Experimental*
-
-🐛 *Bug Fixes*
-
-💅 *Improvements*
-
-🥷 *Internal*
-
-📃 *Docs*
 
 ## v0.66.0
 

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/cli/_arg_resolvers.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/cli/_arg_resolvers.py
@@ -281,6 +281,9 @@ class WFRunResolver:
             for log_type in user_switch_values
             if log_availibility[log_type] and user_switch_values[log_type] is None
         ]
+        if not valid_switches:
+            warnings.warn("No logs are available for this workflow.")
+            return ret_switch_values
 
         choice: t.Union[str, WorkflowLogs.WorkflowLogTypeName] = self._prompter.choice(
             [(switch.value, switch) for switch in valid_switches],

--- a/projects/orquestra-sdk/tests/cli/test_arg_resolvers.py
+++ b/projects/orquestra-sdk/tests/cli/test_arg_resolvers.py
@@ -1,6 +1,7 @@
 ################################################################################
 # © Copyright 2023 - 2024 Zapata Computing Inc.
 ################################################################################
+import contextlib
 import typing as t
 from datetime import timedelta
 from types import ModuleType
@@ -884,24 +885,38 @@ class TestWFRunResolver:
             if other_choice:
                 expected_choices.append(WorkflowLogs.WorkflowLogTypeName.OTHER)
 
+            if not any([task_choice, system_choice, env_choice, other_choice]):
+                expected_call = 0
+                context = pytest.warns(UserWarning)
+            else:
+                expected_call = 1
+                context = contextlib.nullcontext()
+
             # When
-            _ = resolver.resolve_log_switches(
-                None,
-                None,
-                None,
-                None,
-                WorkflowLogs(
-                    per_task=per_task, system=system, env_setup=env_setup, other=other
-                ),
-            )
+            with context:
+                _ = resolver.resolve_log_switches(
+                    None,
+                    None,
+                    None,
+                    None,
+                    WorkflowLogs(
+                        per_task=per_task,
+                        system=system,
+                        env_setup=env_setup,
+                        other=other,
+                    ),
+                )
 
             # Then
-            prompter.choice.assert_called_once_with(
-                [(v.value, v) for v in expected_choices],
-                message="available logs",
-                default="all",
-                allow_all=True,
-            )
+            if expected_call:
+                prompter.choice.assert_called_once_with(
+                    [(v.value, v) for v in expected_choices],
+                    message="available logs",
+                    default="all",
+                    allow_all=True,
+                )
+            else:
+                prompter.choice.assert_not_called()
 
         @staticmethod
         @pytest.mark.parametrize(

--- a/projects/orquestra-sdk/tests/cli/test_arg_resolvers.py
+++ b/projects/orquestra-sdk/tests/cli/test_arg_resolvers.py
@@ -885,6 +885,7 @@ class TestWFRunResolver:
             if other_choice:
                 expected_choices.append(WorkflowLogs.WorkflowLogTypeName.OTHER)
 
+            context: t.Union[contextlib.nullcontext, pytest.WarningsRecorder]
             if not any([task_choice, system_choice, env_choice, other_choice]):
                 expected_call = 0
                 context = pytest.warns(UserWarning)

--- a/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
+++ b/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
@@ -1801,12 +1801,6 @@ class TestGetWorkflowLogs:
         monkeypatch: pytest.MonkeyPatch,
     ):
         # Given
-        sys_logs = [
-            _models.K8sEventLog(tag=tag, log={"some": "values", "another": "thing"}),
-            _models.RayHeadNodeEventLog(tag=tag, log="Ray head log line"),
-            _models.RayWorkerNodeEventLog(tag=tag, log="Ray worker log line"),
-            _models.UnknownEventLog(tag=tag, log="Unknown log line"),
-        ]
         wf_run = Mock()
         wf_run.workflow_def.task_invocations.keys.return_value = ["inv1", "inv2"]
         mocked_client.get_workflow_run.return_value = wf_run

--- a/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
+++ b/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
@@ -1791,6 +1791,42 @@ class TestGetWorkflowLogs:
 
         assert logs.other == LogOutput(out=["line 2", "line 3"], err=["line 1"])
 
+    def test_no_logs_exception(
+        self,
+        mocked_client: MagicMock,
+        runtime: _ce_runtime.CERuntime,
+        tag: str,
+        ray_logs: List[_models.WorkflowLogMessage],
+        workflow_run_id: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # Given
+        sys_logs = [
+            _models.K8sEventLog(tag=tag, log={"some": "values", "another": "thing"}),
+            _models.RayHeadNodeEventLog(tag=tag, log="Ray head log line"),
+            _models.RayWorkerNodeEventLog(tag=tag, log="Ray worker log line"),
+            _models.UnknownEventLog(tag=tag, log="Unknown log line"),
+        ]
+        wf_run = Mock()
+        wf_run.workflow_def.task_invocations.keys.return_value = ["inv1", "inv2"]
+        mocked_client.get_workflow_run.return_value = wf_run
+
+        mocked_client.get_workflow_run_logs.side_effect = (
+            _exceptions.WorkflowRunLogsNotFound("abc")
+        )
+
+        # When
+        logs = runtime.get_workflow_logs(workflow_run_id)
+
+        # Then
+        mocked_client.get_workflow_run_logs.assert_called_once_with(workflow_run_id)
+
+        assert logs.env_setup == LogOutput(out=[], err=[])
+
+        assert logs.system == LogOutput(out=[], err=[])
+
+        assert logs.other == LogOutput(out=[], err=[])
+
     @pytest.mark.parametrize(
         "exception, expected_exception, exception_args",
         [


### PR DESCRIPTION
# The problem
When trying to get logs from WF that didnt generate any logs users would be prompted with useless stacktrace and 
`Something unexpected happened. Please consider reporting this error to the SDK team at Zapata Computing.`
info

# This PR's solution
Fix how we handle no-logs message during log extraction

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
