### PR TITLE
Feat: add debug flag while starting workflows

### DIFF
--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_api/_wf_run.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_api/_wf_run.py
@@ -138,6 +138,7 @@ class WorkflowRun:
         workspace_id: t.Optional[WorkspaceId] = None,
         project_id: t.Optional[ProjectId] = None,
         dry_run: bool = False,
+        debug: bool = False,
     ):
         """Start workflow run from its IR representation.
 
@@ -150,6 +151,7 @@ class WorkflowRun:
             project_id: ID of the project for workflow - supported only on CE
             dry_run: Run the workflow without actually executing any task code.
                 Useful for testing infrastructure, dependency imports, etc.
+            debug: Run the workflow with debug flag on.
         """
         _config = resolve_config(config)
 
@@ -168,6 +170,7 @@ class WorkflowRun:
             config=_config,
             project=_project,
             dry_run=dry_run,
+            debug=debug,
         )
 
         return wf_run
@@ -179,10 +182,11 @@ class WorkflowRun:
         runtime: RuntimeInterface,
         config: t.Optional[RuntimeConfig],
         dry_run: bool,
+        debug: bool,
         project: t.Optional[ProjectRef] = None,
     ):
         """Schedule workflow for execution and return WorkflowRun."""
-        run_id = runtime.create_workflow_run(wf_def, project, dry_run)
+        run_id = runtime.create_workflow_run(wf_def, project, dry_run, debug)
 
         workflow_run = WorkflowRun(
             run_id=run_id,

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_ce_runtime.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_ce_runtime.py
@@ -159,7 +159,11 @@ class CERuntime(RuntimeInterface):
         self._token = token
 
     def create_workflow_run(
-        self, workflow_def: WorkflowDef, project: Optional[ProjectRef], dry_run: bool
+        self,
+        workflow_def: WorkflowDef,
+        project: Optional[ProjectRef],
+        dry_run: bool,
+        debug: bool = False,
     ) -> WorkflowRunId:
         """Schedules a workflow definition for execution.
 
@@ -168,6 +172,7 @@ class CERuntime(RuntimeInterface):
             project: Project dir (workspace and project ID) on which the workflow
                 will be run.
             dry_run: If True, code of the tasks will not be executed.
+            debug: If True, debug mode on CE will be enabled
 
         Raises:
             WorkflowSyntaxError: when the workflow definition was rejected by the remote
@@ -225,7 +230,11 @@ class CERuntime(RuntimeInterface):
             workflow_def_id = self._client.create_workflow_def(workflow_def, project)
 
             workflow_run_id = self._client.create_workflow_run(
-                workflow_def_id, resources, dry_run, head_node_resources
+                workflow_def_id=workflow_def_id,
+                resources=resources,
+                dry_run=dry_run,
+                debug=debug,
+                head_node_resources=head_node_resources,
             )
         except _exceptions.InvalidWorkflowDef as e:
             raise exceptions.WorkflowSyntaxError(

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_client.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_client.py
@@ -479,6 +479,7 @@ class DriverClient:
         workflow_def_id: _models.WorkflowDefID,
         resources: _models.Resources,
         dry_run: bool,
+        debug: bool,
         head_node_resources: Optional[_models.HeadNodeResources],
     ) -> _models.WorkflowRunID:
         """Submit a workflow def to run in the workflow driver.
@@ -487,6 +488,7 @@ class DriverClient:
             workflow_def_id: ID of the workflow definition to be submitted.
             resources: The resources required to execute the workflow.
             dry_run: Run the workflow without actually executing any task code.
+            debug: pass debug flag to workflow driver
             head_node_resources: the requested resources for the head node
 
         Raises:
@@ -507,6 +509,7 @@ class DriverClient:
                 workflowDefinitionID=workflow_def_id,
                 resources=resources,
                 dryRun=dry_run,
+                debug=debug,
                 headNodeResources=head_node_resources,
             ).model_dump(),
         )

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_models.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_driver/_models.py
@@ -309,6 +309,7 @@ class CreateWorkflowRunRequest(BaseModel):
     workflowDefinitionID: WorkflowDefID
     resources: Resources
     dryRun: bool
+    debug: bool
     headNodeResources: Optional[HeadNodeResources] = None
 
 

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_in_process_runtime.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_in_process_runtime.py
@@ -133,7 +133,14 @@ class InProcessRuntime(abc.RuntimeInterface):
         workflow_def: ir.WorkflowDef,
         project: t.Optional[ProjectRef],
         dry_run: bool,
