### PR TITLE
Feat: Add ability to pass int as GPU number in resources

### DIFF
--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 🔥 *Features*
 
+* Allow to set `int` as GPU number in task resources.
+
 🧟 *Deprecations*
 
 👩‍🔬 *Experimental*

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_models.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_models.py
@@ -283,7 +283,7 @@ class Resources(BaseModel):
     memory: Optional[str] = pydantic.Field(
         pattern=r"^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
     )
-    gpu: Optional[str] = pydantic.Field(pattern="^[01]+$")
+    gpu: Optional[str] = pydantic.Field(pattern="^[0-9.]+$")
 
 
 class HeadNodeResources(BaseModel):

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_models.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_models.py
@@ -283,7 +283,7 @@ class Resources(BaseModel):
     memory: Optional[str] = pydantic.Field(
         pattern=r"^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$"
     )
-    gpu: Optional[str] = pydantic.Field(pattern="^[0-9.]+$")
+    gpu: Optional[str] = pydantic.Field(pattern=r"^\d+$")
 
 
 class HeadNodeResources(BaseModel):

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
@@ -407,7 +407,7 @@ class Resources(NamedTuple):
             Binary or decimal suffixes are supported. e.g. "10G" for 10 gigabytes
         disk: The requested disk space in "bytes".
             Binary or decimal suffixes are supported. e.g. "10Gi" for 10 gibibytes
-        gpu: Either "0" or "1" to use a GPU or not.
+        gpu: Number of gpus used either as string ("1" or "4") or as int
         nodes: The number of nodes requested. This option only applies to workflows.
             This should be a positive integer.
     """
@@ -415,7 +415,9 @@ class Resources(NamedTuple):
     cpu: Optional[str] = None
     memory: Optional[str] = None
     disk: Optional[str] = None
-    gpu: Optional[str] = None
+    # gpu accept str for legacy reasons. It used to accept "0" or "1" only, but
+    # to add more granular selection it now accepts INTs.
+    gpu: Optional[str, int] = None
     nodes: Optional[int] = None
 
     def is_empty(self) -> bool:

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
@@ -417,7 +417,7 @@ class Resources(NamedTuple):
     disk: Optional[str] = None
     # gpu accept str for legacy reasons. It used to accept "0" or "1" only, but
     # to add more granular selection it now accepts INTs.
-    gpu: Optional[str, int] = None
+    gpu: Optional[Union[str, int]] = None
     nodes: Optional[int] = None
 
     def is_empty(self) -> bool:
@@ -866,7 +866,9 @@ class ArtifactFuture(Generic[_TaskReturn]):
             Union[str, "orquestra.sdk._client._base._dsl.Sentinel"]  # pyright: ignore
         ] = Sentinel.NO_UPDATE,
         gpu: Optional[
-            Union[str, "orquestra.sdk._client._base._dsl.Sentinel"]  # pyright: ignore
+            Union[
+                str, int, "orquestra.sdk._client._base._dsl.Sentinel"  # pyright: ignore
+            ]
         ] = Sentinel.NO_UPDATE,
         custom_image: Optional[
             Union[str, "orquestra.sdk._client._base._dsl.Sentinel"]  # pyright: ignore
@@ -962,7 +964,9 @@ class ArtifactFuture(Generic[_TaskReturn]):
             Union[str, "orquestra.sdk._client._base._dsl.Sentinel"]  # pyright: ignore
         ] = Sentinel.NO_UPDATE,
         gpu: Optional[
-            Union[str, "orquestra.sdk._client._base._dsl.Sentinel"]  # pyright: ignore
+            Union[
+                str, int, "orquestra.sdk._client._base._dsl.Sentinel"  # pyright: ignore
+            ]
         ] = Sentinel.NO_UPDATE,
     ) -> "ArtifactFuture":
         """

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_traversal.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_traversal.py
@@ -32,7 +32,7 @@ from . import _docker_images, _dsl, _workflow
 N_BYTES_IN_HASH = 8
 
 
