### PR TITLE
Feat!: remove default values from TaskDef and WorkflowDef

### DIFF
--- a/projects/orquestra-sdk/CHANGELOG.md
+++ b/projects/orquestra-sdk/CHANGELOG.md
@@ -5,6 +5,7 @@
 🚨 *Breaking Changes*
 
 * Setting `workspace_id` is now required when submitting workflow to remote clusters
+* `TaskDef` `WorkflowDef` and `TaskInvocation` Objects `__init__` functions now do set parameters by default.
 
 🔥 *Features*
 

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
@@ -670,6 +670,7 @@ class TaskDef(wrapt.ObjectProxy, Generic[_TaskReturn]):
                 custom_name=parse_custom_name(self._custom_name, signature),
                 custom_image=self._custom_image,
                 env_vars=self._env_vars,
+                type="task_invocation",
             )
         )
 
@@ -735,7 +736,7 @@ class TaskInvocation(Generic[_TaskReturn]):
         custom_name: Optional[str],
         custom_image: Optional[str],
         env_vars: Optional[Dict[str, str]],
-        type: str = "task_invocation",
+        type: str,
     ):
         self.task = task
         self.args = args
@@ -939,6 +940,7 @@ class ArtifactFuture(Generic[_TaskReturn]):
             custom_name=invocation.custom_name,
             custom_image=new_custom_image,
             env_vars=new_env_vars,
+            type=invocation.type,
         )
 
         return ArtifactFuture(

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
@@ -538,15 +538,15 @@ class TaskDef(wrapt.ObjectProxy, Generic[_TaskReturn]):
         self,
         fn: Callable[..., _TaskReturn],
         output_metadata: "orquestra.sdk._client._base._dsl.TaskOutputMetadata",  # pyright: ignore # NOQA
-        source_import: Optional[Import] = None,
-        parameters: Optional[OrderedDict] = None,
-        dependency_imports: Optional[Tuple[Import, ...]] = None,
-        resources: Resources = Resources(),
-        custom_image: Optional[str] = None,
-        custom_name: Optional[str] = None,
-        fn_ref: Optional[FunctionRef] = None,
-        max_retries: Optional[int] = None,
-        env_vars: Optional[Dict[str, str]] = None,
+        source_import: Optional[Import],
+        parameters: Optional[OrderedDict],
+        dependency_imports: Optional[Tuple[Import, ...]],
+        resources: Resources,
+        custom_image: Optional[str],
+        custom_name: Optional[str],
+        fn_ref: Optional[FunctionRef],
+        max_retries: Optional[int],
+        env_vars: Optional[Dict[str, str]],
     ):
         if isinstance(fn, BuiltinFunctionType):
             raise NotImplementedError("Built-in functions are not supported as Tasks")
@@ -731,11 +731,11 @@ class TaskInvocation(Generic[_TaskReturn]):
         task: TaskDef[_TaskReturn],
         args: Tuple[Argument, ...],
         kwargs: Tuple[Tuple[str, Argument], ...],
+        resources: Resources,
+        custom_name: Optional[str],
+        custom_image: Optional[str],
+        env_vars: Optional[Dict[str, str]],
         type: str = "task_invocation",
-        resources: Resources = Resources(),
-        custom_name: Optional[str] = None,
-        custom_image: Optional[str] = None,
-        env_vars: Optional[Dict[str, str]] = None,
     ):
         self.task = task
         self.args = args
@@ -1296,6 +1296,7 @@ def task(
             custom_name=custom_name,
             max_retries=max_retries,
             env_vars=env_vars,
+            fn_ref=None,
         )
 
         return task_def

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_dsl.py
@@ -732,11 +732,11 @@ class TaskInvocation(Generic[_TaskReturn]):
         task: TaskDef[_TaskReturn],
         args: Tuple[Argument, ...],
         kwargs: Tuple[Tuple[str, Argument], ...],
+        type: str,
         resources: Resources,
         custom_name: Optional[str],
         custom_image: Optional[str],
         env_vars: Optional[Dict[str, str]],
-        type: str,
     ):
         self.task = task
         self.args = args

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
@@ -72,11 +72,11 @@ class WorkflowDef(Generic[_R]):
         fn_ref: FunctionRef,
         resources: _dsl.Resources,
         head_node_image: Optional[str],
-        data_aggregation: Optional[DataAggregation] = None,
-        workflow_args: Optional[Tuple[Any, ...]] = None,
-        workflow_kwargs: Optional[Dict[str, Any]] = None,
-        default_source_import: Optional[Import] = None,
-        default_dependency_imports: Optional[Iterable[Import]] = None,
+        data_aggregation: Optional[DataAggregation],
+        workflow_args: Optional[Tuple[Any, ...]],
+        workflow_kwargs: Optional[Dict[str, Any]],
+        default_source_import: Optional[Import],
+        default_dependency_imports: Optional[Iterable[Import]],
     ):
         self._name = name
         self._fn = workflow_fn


### PR DESCRIPTION
# The problem
Using default values create problems when we want to copy those objects around. One might forget parameter.
https://zapatacomputing.atlassian.net/browse/ORQSDK-1054

# This PR's solution
Remove default parameters for WorkflowDef and TaskDef objects

Note:
This is marked as breaking change, as those objects are within public API - although they were not supposed to be created by users so we should not expect any incompatibilities

# Checklist

_Check that this PR satisfies the following items:_

- [x] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [x] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [x] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [x] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