+        debug: bool = False,
     ) -> WfRunId:
+        if debug:
+            warnings.warn(
+                "InProcessRuntime doesn't support `debug`." " Flag will be ignored.",
+                category=exceptions.UnsupportedRuntimeFeature,
+            )
+
         if project:
             warnings.warn(
                 "in_process runtime doesn't support project-scoped workflows. "

--- a/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
+++ b/projects/orquestra-sdk/src/orquestra/sdk/_client/_base/_workflow.py
@@ -156,6 +156,7 @@ class WorkflowDef(Generic[_R]):
         workspace_id: Optional[WorkspaceId] = None,
         project_id: Optional[ProjectId] = None,
         dry_run: bool = False,
+        debug: bool = False,
     ) -> _api.WorkflowRun:
         """Schedules workflow for execution.
 
@@ -167,6 +168,7 @@ class WorkflowDef(Generic[_R]):
             project_id: ID of the project for workflow - supported only on CE
             dry_run: Run the workflow without actually executing any task code.
                 Useful for testing infrastructure, dependency imports, etc.
+            debug: sends workflow to CE with debug flag
 
         Raises:
             orquestra.sdk.exceptions.DirtyGitRepo: (warning) when a task def used by
@@ -187,6 +189,7 @@ class WorkflowDef(Generic[_R]):
                 workspace_id=workspace_id,
                 project_id=project_id,
                 dry_run=dry_run,
+                debug=debug,
             )
         except exceptions.ProjectInvalidError:
             raise

--- a/projects/orquestra-sdk/tests/sdk/api/test_wf_run.py
+++ b/projects/orquestra-sdk/tests/sdk/api/test_wf_run.py
@@ -240,6 +240,7 @@ class TestWorkflowRun:
             config=None,
             project=None,
             dry_run=False,
+            debug=False,
         )
 
     class TestByID:
@@ -2182,7 +2183,9 @@ class TestProjectId:
         monkeypatch.setattr(_config.RuntimeConfig, "name", "auto")
         with raises:
             wf_def.run("in_process", workspace_id=workspace_id, project_id=project_id)
-            workflow_create_mock.assert_called_once_with(wf_def.model, expected, False)
+            workflow_create_mock.assert_called_once_with(
+                wf_def.model, expected, False, False
+            )
 
 
 class TestListWorkspaces:

--- a/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
+++ b/projects/orquestra-sdk/tests/sdk/driver/test_ce_runtime.py
@@ -107,10 +107,11 @@ class TestCreateWorkflowRun:
             my_workflow.model, ProjectRef(workspace_id="a", project_id="b")
         )
         mocked_client.create_workflow_run.assert_called_once_with(
-            workflow_def_id,
-            _models.Resources(cpu=None, memory=None, gpu=None, nodes=None),
-            False,
-            None,
+            workflow_def_id=workflow_def_id,
+            resources=_models.Resources(cpu=None, memory=None, gpu=None, nodes=None),
+            dry_run=False,
+            debug=False,
+            head_node_resources=None,
         )
         assert isinstance(wf_run_id, WorkflowRunId)
         assert (
@@ -136,12 +137,15 @@ class TestCreateWorkflowRun:
                 dry_run=False,
             )
 
-            # Then
+            # then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id,
-                _models.Resources(cpu=None, memory="10Gi", gpu=None, nodes=None),
-                False,
-                None,
+                workflow_def_id=workflow_def_id,
+                resources=_models.Resources(
+                    cpu=None, memory="10Gi", gpu=None, nodes=None
+                ),
+                dry_run=False,
+                debug=False,
+                head_node_resources=None,
             )
 
         def test_with_cpu(
@@ -164,10 +168,13 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id,
-                _models.Resources(cpu="1000m", memory=None, gpu=None, nodes=None),
-                False,
-                None,
+                workflow_def_id=workflow_def_id,
+                resources=_models.Resources(
+                    cpu="1000m", memory=None, gpu=None, nodes=None
+                ),
+                dry_run=False,
+                debug=False,
+                head_node_resources=None,
             )
 
         def test_with_gpu(
@@ -190,10 +197,11 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id,
-                _models.Resources(cpu=None, memory=None, gpu="1", nodes=None),
-                False,
-                None,
+                workflow_def_id=workflow_def_id,
+                resources=_models.Resources(cpu=None, memory=None, gpu="1", nodes=None),
+                dry_run=False,
+                debug=False,
+                head_node_resources=None,
             )
 
         def test_maximum_resource(
@@ -216,10 +224,13 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id,
-                _models.Resources(cpu="5000m", memory="3G", gpu="1", nodes=None),
-                False,
-                None,
+                workflow_def_id=workflow_def_id,
+                resources=_models.Resources(
+                    cpu="5000m", memory="3G", gpu="1", nodes=None
+                ),
+                dry_run=False,
+                debug=False,
+                head_node_resources=None,
             )
 
         def test_resources_from_workflow(
@@ -244,10 +255,11 @@ class TestCreateWorkflowRun:
 
             # Then
             mocked_client.create_workflow_run.assert_called_once_with(
-                workflow_def_id,
-                _models.Resources(cpu="1", memory="1.5G", gpu="1", nodes=20),
-                False,
-                None,
+                workflow_def_id=workflow_def_id,
+                resources=_models.Resources(cpu="1", memory="1.5G", gpu="1", nodes=20),
+                dry_run=False,
+                debug=False,
+                head_node_resources=None,
             )
 
     @pytest.mark.parametrize(
@@ -284,10 +296,11 @@ class TestCreateWorkflowRun:
 
         # Then
         mocked_client.create_workflow_run.assert_called_once_with(
-            workflow_def_id,
-            _models.Resources(cpu=None, memory=None, nodes=None, gpu=None),
-            False,
-            None,
+            workflow_def_id=workflow_def_id,
+            resources=_models.Resources(cpu=None, memory=None, gpu=None, nodes=None),
+            dry_run=False,
+            debug=False,
+            head_node_resources=None,
         )
 
     @pytest.mark.parametrize(
@@ -323,11 +336,13 @@ class TestCreateWorkflowRun:
         )
 
         # Then
+
         mocked_client.create_workflow_run.assert_called_once_with(
-            workflow_def_id,
-            _models.Resources(cpu=None, memory=None, nodes=None, gpu=None),
-            False,
-            _models.HeadNodeResources(cpu=cpu, memory=memory),
+            workflow_def_id=workflow_def_id,
+            resources=_models.Resources(cpu=None, memory=None, gpu=None, nodes=None),
+            dry_run=False,
+            debug=False,
+            head_node_resources=_models.HeadNodeResources(cpu=cpu, memory=memory),
         )
 
     class TestWorkflowDefFailure:
@@ -2159,10 +2174,11 @@ def test_ce_resources(
         assert all([telltale in str(exec_info) for telltale in telltales])
     else:
         mocked_client.create_workflow_run.assert_called_once_with(
-            workflow_def_id,
-            expected_resources,
-            False,
-            None,
+            workflow_def_id=workflow_def_id,
+            resources=expected_resources,
+            dry_run=False,
+            debug=False,
+            head_node_resources=None,
         )
 
 

--- a/projects/orquestra-sdk/tests/sdk/driver/test_client.py
+++ b/projects/orquestra-sdk/tests/sdk/driver/test_client.py
@@ -1247,6 +1247,7 @@ class TestClient:
                         resources,
                         dry_run=False,
                         head_node_resources=None,
+                        debug=False,
                     )
 
             @staticmethod
@@ -1271,7 +1272,11 @@ class TestClient:
 
                 with pytest.raises(_exceptions.UnsupportedSDKVersion) as exc_info:
                     _ = client.create_workflow_run(
-                        workflow_def_id, resources, False, head_node_resources=None
+                        workflow_def_id,
+                        resources,
+                        False,
+                        head_node_resources=None,
+                        debug=False,
                     )
 
                 assert exc_info.value.submitted_version == submitted_version
@@ -1297,7 +1302,11 @@ class TestClient:
 
                 with pytest.raises(_exceptions.UnsupportedSDKVersion) as exc_info:
                     _ = client.create_workflow_run(
-                        workflow_def_id, resources, False, head_node_resources=None
+                        workflow_def_id,
+                        resources,
+                        False,
+                        head_node_resources=None,
+                        debug=False,
                     )
 
                 assert exc_info.value.submitted_version is None
@@ -1321,7 +1330,11 @@ class TestClient:
                 )
 
                 client.create_workflow_run(
-                    workflow_def_id, resources, False, head_node_resources=None
+                    workflow_def_id,
+                    resources,
+                    False,
+                    head_node_resources=None,
+                    debug=False,
                 )
 
                 # The assertion is done by mocked_responses
@@ -1341,7 +1354,11 @@ class TestClient:
 
                 with pytest.raises(_exceptions.InvalidTokenError):
                     _ = client.create_workflow_run(
-                        workflow_def_id, resources, False, head_node_resources=None
+                        workflow_def_id,
+                        resources,
+                        False,
+                        head_node_resources=None,
+                        debug=False,
                     )
 
             @staticmethod
@@ -1359,7 +1376,11 @@ class TestClient:
 
                 with pytest.raises(_exceptions.ForbiddenError):
                     _ = client.create_workflow_run(
-                        workflow_def_id, resources, False, head_node_resources=None
+                        workflow_def_id,
+                        resources,
+                        False,
+                        head_node_resources=None,
+                        debug=False,
                     )
 
             @staticmethod
@@ -1377,7 +1398,11 @@ class TestClient:
 
                 with pytest.raises(_exceptions.UnknownHTTPError):
                     _ = client.create_workflow_run(
-                        workflow_def_id, resources, False, head_node_resources=None
+                        workflow_def_id,
+                        resources,
+                        False,
+                        head_node_resources=None,
+                        debug=False,
                     )
 
         class TestTerminate:

--- a/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_dag.py
+++ b/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_dag.py
@@ -381,11 +381,18 @@ class RayRuntime(RuntimeInterface):
         workflow_def: ir.WorkflowDef,
         project: t.Optional[ProjectRef],
         dry_run: bool,
+        debug: bool = False,
     ) -> WorkflowRunId:
         if project:
             warnings.warn(
                 "Ray doesn't support project-scoped workflows. "
                 "Project and workspace IDs will be ignored.",
+                category=exceptions.UnsupportedRuntimeFeature,
+            )
+        if debug:
+            warnings.warn(
+                "InProcessRuntime doesn't support `debug`."
+                " Flag will be ignored.",
                 category=exceptions.UnsupportedRuntimeFeature,
             )
 

--- a/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_dag.py
+++ b/projects/orquestra-workflow-runtime/src/orquestra/workflow_runtime/_ray/_dag.py
@@ -391,8 +391,7 @@ class RayRuntime(RuntimeInterface):
             )
         if debug:
             warnings.warn(
-                "InProcessRuntime doesn't support `debug`."
-                " Flag will be ignored.",
+                "Ray Runtime doesn't support `debug`. Flag will be ignored.",
                 category=exceptions.UnsupportedRuntimeFeature,
             )
 

--- a/projects/orquestra-workflow-shared/src/orquestra/workflow_shared/abc.py
+++ b/projects/orquestra-workflow-shared/src/orquestra/workflow_shared/abc.py
@@ -39,7 +39,11 @@ class RuntimeInterface(ABC, LogReader):
 
     @abstractmethod
     def create_workflow_run(
-        self, workflow_def: WorkflowDef, project: t.Optional[ProjectRef], dry_run: bool
+        self,
+        workflow_def: WorkflowDef,
+        project: t.Optional[ProjectRef],
+        dry_run: bool,
+        debug: bool = False,  # adding default to keep backward compatibility
     ) -> WorkflowRunId:
         """Schedules a workflow definition for execution.
 
@@ -50,6 +54,7 @@ class RuntimeInterface(ABC, LogReader):
                 When omitted, WF will be scheduled at default project
             dry_run: Run the workflow without actually executing any task code.
                 Useful for testing infrastructure, dependency imports, etc.
+            debug: Sets debug flag. Currently, only supported in CE runtime.
 
         Raises:
             NotImplementedError: when not implemented on given runtime


### PR DESCRIPTION
# The problem
WD introduced new debug flag to help debugging issues with starting up/shutting down of workflows
# This PR's solution
Add API for users to set that flag
# Checklist

_Check that this PR satisfies the following items:_

- [ ] Tests have been added for new features/changed behavior (if no new features have been added, check the box).
- [ ] The [changelog file](CHANGELOG.md) has been updated with a user-readable description of the changes (if the change isn't visible to the user in any way, check the box).
- [ ] The PR's title is prefixed with `<feat/fix/chore/imp[rovement]/int[ernal]/docs>[!]:`
- [ ] The PR is linked to a JIRA ticket (if there's no suitable ticket, check the box).