-def _get_default_image(num_gpus: t.Optional[str]):
+def _get_default_image(num_gpus: t.Optional[t.Union[str, int]]):
     image = _docker_images.DEFAULT_WORKER_IMAGE
     if num_gpus:
         image = f"{image}-cuda"
@@ -775,7 +775,7 @@ def _make_invocation_model(
         arg_name: graph.get_node_id(arg_val) for arg_name, arg_val in invocation.kwargs
     }
 
-    gpu_used: t.Optional[str]
+    gpu_used: t.Optional[t.Union[str, int]]
     if invocation.resources.gpu:
         gpu_used = invocation.resources.gpu
     elif task_models_dict[invocation.task].resources is not None:

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_traversal.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_traversal.py
@@ -491,7 +491,7 @@ def _make_resources_model(
         cpu=resources.cpu,
         memory=resources.memory,
         disk=resources.disk,
-        gpu=resources.gpu,
+        gpu=str(resources.gpu) if isinstance(resources.gpu, int) else resources.gpu,
         nodes=nodes,
     )
 

--- a/projects/orquestra-sdk/tests/sdk/test_dsl.py
+++ b/projects/orquestra-sdk/tests/sdk/test_dsl.py
@@ -68,6 +68,7 @@ class TestArtifactFuturePublicMethods:
         ("memory", {"memory": None}),
         ("disk", {"disk": None}),
         ("gpu", {"gpu": None}),
+        ("gpu", {"gpu": 15}),
         # Empty args, expect default value
         ("cpu", {}),
         ("memory", {}),
@@ -879,7 +880,7 @@ class TestResources:
         # should not raise
         wf().model
 
-    @pytest.mark.parametrize("gpu", ["1", "1.0", "10.0"])
+    @pytest.mark.parametrize("gpu", ["1", "1.0", "10.0", 3, 0, 15])
     def test_valid_gpu_resources(self, gpu):
         @sdk.task(resources=sdk.Resources(gpu=gpu))
         def t():

--- a/projects/orquestra-sdk/tests/sdk/test_traversal.py
+++ b/projects/orquestra-sdk/tests/sdk/test_traversal.py
@@ -416,7 +416,6 @@ class TestFlattenGraph:
             memory=None,
             disk=None,
             gpu="26",
-
         )
         assert with_task_meta.resources == ir.Resources(
             cpu="2000m",

--- a/projects/orquestra-sdk/tests/sdk/test_traversal.py
+++ b/projects/orquestra-sdk/tests/sdk/test_traversal.py
@@ -66,6 +66,7 @@ def capitalize(text: str):
     resources=_dsl.Resources(
         cpu="2000m",
         memory="10Gi",
+        gpu=6,
     )
 )
 def capitalize_resourced(text: str):
@@ -270,6 +271,7 @@ def resources_invocation():
     with_inv_meta = with_task_meta.with_resources(
         cpu="1000m",
         memory=None,
+        gpu=26,
     )
     no_meta = capitalize(name)
 
@@ -401,7 +403,7 @@ class TestFlattenGraph:
     def test_setting_invocation_metadata(self):
         # preconditions
         wf = resources_invocation.model
-        with_inv_meta, with_task_meta, no_meta = [
+        with_task_meta, with_inv_meta, no_meta = [
             invocation
             for output_id in wf.output_ids
             for invocation in wf.task_invocations.values()
@@ -410,16 +412,17 @@ class TestFlattenGraph:
 
         # main assertions
         assert with_inv_meta.resources == ir.Resources(
-            cpu="2000m",
-            memory="10Gi",
-            disk=None,
-            gpu=None,
-        )
-        assert with_task_meta.resources == ir.Resources(
             cpu="1000m",
             memory=None,
             disk=None,
-            gpu=None,
+            gpu="26",
+
+        )
+        assert with_task_meta.resources == ir.Resources(
+            cpu="2000m",
+            memory="10Gi",
+            disk=None,
+            gpu="6",
         )
 
         assert no_meta.resources is None


### PR DESCRIPTION
# The problem
GPu could only be "1" or "0" till now.
https://zapatacomputing.atlassian.net/browse/ORQSDK-1069

# This PR's solution
Allow users to set precise number of GPUs they want in their task

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
